### PR TITLE
feat(#10): GraphQL edit history + transaction model for issues and comments

### DIFF
--- a/am_i_shipping/db.py
+++ b/am_i_shipping/db.py
@@ -61,6 +61,7 @@ CREATE TABLE IF NOT EXISTS issues (
     comments_json   TEXT,
     created_at      TEXT,
     closed_at       TEXT,
+    updated_at      TEXT,
     PRIMARY KEY (repo, issue_number)
 );
 """
@@ -77,6 +78,7 @@ CREATE TABLE IF NOT EXISTS pull_requests (
     push_count          INTEGER DEFAULT 0,
     created_at          TEXT,
     merged_at           TEXT,
+    updated_at          TEXT,
     PRIMARY KEY (repo, pr_number)
 );
 """
@@ -106,6 +108,58 @@ CREATE TABLE IF NOT EXISTS poll_cursor (
 );
 """
 
+GITHUB_ISSUE_BODY_EDITS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS issue_body_edits (
+    repo        TEXT NOT NULL,
+    issue_number INTEGER NOT NULL,
+    edited_at   TEXT NOT NULL,
+    diff        TEXT,
+    editor      TEXT,
+    PRIMARY KEY (repo, issue_number, edited_at)
+);
+"""
+
+GITHUB_ISSUE_COMMENT_EDITS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS issue_comment_edits (
+    repo         TEXT NOT NULL,
+    issue_number INTEGER NOT NULL,
+    comment_id   INTEGER NOT NULL,
+    edited_at    TEXT NOT NULL,
+    diff         TEXT,
+    editor       TEXT,
+    PRIMARY KEY (repo, issue_number, comment_id, edited_at)
+);
+"""
+
+GITHUB_PR_BODY_EDITS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS pr_body_edits (
+    repo       TEXT NOT NULL,
+    pr_number  INTEGER NOT NULL,
+    edited_at  TEXT NOT NULL,
+    diff        TEXT,
+    editor      TEXT,
+    PRIMARY KEY (repo, pr_number, edited_at)
+);
+"""
+
+GITHUB_PR_REVIEW_COMMENT_EDITS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS pr_review_comment_edits (
+    repo        TEXT NOT NULL,
+    pr_number   INTEGER NOT NULL,
+    comment_id  INTEGER NOT NULL,
+    edited_at   TEXT NOT NULL,
+    diff         TEXT,
+    editor       TEXT,
+    PRIMARY KEY (repo, pr_number, comment_id, edited_at)
+);
+"""
+
+# Columns added to existing tables after initial schema — migrated on init
+_GITHUB_MIGRATIONS = [
+    "ALTER TABLE issues ADD COLUMN updated_at TEXT",
+    "ALTER TABLE pull_requests ADD COLUMN updated_at TEXT",
+]
+
 APPSWITCH_SCHEMA = """
 CREATE TABLE IF NOT EXISTS app_events (
     timestamp_bucket INTEGER NOT NULL,
@@ -134,7 +188,7 @@ def init_sessions_db(db_path: Path) -> None:
 
 
 def init_github_db(db_path: Path) -> None:
-    """Create github.db with issues, PRs, linkage, and cursor tables."""
+    """Create github.db with issues, PRs, linkage, cursor, and edit history tables."""
     conn = sqlite3.connect(str(db_path))
     try:
         conn.execute(GITHUB_ISSUES_SCHEMA)
@@ -142,6 +196,15 @@ def init_github_db(db_path: Path) -> None:
         conn.execute(GITHUB_PR_ISSUES_SCHEMA)
         conn.execute(GITHUB_PR_SESSIONS_SCHEMA)
         conn.execute(GITHUB_CURSOR_SCHEMA)
+        conn.execute(GITHUB_ISSUE_BODY_EDITS_SCHEMA)
+        conn.execute(GITHUB_ISSUE_COMMENT_EDITS_SCHEMA)
+        conn.execute(GITHUB_PR_BODY_EDITS_SCHEMA)
+        conn.execute(GITHUB_PR_REVIEW_COMMENT_EDITS_SCHEMA)
+        for migration in _GITHUB_MIGRATIONS:
+            try:
+                conn.execute(migration)
+            except sqlite3.OperationalError:
+                pass  # column already exists
         conn.commit()
     finally:
         conn.close()

--- a/collector/github_poller/fetch_issues.py
+++ b/collector/github_poller/fetch_issues.py
@@ -7,6 +7,7 @@ body, comments (list of {author, body, created_at}).
 
 from __future__ import annotations
 
+import sys
 from typing import Any, Dict, List, Optional
 
 from .gh_client import GhCliError, run_gh_json, gh_api, gh_graphql
@@ -183,7 +184,8 @@ def fetch_issue_edit_history(repo: str, issue_number: int) -> Dict[str, Any]:
             _ISSUE_EDIT_HISTORY_QUERY,
             {"owner": owner, "name": name, "number": issue_number},
         )
-    except Exception:
+    except Exception as exc:
+        print(f"  warning: edit history fetch failed for issue {issue_number}: {exc}", file=sys.stderr)
         return {}
 
     if response.get("errors"):
@@ -254,7 +256,7 @@ def fetch_issue_edit_history_batch(
         except Exception:
             continue
 
-        if response.get("errors"):
+        if response.get("errors") and not response.get("data"):
             continue
 
         repo_data = (response.get("data") or {}).get("repository") or {}

--- a/collector/github_poller/fetch_issues.py
+++ b/collector/github_poller/fetch_issues.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from .gh_client import GhCliError, run_gh_json, gh_api
+from .gh_client import GhCliError, run_gh_json, gh_api, gh_graphql
 
 
 def fetch_issues(
@@ -42,7 +42,7 @@ def fetch_issues(
         "--repo", repo,
         "--state", state,
         "--limit", str(limit),
-        "--json", "number,title,labels,createdAt,closedAt,state,body",
+        "--json", "number,title,labels,createdAt,closedAt,state,body,updatedAt",
     ]
     if since:
         args.extend(["--search", f"updated:>{since}"])
@@ -62,6 +62,7 @@ def fetch_issues(
             "type_label": type_label,
             "created_at": issue.get("createdAt"),
             "closed_at": issue.get("closedAt"),
+            "updated_at": issue.get("updatedAt"),
             "state": issue.get("state", "").upper(),
             "body": issue.get("body", ""),
             "comments": comments,
@@ -86,14 +87,182 @@ def _fetch_issue_comments(
     if not isinstance(raw, list):
         return []
 
-    comments: List[Dict[str, str]] = []
+    comments: List[Dict[str, Any]] = []
     for c in raw:
         comments.append({
+            "id": c.get("id"),
             "author": (c.get("user") or {}).get("login", ""),
             "body": c.get("body", ""),
             "created_at": c.get("created_at", ""),
         })
     return comments
+
+
+_ISSUE_EDIT_HISTORY_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      userContentEdits(first: 100) {
+        nodes {
+          editedAt
+          diff
+          editor { login }
+        }
+      }
+      comments(first: 100) {
+        nodes {
+          databaseId
+          userContentEdits(first: 100) {
+            nodes {
+              editedAt
+              diff
+              editor { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def _parse_issue_edit_history(issue_data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Parse a single issue node from GraphQL into body_edits + comment_edits."""
+    if not issue_data:
+        return {"body_edits": [], "comment_edits": []}
+
+    body_edits: List[Dict[str, Any]] = []
+    for node in (issue_data.get("userContentEdits") or {}).get("nodes") or []:
+        editor_login = None
+        editor = node.get("editor")
+        if editor:
+            editor_login = editor.get("login")
+        body_edits.append({
+            "edited_at": node.get("editedAt"),
+            "diff": node.get("diff"),
+            "editor": editor_login,
+        })
+
+    comment_edits: List[Dict[str, Any]] = []
+    for comment_node in (issue_data.get("comments") or {}).get("nodes") or []:
+        comment_id = comment_node.get("databaseId")
+        for node in (comment_node.get("userContentEdits") or {}).get("nodes") or []:
+            editor_login = None
+            editor = node.get("editor")
+            if editor:
+                editor_login = editor.get("login")
+            comment_edits.append({
+                "comment_id": comment_id,
+                "edited_at": node.get("editedAt"),
+                "diff": node.get("diff"),
+                "editor": editor_login,
+            })
+
+    return {"body_edits": body_edits, "comment_edits": comment_edits}
+
+
+def fetch_issue_edit_history(repo: str, issue_number: int) -> Dict[str, Any]:
+    """Fetch edit history for a single issue via GraphQL.
+
+    Parameters
+    ----------
+    repo:
+        GitHub repository in ``owner/repo`` format.
+    issue_number:
+        Issue number to query.
+
+    Returns
+    -------
+    Dict with keys ``body_edits`` and ``comment_edits``, each a list of
+    edit dicts.  Returns an empty dict on GraphQL error.
+    """
+    owner, name = repo.split("/", 1)
+    try:
+        response = gh_graphql(
+            _ISSUE_EDIT_HISTORY_QUERY,
+            {"owner": owner, "name": name, "number": issue_number},
+        )
+    except Exception:
+        return {}
+
+    if response.get("errors"):
+        return {}
+
+    issue_data = (
+        (response.get("data") or {})
+        .get("repository", {})
+        .get("issue")
+    )
+    return _parse_issue_edit_history(issue_data)
+
+
+def fetch_issue_edit_history_batch(
+    repo: str,
+    issue_numbers: List[int],
+) -> Dict[int, Dict[str, Any]]:
+    """Fetch edit history for up to 20 issues per GraphQL call using aliases.
+
+    Parameters
+    ----------
+    repo:
+        GitHub repository in ``owner/repo`` format.
+    issue_numbers:
+        List of issue numbers to query (max 20 per call; larger lists are
+        processed in chunks of 20).
+
+    Returns
+    -------
+    Mapping of issue_number -> edit history dict (same shape as
+    :func:`fetch_issue_edit_history`).  Issues that fail are omitted.
+    """
+    owner, name = repo.split("/", 1)
+    results: Dict[int, Dict[str, Any]] = {}
+
+    CHUNK_SIZE = 20
+    for chunk_start in range(0, len(issue_numbers), CHUNK_SIZE):
+        chunk = issue_numbers[chunk_start : chunk_start + CHUNK_SIZE]
+
+        # Build aliased query for this chunk
+        alias_blocks = []
+        for i, num in enumerate(chunk):
+            alias_blocks.append(f"""
+    issue{i}: issue(number: {num}) {{
+      number
+      userContentEdits(first: 100) {{
+        nodes {{ editedAt diff editor {{ login }} }}
+      }}
+      comments(first: 100) {{
+        nodes {{
+          databaseId
+          userContentEdits(first: 100) {{
+            nodes {{ editedAt diff editor {{ login }} }}
+          }}
+        }}
+      }}
+    }}""")
+
+        query = (
+            "query($owner: String!, $name: String!) {\n"
+            "  repository(owner: $owner, name: $name) {"
+            + "".join(alias_blocks)
+            + "\n  }\n}"
+        )
+
+        try:
+            response = gh_graphql(query, {"owner": owner, "name": name})
+        except Exception:
+            continue
+
+        if response.get("errors"):
+            continue
+
+        repo_data = (response.get("data") or {}).get("repository") or {}
+        for i, num in enumerate(chunk):
+            issue_data = repo_data.get(f"issue{i}")
+            results[num] = _parse_issue_edit_history(issue_data)
+
+    return results
 
 
 def _extract_type_label(labels: List[Any]) -> Optional[str]:

--- a/collector/github_poller/fetch_prs.py
+++ b/collector/github_poller/fetch_prs.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from .gh_client import GhCliError, run_gh_json, gh_api
+from .gh_client import GhCliError, run_gh_json, gh_api, gh_graphql
 
 
 def fetch_prs(
@@ -41,7 +41,7 @@ def fetch_prs(
         "--repo", repo,
         "--state", state,
         "--limit", str(limit),
-        "--json", "number,createdAt,mergedAt,headRefName,body,title",
+        "--json", "number,createdAt,mergedAt,headRefName,body,title,updatedAt",
     ]
     if since:
         args.extend(["--search", f"updated:>{since}"])
@@ -59,6 +59,7 @@ def fetch_prs(
             "title": pr.get("title", ""),
             "created_at": pr.get("createdAt"),
             "merged_at": pr.get("mergedAt"),
+            "updated_at": pr.get("updatedAt"),
             "head_ref": pr.get("headRefName", ""),
             "body": pr.get("body", ""),
             "review_comment_count": len(review_comments),
@@ -84,11 +85,111 @@ def _fetch_review_comments(
     if not isinstance(raw, list):
         return []
 
-    comments: List[Dict[str, str]] = []
+    comments: List[Dict[str, Any]] = []
     for c in raw:
         comments.append({
+            "id": c.get("id"),
             "author": (c.get("user") or {}).get("login", ""),
             "body": c.get("body", ""),
             "created_at": c.get("created_at", ""),
         })
     return comments
+
+
+_PR_EDIT_HISTORY_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      userContentEdits(first: 100) {
+        nodes {
+          editedAt
+          diff
+          editor { login }
+        }
+      }
+      reviews(first: 100) {
+        nodes {
+          comments(first: 100) {
+            nodes {
+              databaseId
+              userContentEdits(first: 100) {
+                nodes {
+                  editedAt
+                  diff
+                  editor { login }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def fetch_pr_edit_history(repo: str, pr_number: int) -> Dict[str, Any]:
+    """Fetch edit history for a single PR via GraphQL.
+
+    Parameters
+    ----------
+    repo:
+        GitHub repository in ``owner/repo`` format.
+    pr_number:
+        Pull request number to query.
+
+    Returns
+    -------
+    Dict with keys ``body_edits`` and ``review_comment_edits``, each a
+    list of edit dicts.  Returns an empty dict on GraphQL error.
+    """
+    owner, name = repo.split("/", 1)
+    try:
+        response = gh_graphql(
+            _PR_EDIT_HISTORY_QUERY,
+            {"owner": owner, "name": name, "number": pr_number},
+        )
+    except Exception:
+        return {}
+
+    if response.get("errors"):
+        return {}
+
+    pr_data = (
+        (response.get("data") or {})
+        .get("repository", {})
+        .get("pullRequest")
+    )
+    if not pr_data:
+        return {"body_edits": [], "review_comment_edits": []}
+
+    body_edits: List[Dict[str, Any]] = []
+    for node in (pr_data.get("userContentEdits") or {}).get("nodes") or []:
+        editor_login = None
+        editor = node.get("editor")
+        if editor:
+            editor_login = editor.get("login")
+        body_edits.append({
+            "edited_at": node.get("editedAt"),
+            "diff": node.get("diff"),
+            "editor": editor_login,
+        })
+
+    review_comment_edits: List[Dict[str, Any]] = []
+    for review_node in (pr_data.get("reviews") or {}).get("nodes") or []:
+        for comment_node in (review_node.get("comments") or {}).get("nodes") or []:
+            comment_id = comment_node.get("databaseId")
+            for node in (comment_node.get("userContentEdits") or {}).get("nodes") or []:
+                editor_login = None
+                editor = node.get("editor")
+                if editor:
+                    editor_login = editor.get("login")
+                review_comment_edits.append({
+                    "comment_id": comment_id,
+                    "edited_at": node.get("editedAt"),
+                    "diff": node.get("diff"),
+                    "editor": editor_login,
+                })
+
+    return {"body_edits": body_edits, "review_comment_edits": review_comment_edits}

--- a/collector/github_poller/gh_client.py
+++ b/collector/github_poller/gh_client.py
@@ -75,6 +75,51 @@ def run_gh_json(
     return json.loads(stdout)
 
 
+def gh_graphql(
+    query: str,
+    variables: Optional[Dict[str, Any]] = None,
+    *,
+    max_retries: int = 3,
+    backoff_base: float = 2.0,
+) -> Dict[str, Any]:
+    """Call the GitHub GraphQL API via ``gh api graphql``.
+
+    Parameters
+    ----------
+    query:
+        GraphQL query string.
+    variables:
+        Dict of variable name -> value.  String values are passed with
+        ``-f`` (untyped); all other types are serialized with ``-F``
+        (typed) so that integers, booleans, etc. are interpreted correctly
+        by the ``gh`` CLI.
+    max_retries:
+        Number of retries on failure (same semantics as ``run_gh``).
+    backoff_base:
+        Base for exponential back-off between retries.
+
+    Returns
+    -------
+    Parsed JSON dict (the full GraphQL response, including ``data`` and
+    any ``errors`` keys).
+
+    Raises
+    ------
+    GhCliError
+        After exhausting retries.
+    """
+    args: List[str] = ["api", "graphql", "-f", f"query={query}"]
+
+    for k, v in (variables or {}).items():
+        if isinstance(v, str):
+            args.extend(["-f", f"{k}={v}"])
+        else:
+            args.extend(["-F", f"{k}={v}"])
+
+    stdout = run_gh(args, max_retries=max_retries, backoff_base=backoff_base)
+    return json.loads(stdout)
+
+
 def gh_api(
     endpoint: str,
     *,

--- a/collector/github_poller/run.py
+++ b/collector/github_poller/run.py
@@ -58,6 +58,8 @@ def _get_stored_updated_at(
     db_path: Path,
 ) -> Optional[str]:
     """Return the stored ``updated_at`` value for a row, or None if not found."""
+    assert table in ("issues", "pull_requests"), f"unexpected table: {table}"
+    assert number_col in ("issue_number", "pr_number"), f"unexpected number_col: {number_col}"
     try:
         conn = sqlite3.connect(str(db_path))
         try:

--- a/collector/github_poller/run.py
+++ b/collector/github_poller/run.py
@@ -6,8 +6,9 @@ For each configured repo:
 3. Resolve PR→issue links
 4. Derive push-after-review counts
 5. Upsert into github.db
-6. Link PRs to sessions (via head_ref matching)
-7. Advance cursor
+6. Fetch and store edit history (body + comment edits)
+7. Link PRs to sessions (via head_ref matching)
+8. Advance cursor
 
 Writes ``health.json`` only after all repos succeed.  Supports
 ``--dry-run`` flag (fetch and parse, skip all DB writes).
@@ -19,6 +20,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import sqlite3
 import sys
 from pathlib import Path
 from typing import Optional
@@ -28,12 +30,46 @@ from am_i_shipping.db import init_github_db
 from am_i_shipping.health_writer import write_health
 
 from .cursor import advance_cursor, compute_since, read_cursor
-from .fetch_issues import fetch_issues
-from .fetch_prs import fetch_prs
+from .fetch_issues import (
+    fetch_issue_edit_history,
+    fetch_issue_edit_history_batch,
+    fetch_issues,
+)
+from .fetch_prs import fetch_pr_edit_history, fetch_prs
 from .link_resolver import resolve_link
 from .push_counter import count_pushes_after_review
 from .session_linker import link_sessions
-from .store import upsert_issue, upsert_pr, upsert_pr_issue_link
+from .store import (
+    insert_issue_body_edit,
+    insert_issue_comment_edit,
+    insert_pr_body_edit,
+    insert_pr_review_comment_edit,
+    upsert_issue,
+    upsert_pr,
+    upsert_pr_issue_link,
+)
+
+
+def _get_stored_updated_at(
+    table: str,
+    repo: str,
+    number_col: str,
+    number: int,
+    db_path: Path,
+) -> Optional[str]:
+    """Return the stored ``updated_at`` value for a row, or None if not found."""
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            row = conn.execute(
+                f"SELECT updated_at FROM {table} WHERE repo = ? AND {number_col} = ?",
+                (repo, number),
+            ).fetchone()
+            return row[0] if row else None
+        finally:
+            conn.close()
+    except Exception:
+        return None
 
 
 def run(
@@ -114,10 +150,93 @@ def _poll_repo(
         return len(issues) + len(prs)
 
     # 3–5. Process and upsert issues
-    for issue in issues:
-        upsert_issue(repo, issue, github_db)
+    is_backfill = cursor_value is None
 
-    # 3–5. Process PRs: resolve links, derive push counts, upsert
+    if is_backfill:
+        # Backfill: upsert all issues first, then batch-fetch edit history
+        for issue in issues:
+            upsert_issue(repo, issue, github_db)
+
+        # Batch-fetch edit history for all issues in chunks of 20
+        issue_numbers = [issue["number"] for issue in issues]
+        if issue_numbers:
+            try:
+                batch_results = fetch_issue_edit_history_batch(repo, issue_numbers)
+            except Exception as exc:
+                print(f"  {repo}: edit history batch fetch error: {exc}", file=sys.stderr)
+                batch_results = {}
+
+            for issue_number, edits in batch_results.items():
+                for edit in edits.get("body_edits", []):
+                    try:
+                        insert_issue_body_edit(
+                            repo,
+                            issue_number,
+                            edit["edited_at"],
+                            edit.get("diff"),
+                            edit.get("editor"),
+                            github_db,
+                        )
+                    except Exception as exc:
+                        print(f"  {repo}: insert issue body edit error (issue #{issue_number}): {exc}", file=sys.stderr)
+
+                for edit in edits.get("comment_edits", []):
+                    try:
+                        insert_issue_comment_edit(
+                            repo,
+                            issue_number,
+                            edit["comment_id"],
+                            edit["edited_at"],
+                            edit.get("diff"),
+                            edit.get("editor"),
+                            github_db,
+                        )
+                    except Exception as exc:
+                        print(f"  {repo}: insert issue comment edit error (issue #{issue_number}): {exc}", file=sys.stderr)
+    else:
+        # Delta: upsert each issue and fetch edit history if updated_at changed
+        for issue in issues:
+            prev_updated_at = _get_stored_updated_at(
+                "issues", repo, "issue_number", issue["number"], github_db
+            )
+            upsert_issue(repo, issue, github_db)
+
+            current_updated_at = issue.get("updated_at")
+            if current_updated_at and current_updated_at != prev_updated_at:
+                try:
+                    edits = fetch_issue_edit_history(repo, issue["number"])
+                except Exception as exc:
+                    print(f"  {repo}: edit history fetch error (issue #{issue['number']}): {exc}", file=sys.stderr)
+                    continue
+
+                for edit in edits.get("body_edits", []):
+                    try:
+                        insert_issue_body_edit(
+                            repo,
+                            issue["number"],
+                            edit["edited_at"],
+                            edit.get("diff"),
+                            edit.get("editor"),
+                            github_db,
+                        )
+                    except Exception as exc:
+                        print(f"  {repo}: insert issue body edit error (issue #{issue['number']}): {exc}", file=sys.stderr)
+
+                for edit in edits.get("comment_edits", []):
+                    try:
+                        insert_issue_comment_edit(
+                            repo,
+                            issue["number"],
+                            edit["comment_id"],
+                            edit["edited_at"],
+                            edit.get("diff"),
+                            edit.get("editor"),
+                            github_db,
+                        )
+                    except Exception as exc:
+                        print(f"  {repo}: insert issue comment edit error (issue #{issue['number']}): {exc}", file=sys.stderr)
+
+    # 3–5. Process PRs: resolve links, derive push counts, upsert, edit history
     for pr in prs:
         # Resolve PR→issue link
         linked_issue = resolve_link(
@@ -129,12 +248,89 @@ def _poll_repo(
         push_count = count_pushes_after_review(repo, pr["number"])
         pr["push_count"] = push_count
 
-        # Upsert PR
-        upsert_pr(repo, pr, github_db)
+        if is_backfill:
+            # Backfill: upsert without updated_at gating
+            upsert_pr(repo, pr, github_db)
+        else:
+            # Delta: check updated_at before upsert
+            prev_updated_at = _get_stored_updated_at(
+                "pull_requests", repo, "pr_number", pr["number"], github_db
+            )
+            upsert_pr(repo, pr, github_db)
+
+            current_updated_at = pr.get("updated_at")
+            if current_updated_at and current_updated_at != prev_updated_at:
+                try:
+                    edits = fetch_pr_edit_history(repo, pr["number"])
+                except Exception as exc:
+                    print(f"  {repo}: edit history fetch error (PR #{pr['number']}): {exc}", file=sys.stderr)
+                else:
+                    for edit in edits.get("body_edits", []):
+                        try:
+                            insert_pr_body_edit(
+                                repo,
+                                pr["number"],
+                                edit["edited_at"],
+                                edit.get("diff"),
+                                edit.get("editor"),
+                                github_db,
+                            )
+                        except Exception as exc:
+                            print(f"  {repo}: insert PR body edit error (PR #{pr['number']}): {exc}", file=sys.stderr)
+
+                    for edit in edits.get("review_comment_edits", []):
+                        try:
+                            insert_pr_review_comment_edit(
+                                repo,
+                                pr["number"],
+                                edit["comment_id"],
+                                edit["edited_at"],
+                                edit.get("diff"),
+                                edit.get("editor"),
+                                github_db,
+                            )
+                        except Exception as exc:
+                            print(f"  {repo}: insert PR review comment edit error (PR #{pr['number']}): {exc}", file=sys.stderr)
 
         # Insert PR→issue link if resolved
         if linked_issue is not None:
             upsert_pr_issue_link(repo, pr["number"], linked_issue, github_db)
+
+    # Backfill: fetch PR edit history in bulk after all upserts
+    if is_backfill and prs:
+        for pr in prs:
+            try:
+                edits = fetch_pr_edit_history(repo, pr["number"])
+            except Exception as exc:
+                print(f"  {repo}: edit history fetch error (PR #{pr['number']}): {exc}", file=sys.stderr)
+                continue
+
+            for edit in edits.get("body_edits", []):
+                try:
+                    insert_pr_body_edit(
+                        repo,
+                        pr["number"],
+                        edit["edited_at"],
+                        edit.get("diff"),
+                        edit.get("editor"),
+                        github_db,
+                    )
+                except Exception as exc:
+                    print(f"  {repo}: insert PR body edit error (PR #{pr['number']}): {exc}", file=sys.stderr)
+
+            for edit in edits.get("review_comment_edits", []):
+                try:
+                    insert_pr_review_comment_edit(
+                        repo,
+                        pr["number"],
+                        edit["comment_id"],
+                        edit["edited_at"],
+                        edit.get("diff"),
+                        edit.get("editor"),
+                        github_db,
+                    )
+                except Exception as exc:
+                    print(f"  {repo}: insert PR review comment edit error (PR #{pr['number']}): {exc}", file=sys.stderr)
 
     # 6. Link PRs to sessions
     session_links = link_sessions(repo, github_db, sessions_db)

--- a/collector/github_poller/store.py
+++ b/collector/github_poller/store.py
@@ -46,8 +46,8 @@ def upsert_issue(
             """
             INSERT INTO issues (
                 repo, issue_number, title, type_label, state,
-                body, comments_json, created_at, closed_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                body, comments_json, created_at, closed_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(repo, issue_number) DO UPDATE SET
                 title = excluded.title,
                 type_label = excluded.type_label,
@@ -55,7 +55,8 @@ def upsert_issue(
                 body = excluded.body,
                 comments_json = excluded.comments_json,
                 created_at = excluded.created_at,
-                closed_at = excluded.closed_at
+                closed_at = excluded.closed_at,
+                updated_at = excluded.updated_at
             """,
             (
                 repo,
@@ -67,6 +68,7 @@ def upsert_issue(
                 json.dumps(issue.get("comments", []), ensure_ascii=False),
                 issue.get("created_at"),
                 issue.get("closed_at"),
+                issue.get("updated_at"),
             ),
         )
         conn.commit()
@@ -96,8 +98,8 @@ def upsert_pr(
             INSERT INTO pull_requests (
                 repo, pr_number, head_ref, title, body,
                 review_comments_json, review_comment_count,
-                push_count, created_at, merged_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                push_count, created_at, merged_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(repo, pr_number) DO UPDATE SET
                 head_ref = excluded.head_ref,
                 title = excluded.title,
@@ -106,7 +108,8 @@ def upsert_pr(
                 review_comment_count = excluded.review_comment_count,
                 push_count = excluded.push_count,
                 created_at = excluded.created_at,
-                merged_at = excluded.merged_at
+                merged_at = excluded.merged_at,
+                updated_at = excluded.updated_at
             """,
             (
                 repo,
@@ -119,6 +122,7 @@ def upsert_pr(
                 pr.get("push_count", 0),
                 pr.get("created_at"),
                 pr.get("merged_at"),
+                pr.get("updated_at"),
             ),
         )
         conn.commit()
@@ -142,6 +146,108 @@ def upsert_pr_issue_link(
             VALUES (?, ?, ?)
             """,
             (repo, pr_number, issue_number),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def insert_issue_body_edit(
+    repo: str,
+    issue_number: int,
+    edited_at: str,
+    diff: Optional[str],
+    editor: Optional[str],
+    db_path: Union[str, Path],
+) -> None:
+    """Record an issue body edit.  Idempotent (INSERT OR IGNORE)."""
+    db_path = Path(db_path)
+    conn = _connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO issue_body_edits
+                (repo, issue_number, edited_at, diff, editor)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (repo, issue_number, edited_at, diff, editor),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def insert_issue_comment_edit(
+    repo: str,
+    issue_number: int,
+    comment_id: int,
+    edited_at: str,
+    diff: Optional[str],
+    editor: Optional[str],
+    db_path: Union[str, Path],
+) -> None:
+    """Record an issue comment edit.  Idempotent (INSERT OR IGNORE)."""
+    db_path = Path(db_path)
+    conn = _connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO issue_comment_edits
+                (repo, issue_number, comment_id, edited_at, diff, editor)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (repo, issue_number, comment_id, edited_at, diff, editor),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def insert_pr_body_edit(
+    repo: str,
+    pr_number: int,
+    edited_at: str,
+    diff: Optional[str],
+    editor: Optional[str],
+    db_path: Union[str, Path],
+) -> None:
+    """Record a PR body edit.  Idempotent (INSERT OR IGNORE)."""
+    db_path = Path(db_path)
+    conn = _connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO pr_body_edits
+                (repo, pr_number, edited_at, diff, editor)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (repo, pr_number, edited_at, diff, editor),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def insert_pr_review_comment_edit(
+    repo: str,
+    pr_number: int,
+    comment_id: int,
+    edited_at: str,
+    diff: Optional[str],
+    editor: Optional[str],
+    db_path: Union[str, Path],
+) -> None:
+    """Record a PR review comment edit.  Idempotent (INSERT OR IGNORE)."""
+    db_path = Path(db_path)
+    conn = _connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO pr_review_comment_edits
+                (repo, pr_number, comment_id, edited_at, diff, editor)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (repo, pr_number, comment_id, edited_at, diff, editor),
         )
         conn.commit()
     finally:

--- a/tests/test_e2e_github_poller.py
+++ b/tests/test_e2e_github_poller.py
@@ -11,11 +11,11 @@ What is tested
 1. A new issue appears in the DB after the first poll.
 2. Re-polling produces no duplicate rows (upsert is idempotent).
 3. Editing the issue body is reflected on the next poll; old text is not
-   preserved (known gap — no history table).
-4. A new comment appears in ``comments_json`` after a re-poll.
+   preserved (upsert overwrites); edit history is recorded in issue_body_edits.
+4. A new comment appears in ``comments_json`` after a re-poll; each stored
+   comment dict includes an ``id`` key.
 5. Editing a comment is reflected; no duplicate comment entry is created;
-   original text is not preserved; ``updated_at`` is absent from the stored
-   comment (known gap — fetch_issues does not capture it).
+   original text is not preserved; edit history is recorded in issue_comment_edits.
 
 Cursor note
 -----------
@@ -222,10 +222,8 @@ class TestGitHubPollerE2E:
         )
 
     def test_issue_body_edit_is_reflected(self, class_tmp_path, live_issue):
-        """Editing the issue body updates the stored row on the next poll.
-
-        Known gap: old body text is not preserved — the upsert overwrites it
-        with no history table.  This test documents that gap explicitly.
+        """Editing the issue body updates the stored row on the next poll
+        and records a row in issue_body_edits.
         """
         config = _write_config(class_tmp_path)
         db_path = class_tmp_path / "data" / "github.db"
@@ -254,11 +252,20 @@ class TestGitHubPollerE2E:
             "Updated body was not reflected in DB after re-poll"
         )
 
-        # Known gap: original text is gone — no history preserved
+        # Original text is gone — upsert overwrites it
         assert "Initial body text" not in after["body"], (
             "Old body text unexpectedly still present — "
             "upsert should have overwritten it"
         )
+
+        # Edit history is now recorded
+        conn = sqlite3.connect(str(db_path))
+        edits = conn.execute(
+            "SELECT * FROM issue_body_edits WHERE repo = ? AND issue_number = ?",
+            (REPO, live_issue),
+        ).fetchall()
+        conn.close()
+        assert len(edits) >= 1, "No body edit history recorded in issue_body_edits"
 
     def test_new_comment_appears_after_poll(self, class_tmp_path, live_issue):
         """A comment added to an issue appears in ``comments_json`` after re-poll."""
@@ -290,20 +297,20 @@ class TestGitHubPollerE2E:
         assert any("First comment" in b for b in bodies), (
             "Comment body not found in stored comments"
         )
+        for c in after["comments"]:
+            assert "id" in c, "comment_id missing from stored comment"
 
     def test_comment_edit_reflected_no_duplicate_no_history(
         self, class_tmp_path, live_issue
     ):
-        """Editing a comment updates the stored text on re-poll.
+        """Editing a comment updates the stored text on re-poll and records
+        a row in issue_comment_edits.
 
         Asserts:
         - Edited text appears in ``comments_json``
         - Comment count does not increase (no duplication)
-
-        Known gaps documented:
         - Original comment text is not preserved (overwritten by upsert)
-        - ``updated_at`` is absent from stored comment dicts (not fetched)
-          — if this assertion fails, the gap has been fixed; remove it
+        - At least one row is recorded in issue_comment_edits
         """
         config = _write_config(class_tmp_path)
         db_path = class_tmp_path / "data" / "github.db"
@@ -359,14 +366,16 @@ class TestGitHubPollerE2E:
             "after comment edit — possible duplication in comments_json"
         )
 
-        # Known gap: original text is gone
+        # Original text is gone — upsert overwrites it
         assert not any("ORIGINAL TEXT" in b for b in bodies), (
             "Original comment text still present — expected upsert to overwrite it"
         )
 
-        # Known gap: no updated_at on stored comments
-        for c in after["comments"]:
-            assert "updated_at" not in c, (
-                "updated_at present on stored comment — "
-                "remove this assertion if the gap is intentionally fixed"
-            )
+        # Comment edit history is now recorded
+        conn = sqlite3.connect(str(db_path))
+        edits = conn.execute(
+            "SELECT * FROM issue_comment_edits WHERE repo = ? AND issue_number = ?",
+            (REPO, live_issue),
+        ).fetchall()
+        conn.close()
+        assert len(edits) >= 1, "No comment edit history recorded in issue_comment_edits"

--- a/tests/test_e2e_github_poller.py
+++ b/tests/test_e2e_github_poller.py
@@ -1,0 +1,372 @@
+"""E2E tests for the GitHub poller against a real GitHub repo.
+
+Guards
+------
+Requires ``AM_I_SHIPPING_E2E=1`` in the environment.  The ``gh`` CLI must be
+authenticated.  A temporary issue is created on the target repo for each test
+class run and closed in teardown.
+
+What is tested
+--------------
+1. A new issue appears in the DB after the first poll.
+2. Re-polling produces no duplicate rows (upsert is idempotent).
+3. Editing the issue body is reflected on the next poll; old text is not
+   preserved (known gap — no history table).
+4. A new comment appears in ``comments_json`` after a re-poll.
+5. Editing a comment is reflected; no duplicate comment entry is created;
+   original text is not preserved; ``updated_at`` is absent from the stored
+   comment (known gap — fetch_issues does not capture it).
+
+Cursor note
+-----------
+``advance_cursor`` sets ``last_polled_at`` to today.  GitHub's
+``updated:>DATE`` filter is strictly greater than, so same-day edits would
+be missed on a real incremental poll.  Tests call ``_reset_cursor`` (rewinds
+to yesterday) before each re-poll so edits made in the test run are caught.
+This is intentional: the cursor-skipping behaviour is a separate known issue
+that should be addressed in the cursor design, not papered over here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Constants / environment
+# ---------------------------------------------------------------------------
+
+REPO = os.environ.get("GITHUB_E2E_REPO", "hyang0129/am-i-shipping")
+PROJECTS_PATH = Path(
+    os.environ.get(
+        "AM_I_SHIPPING_PROJECTS_PATH",
+        str(Path.home() / ".claude" / "projects"),
+    )
+)
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("AM_I_SHIPPING_E2E", "0") != "1",
+    reason="E2E GitHub poller tests require AM_I_SHIPPING_E2E=1 and gh CLI auth",
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _gh(*args: str) -> str:
+    result = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+def _gh_json(*args: str) -> Any:
+    return json.loads(_gh(*args))
+
+
+def _write_config(tmp_path: Path) -> Path:
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        f"""
+session:
+  projects_path: "{PROJECTS_PATH}"
+github:
+  repos:
+    - {REPO}
+  backfill_days: 7
+data:
+  data_dir: "{tmp_path / 'data'}"
+""".lstrip()
+    )
+    return config
+
+
+def _poll(config_path: Path) -> tuple[int, bool]:
+    from collector.github_poller.run import run
+
+    return run(config_path=str(config_path))
+
+
+def _reset_cursor(db_path: Path, repo: str) -> None:
+    """Rewind the poll cursor to yesterday.
+
+    GitHub's ``updated:>DATE`` filter is strictly greater-than, so issues
+    updated *today* would be missed if the cursor is set to today.  Rewinding
+    to yesterday ensures same-day edits are picked up in tests.
+    """
+    yesterday = (
+        datetime.now(timezone.utc) - timedelta(days=1)
+    ).strftime("%Y-%m-%d")
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        INSERT INTO poll_cursor (repo, last_polled_at) VALUES (?, ?)
+        ON CONFLICT(repo) DO UPDATE SET last_polled_at = excluded.last_polled_at
+        """,
+        (repo, yesterday),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _get_issue(
+    db_path: Path, repo: str, issue_number: int
+) -> Optional[Dict[str, Any]]:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT * FROM issues WHERE repo = ? AND issue_number = ?",
+        (repo, issue_number),
+    ).fetchone()
+    conn.close()
+    if row is None:
+        return None
+    d = dict(row)
+    d["comments"] = json.loads(d.get("comments_json") or "[]")
+    return d
+
+
+def _issue_row_count(db_path: Path, repo: str, issue_number: int) -> int:
+    conn = sqlite3.connect(str(db_path))
+    n = conn.execute(
+        "SELECT COUNT(*) FROM issues WHERE repo = ? AND issue_number = ?",
+        (repo, issue_number),
+    ).fetchone()[0]
+    conn.close()
+    return n
+
+
+# ---------------------------------------------------------------------------
+# Fixture: real GitHub issue, closed on teardown
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="class")
+def live_issue(tmp_path_factory) -> int:
+    """Create a real GitHub issue; yield its number; close it on teardown."""
+    issue_url = _gh(
+        "issue", "create",
+        "--repo", REPO,
+        "--title", "[e2e-test] GitHub poller lifecycle test",
+        "--body", "Initial body text. Created by e2e test.",
+    )
+    issue_number = int(issue_url.rstrip("/").split("/")[-1])
+    yield issue_number
+    # Cleanup: close the issue (delete requires admin; close is sufficient)
+    try:
+        _gh(
+            "issue", "close", str(issue_number),
+            "--repo", REPO,
+            "--comment", "Closed by e2e test cleanup.",
+        )
+    except subprocess.CalledProcessError:
+        pass  # best-effort; don't fail the test suite on cleanup error
+
+
+@pytest.fixture(scope="class")
+def class_tmp_path(tmp_path_factory) -> Path:
+    return tmp_path_factory.mktemp("github_poller_e2e")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubPollerE2E:
+    """End-to-end lifecycle tests for the GitHub poller."""
+
+    def test_new_issue_appears_after_poll(self, class_tmp_path, live_issue):
+        """A newly created issue is persisted after the first poll."""
+        config = _write_config(class_tmp_path)
+        db_path = class_tmp_path / "data" / "github.db"
+
+        total, ok = _poll(config)
+
+        assert ok, "Poller reported failure"
+        assert total > 0, "Poller fetched zero records"
+
+        row = _get_issue(db_path, REPO, live_issue)
+        assert row is not None, f"Issue #{live_issue} not found in DB after first poll"
+        assert row["title"] == "[e2e-test] GitHub poller lifecycle test"
+        assert "Initial body text" in row["body"]
+        assert row["state"] == "OPEN"
+
+    def test_no_duplicate_rows_on_repoll(self, class_tmp_path, live_issue):
+        """Re-polling the same data produces exactly one row for the test issue.
+
+        Note: total row count may legitimately increase if other issues were
+        updated on GitHub between runs; we only assert on the test issue itself.
+        """
+        config = _write_config(class_tmp_path)
+        db_path = class_tmp_path / "data" / "github.db"
+
+        # Ensure DB is populated from a previous test or seed here
+        _poll(config)
+
+        # Rewind cursor and re-poll
+        _reset_cursor(db_path, REPO)
+        _poll(config)
+
+        count = _issue_row_count(db_path, REPO, live_issue)
+        assert count == 1, (
+            f"Expected exactly 1 row for issue #{live_issue}, found {count}"
+        )
+
+    def test_issue_body_edit_is_reflected(self, class_tmp_path, live_issue):
+        """Editing the issue body updates the stored row on the next poll.
+
+        Known gap: old body text is not preserved — the upsert overwrites it
+        with no history table.  This test documents that gap explicitly.
+        """
+        config = _write_config(class_tmp_path)
+        db_path = class_tmp_path / "data" / "github.db"
+
+        # Seed poll
+        _poll(config)
+        before = _get_issue(db_path, REPO, live_issue)
+        assert before is not None
+        assert "Initial body text" in before["body"]
+
+        # Edit body via gh CLI
+        _gh(
+            "issue", "edit", str(live_issue),
+            "--repo", REPO,
+            "--body", "EDITED body text. Updated by e2e test.",
+        )
+
+        _reset_cursor(db_path, REPO)
+        _poll(config)
+
+        after = _get_issue(db_path, REPO, live_issue)
+        assert after is not None
+
+        # Updated text is present
+        assert "EDITED body text" in after["body"], (
+            "Updated body was not reflected in DB after re-poll"
+        )
+
+        # Known gap: original text is gone — no history preserved
+        assert "Initial body text" not in after["body"], (
+            "Old body text unexpectedly still present — "
+            "upsert should have overwritten it"
+        )
+
+    def test_new_comment_appears_after_poll(self, class_tmp_path, live_issue):
+        """A comment added to an issue appears in ``comments_json`` after re-poll."""
+        config = _write_config(class_tmp_path)
+        db_path = class_tmp_path / "data" / "github.db"
+
+        _poll(config)
+        before = _get_issue(db_path, REPO, live_issue)
+        assert before is not None
+        initial_count = len(before["comments"])
+
+        # Add a comment
+        _gh(
+            "issue", "comment", str(live_issue),
+            "--repo", REPO,
+            "--body", "First comment. Original text before any edit.",
+        )
+
+        _reset_cursor(db_path, REPO)
+        _poll(config)
+
+        after = _get_issue(db_path, REPO, live_issue)
+        assert after is not None
+
+        assert len(after["comments"]) == initial_count + 1, (
+            "New comment did not appear in comments_json after re-poll"
+        )
+        bodies = [c["body"] for c in after["comments"]]
+        assert any("First comment" in b for b in bodies), (
+            "Comment body not found in stored comments"
+        )
+
+    def test_comment_edit_reflected_no_duplicate_no_history(
+        self, class_tmp_path, live_issue
+    ):
+        """Editing a comment updates the stored text on re-poll.
+
+        Asserts:
+        - Edited text appears in ``comments_json``
+        - Comment count does not increase (no duplication)
+
+        Known gaps documented:
+        - Original comment text is not preserved (overwritten by upsert)
+        - ``updated_at`` is absent from stored comment dicts (not fetched)
+          — if this assertion fails, the gap has been fixed; remove it
+        """
+        config = _write_config(class_tmp_path)
+        db_path = class_tmp_path / "data" / "github.db"
+
+        # Seed: add a comment and poll to capture it
+        _gh(
+            "issue", "comment", str(live_issue),
+            "--repo", REPO,
+            "--body", "Comment before edit. ORIGINAL TEXT.",
+        )
+        _reset_cursor(db_path, REPO)
+        _poll(config)
+
+        before = _get_issue(db_path, REPO, live_issue)
+        assert before is not None
+        count_before = len(before["comments"])
+        assert any("ORIGINAL TEXT" in c["body"] for c in before["comments"]), (
+            "Seeded comment not found in DB before edit"
+        )
+
+        # Fetch the GitHub comment ID so we can PATCH it
+        owner, name = REPO.split("/", 1)
+        raw_comments: List[Dict] = _gh_json(
+            "api", f"/repos/{owner}/{name}/issues/{live_issue}/comments"
+        )
+        gh_comment = next(
+            c for c in raw_comments if "ORIGINAL TEXT" in c["body"]
+        )
+        comment_id = gh_comment["id"]
+
+        # Edit the comment via gh api PATCH
+        _gh(
+            "api", "--method", "PATCH",
+            f"/repos/{owner}/{name}/issues/comments/{comment_id}",
+            "--field", "body=Comment after edit. CHANGED TEXT.",
+        )
+
+        _reset_cursor(db_path, REPO)
+        _poll(config)
+
+        after = _get_issue(db_path, REPO, live_issue)
+        assert after is not None
+        bodies = [c["body"] for c in after["comments"]]
+
+        # Edited text appears
+        assert any("CHANGED TEXT" in b for b in bodies), (
+            "Edited comment text not reflected in comments_json after re-poll"
+        )
+
+        # No duplicate entries
+        assert len(after["comments"]) == count_before, (
+            f"Comment count changed from {count_before} to {len(after['comments'])} "
+            "after comment edit — possible duplication in comments_json"
+        )
+
+        # Known gap: original text is gone
+        assert not any("ORIGINAL TEXT" in b for b in bodies), (
+            "Original comment text still present — expected upsert to overwrite it"
+        )
+
+        # Known gap: no updated_at on stored comments
+        for c in after["comments"]:
+            assert "updated_at" not in c, (
+                "updated_at present on stored comment — "
+                "remove this assertion if the gap is intentionally fixed"
+            )

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -10,8 +10,13 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from collector.github_poller.fetch_issues import fetch_issues, _extract_type_label
-from collector.github_poller.fetch_prs import fetch_prs
+from collector.github_poller.fetch_issues import (
+    fetch_issues,
+    fetch_issue_edit_history,
+    fetch_issue_edit_history_batch,
+    _extract_type_label,
+)
+from collector.github_poller.fetch_prs import fetch_prs, fetch_pr_edit_history
 from collector.github_poller.gh_client import GhCliError
 
 
@@ -40,6 +45,7 @@ ISSUE_FIXTURE = [
 
 ISSUE_COMMENTS_FIXTURE = [
     {
+        "id": 12345,
         "user": {"login": "alice"},
         "body": "Looks good!",
         "created_at": "2024-01-15T12:00:00Z",
@@ -59,6 +65,7 @@ PR_FIXTURE = [
 
 PR_REVIEW_COMMENTS_FIXTURE = [
     {
+        "id": 67890,
         "user": {"login": "bob"},
         "body": "Consider using pathlib here.",
         "created_at": "2024-01-19T10:00:00Z",
@@ -176,3 +183,226 @@ class TestFetchPRs:
         results = fetch_prs("owner/repo")
         assert results[0]["review_comments"] == []
         assert results[0]["review_comment_count"] == 0
+
+
+class TestCommentIds:
+    @patch("collector.github_poller.fetch_issues.gh_api")
+    @patch("collector.github_poller.fetch_issues.run_gh_json")
+    def test_issue_comment_has_id(self, mock_list, mock_api):
+        """Issue comment dicts include the 'id' key from the REST response."""
+        mock_list.return_value = [ISSUE_FIXTURE[0]]
+        mock_api.return_value = ISSUE_COMMENTS_FIXTURE
+
+        results = fetch_issues("owner/repo")
+        assert results[0]["comments"][0]["id"] == 12345
+
+    @patch("collector.github_poller.fetch_issues.gh_api")
+    @patch("collector.github_poller.fetch_issues.run_gh_json")
+    def test_issue_has_updated_at(self, mock_list, mock_api):
+        """Issue dicts include 'updated_at' from the REST updatedAt field."""
+        fixture = [{**ISSUE_FIXTURE[0], "updatedAt": "2024-01-20T16:00:00Z"}]
+        mock_list.return_value = fixture
+        mock_api.return_value = []
+
+        results = fetch_issues("owner/repo")
+        assert results[0]["updated_at"] == "2024-01-20T16:00:00Z"
+
+    @patch("collector.github_poller.fetch_prs.gh_api")
+    @patch("collector.github_poller.fetch_prs.run_gh_json")
+    def test_pr_review_comment_has_id(self, mock_list, mock_api):
+        """PR review comment dicts include the 'id' key from the REST response."""
+        mock_list.return_value = [PR_FIXTURE[0]]
+        mock_api.return_value = PR_REVIEW_COMMENTS_FIXTURE
+
+        results = fetch_prs("owner/repo")
+        assert results[0]["review_comments"][0]["id"] == 67890
+
+    @patch("collector.github_poller.fetch_prs.gh_api")
+    @patch("collector.github_poller.fetch_prs.run_gh_json")
+    def test_pr_has_updated_at(self, mock_list, mock_api):
+        """PR dicts include 'updated_at' from the REST updatedAt field."""
+        fixture = [{**PR_FIXTURE[0], "updatedAt": "2024-01-22T10:00:00Z"}]
+        mock_list.return_value = fixture
+        mock_api.return_value = []
+
+        results = fetch_prs("owner/repo")
+        assert results[0]["updated_at"] == "2024-01-22T10:00:00Z"
+
+
+class TestFetchIssueEditHistory:
+    @patch("collector.github_poller.fetch_issues.gh_graphql")
+    def test_returns_body_and_comment_edits(self, mock_gql):
+        """fetch_issue_edit_history returns body_edits and comment_edits lists."""
+        mock_gql.return_value = {
+            "data": {"repository": {"issue": {
+                "userContentEdits": {"nodes": [
+                    {
+                        "editedAt": "2024-01-20T16:00:00Z",
+                        "diff": "- old\n+ new",
+                        "editor": {"login": "alice"},
+                    }
+                ]},
+                "comments": {"nodes": [
+                    {
+                        "databaseId": 123,
+                        "userContentEdits": {"nodes": [
+                            {
+                                "editedAt": "2024-01-20T17:00:00Z",
+                                "diff": "- old comment\n+ new comment",
+                                "editor": {"login": "bob"},
+                            }
+                        ]},
+                    }
+                ]},
+            }}}
+        }
+
+        result = fetch_issue_edit_history("owner/repo", 1)
+        assert len(result["body_edits"]) == 1
+        assert result["body_edits"][0]["editor"] == "alice"
+        assert result["body_edits"][0]["edited_at"] == "2024-01-20T16:00:00Z"
+        assert len(result["comment_edits"]) == 1
+        assert result["comment_edits"][0]["comment_id"] == 123
+        assert result["comment_edits"][0]["editor"] == "bob"
+
+    @patch("collector.github_poller.fetch_issues.gh_graphql")
+    def test_graceful_empty_on_graphql_error(self, mock_gql):
+        """fetch_issue_edit_history returns empty dict on GraphQL error response."""
+        mock_gql.return_value = {"errors": [{"message": "not found"}]}
+
+        result = fetch_issue_edit_history("owner/repo", 999)
+        assert result == {}
+
+    @patch("collector.github_poller.fetch_issues.gh_graphql")
+    def test_graceful_empty_on_exception(self, mock_gql):
+        """fetch_issue_edit_history returns empty dict when gh_graphql raises."""
+        mock_gql.side_effect = GhCliError(["gh", "api", "graphql"], 1, "network error")
+
+        result = fetch_issue_edit_history("owner/repo", 1)
+        assert result == {}
+
+    @patch("collector.github_poller.fetch_issues.gh_graphql")
+    def test_empty_edits_when_no_edits(self, mock_gql):
+        """Returns empty lists for body_edits and comment_edits when there are none."""
+        mock_gql.return_value = {
+            "data": {"repository": {"issue": {
+                "userContentEdits": {"nodes": []},
+                "comments": {"nodes": []},
+            }}}
+        }
+
+        result = fetch_issue_edit_history("owner/repo", 1)
+        assert result["body_edits"] == []
+        assert result["comment_edits"] == []
+
+
+class TestFetchIssueEditHistoryBatch:
+    @patch("collector.github_poller.fetch_issues.gh_graphql")
+    def test_chunks_large_list(self, mock_gql):
+        """fetch_issue_edit_history_batch makes multiple calls for >20 issues."""
+        mock_gql.return_value = {
+            "data": {"repository": {
+                f"issue{i}": {
+                    "number": i + 1,
+                    "userContentEdits": {"nodes": []},
+                    "comments": {"nodes": []},
+                }
+                for i in range(20)
+            }}
+        }
+
+        issue_numbers = list(range(1, 42))  # 41 issues -> 3 calls (20+20+1)
+        result = fetch_issue_edit_history_batch("owner/repo", issue_numbers)
+
+        assert mock_gql.call_count == 3
+
+    @patch("collector.github_poller.fetch_issues.gh_graphql")
+    def test_returns_mapping_of_issue_number_to_edits(self, mock_gql):
+        """Batch result maps issue_number -> edit history dict."""
+        mock_gql.return_value = {
+            "data": {"repository": {
+                "issue0": {
+                    "number": 1,
+                    "userContentEdits": {"nodes": [
+                        {"editedAt": "2024-01-20T16:00:00Z", "diff": "x", "editor": {"login": "alice"}}
+                    ]},
+                    "comments": {"nodes": []},
+                },
+                "issue1": {
+                    "number": 2,
+                    "userContentEdits": {"nodes": []},
+                    "comments": {"nodes": []},
+                },
+            }}
+        }
+
+        result = fetch_issue_edit_history_batch("owner/repo", [1, 2])
+        assert 1 in result
+        assert 2 in result
+        assert len(result[1]["body_edits"]) == 1
+        assert result[1]["body_edits"][0]["editor"] == "alice"
+        assert result[2]["body_edits"] == []
+
+    @patch("collector.github_poller.fetch_issues.gh_graphql")
+    def test_skips_chunk_on_graphql_error(self, mock_gql):
+        """Batch silently skips chunks that return GraphQL errors."""
+        mock_gql.return_value = {"errors": [{"message": "server error"}]}
+
+        result = fetch_issue_edit_history_batch("owner/repo", [1, 2, 3])
+        assert result == {}
+
+
+class TestFetchPrEditHistory:
+    @patch("collector.github_poller.fetch_prs.gh_graphql")
+    def test_returns_body_and_review_comment_edits(self, mock_gql):
+        """fetch_pr_edit_history returns body_edits and review_comment_edits."""
+        mock_gql.return_value = {
+            "data": {"repository": {"pullRequest": {
+                "userContentEdits": {"nodes": [
+                    {
+                        "editedAt": "2024-01-21T10:00:00Z",
+                        "diff": "- old pr\n+ new pr",
+                        "editor": {"login": "carol"},
+                    }
+                ]},
+                "reviews": {"nodes": [
+                    {
+                        "comments": {"nodes": [
+                            {
+                                "databaseId": 456,
+                                "userContentEdits": {"nodes": [
+                                    {
+                                        "editedAt": "2024-01-21T11:00:00Z",
+                                        "diff": "- old review\n+ new review",
+                                        "editor": {"login": "dave"},
+                                    }
+                                ]},
+                            }
+                        ]}
+                    }
+                ]},
+            }}}
+        }
+
+        result = fetch_pr_edit_history("owner/repo", 6)
+        assert len(result["body_edits"]) == 1
+        assert result["body_edits"][0]["editor"] == "carol"
+        assert len(result["review_comment_edits"]) == 1
+        assert result["review_comment_edits"][0]["comment_id"] == 456
+        assert result["review_comment_edits"][0]["editor"] == "dave"
+
+    @patch("collector.github_poller.fetch_prs.gh_graphql")
+    def test_graceful_empty_on_graphql_error(self, mock_gql):
+        """fetch_pr_edit_history returns empty dict on GraphQL error response."""
+        mock_gql.return_value = {"errors": [{"message": "not found"}]}
+
+        result = fetch_pr_edit_history("owner/repo", 999)
+        assert result == {}
+
+    @patch("collector.github_poller.fetch_prs.gh_graphql")
+    def test_graceful_empty_on_exception(self, mock_gql):
+        """fetch_pr_edit_history returns empty dict when gh_graphql raises."""
+        mock_gql.side_effect = GhCliError(["gh", "api", "graphql"], 1, "timeout")
+
+        result = fetch_pr_edit_history("owner/repo", 6)
+        assert result == {}

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -315,6 +315,7 @@ class TestFetchIssueEditHistoryBatch:
         result = fetch_issue_edit_history_batch("owner/repo", issue_numbers)
 
         assert mock_gql.call_count == 3
+        assert len(result) == 41
 
     @patch("collector.github_poller.fetch_issues.gh_graphql")
     def test_returns_mapping_of_issue_number_to_edits(self, mock_gql):

--- a/tests/test_gh_client.py
+++ b/tests/test_gh_client.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from collector.github_poller.gh_client import GhCliError, run_gh, run_gh_json, gh_api
+from collector.github_poller.gh_client import GhCliError, run_gh, run_gh_json, gh_api, gh_graphql
 
 
 class TestGhCliError:
@@ -102,3 +102,46 @@ class TestGhApi:
         )
         result = gh_api("/repos/owner/repo/issues", paginate=True)
         assert result == [{"id": 1}, {"id": 2}]
+
+
+class TestGhGraphql:
+    @patch("collector.github_poller.gh_client.subprocess.run")
+    def test_basic_query_returns_parsed_data(self, mock_run):
+        """gh_graphql returns parsed data from GraphQL response."""
+        response = {"data": {"repository": {"issue": {"number": 1}}}}
+        mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps(response))
+        result = gh_graphql("query { ... }", {"owner": "test", "name": "repo"})
+        assert result == response
+
+    @patch("collector.github_poller.gh_client.time.sleep")
+    @patch("collector.github_poller.gh_client.subprocess.run")
+    def test_retries_on_failure(self, mock_run, mock_sleep):
+        """gh_graphql retries with backoff like run_gh."""
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="rate limited")
+        with pytest.raises(GhCliError):
+            gh_graphql("query { ... }", {}, max_retries=1)
+        # 2 total attempts: initial + 1 retry
+        assert mock_run.call_count == 2
+
+    @patch("collector.github_poller.gh_client.subprocess.run")
+    def test_string_vars_use_lowercase_f(self, mock_run):
+        """String variables are passed with -f (untyped)."""
+        mock_run.return_value = MagicMock(returncode=0, stdout='{"data":{}}')
+        gh_graphql("query($owner: String!) { ... }", {"owner": "myorg"})
+        cmd = mock_run.call_args[0][0]
+        # Find the index of "-f" that precedes "owner=myorg"
+        assert "-f" in cmd
+        f_indices = [i for i, a in enumerate(cmd) if a == "-f"]
+        owner_args = [cmd[i + 1] for i in f_indices if i + 1 < len(cmd)]
+        assert any("owner=myorg" in arg for arg in owner_args)
+
+    @patch("collector.github_poller.gh_client.subprocess.run")
+    def test_non_string_vars_use_uppercase_f(self, mock_run):
+        """Non-string variables (int, bool) are passed with -F (typed)."""
+        mock_run.return_value = MagicMock(returncode=0, stdout='{"data":{}}')
+        gh_graphql("query($n: Int!) { ... }", {"n": 42})
+        cmd = mock_run.call_args[0][0]
+        assert "-F" in cmd
+        F_indices = [i for i, a in enumerate(cmd) if a == "-F"]
+        n_args = [cmd[i + 1] for i in F_indices if i + 1 < len(cmd)]
+        assert any("n=" in arg for arg in n_args)

--- a/tests/test_github_store.py
+++ b/tests/test_github_store.py
@@ -11,7 +11,15 @@ import sqlite3
 
 import pytest
 
-from collector.github_poller.store import upsert_issue, upsert_pr, upsert_pr_issue_link
+from collector.github_poller.store import (
+    upsert_issue,
+    upsert_pr,
+    upsert_pr_issue_link,
+    insert_issue_body_edit,
+    insert_issue_comment_edit,
+    insert_pr_body_edit,
+    insert_pr_review_comment_edit,
+)
 
 
 def _make_issue(**overrides):
@@ -153,3 +161,133 @@ class TestUpsertPRIssueLink:
         rows = conn.execute("SELECT * FROM pr_issues").fetchall()
         conn.close()
         assert len(rows) == 1
+
+
+class TestInsertIssueBodyEdit:
+    def test_insert_creates_row(self, tmp_path):
+        db = tmp_path / "github.db"
+        insert_issue_body_edit("owner/repo", 1, "2024-01-20T16:00:00Z", "- old\n+ new", "alice", db)
+
+        conn = sqlite3.connect(str(db))
+        rows = conn.execute("SELECT * FROM issue_body_edits").fetchall()
+        conn.close()
+        assert len(rows) == 1
+
+    def test_duplicate_insert_idempotent(self, tmp_path):
+        db = tmp_path / "github.db"
+        insert_issue_body_edit("owner/repo", 1, "2024-01-20T16:00:00Z", "diff", "alice", db)
+        insert_issue_body_edit("owner/repo", 1, "2024-01-20T16:00:00Z", "diff", "alice", db)
+
+        conn = sqlite3.connect(str(db))
+        rows = conn.execute("SELECT * FROM issue_body_edits").fetchall()
+        conn.close()
+        assert len(rows) == 1
+
+
+class TestInsertIssueCommentEdit:
+    def test_insert_creates_row(self, tmp_path):
+        db = tmp_path / "github.db"
+        insert_issue_comment_edit("owner/repo", 1, 123, "2024-01-20T17:00:00Z", "- old\n+ new", "bob", db)
+
+        conn = sqlite3.connect(str(db))
+        rows = conn.execute("SELECT * FROM issue_comment_edits").fetchall()
+        conn.close()
+        assert len(rows) == 1
+
+    def test_duplicate_insert_idempotent(self, tmp_path):
+        db = tmp_path / "github.db"
+        insert_issue_comment_edit("owner/repo", 1, 123, "2024-01-20T17:00:00Z", "diff", "bob", db)
+        insert_issue_comment_edit("owner/repo", 1, 123, "2024-01-20T17:00:00Z", "diff", "bob", db)
+
+        conn = sqlite3.connect(str(db))
+        rows = conn.execute("SELECT * FROM issue_comment_edits").fetchall()
+        conn.close()
+        assert len(rows) == 1
+
+
+class TestInsertPrBodyEdit:
+    def test_insert_creates_row(self, tmp_path):
+        db = tmp_path / "github.db"
+        insert_pr_body_edit("owner/repo", 10, "2024-01-21T10:00:00Z", "- old pr\n+ new pr", "carol", db)
+
+        conn = sqlite3.connect(str(db))
+        rows = conn.execute("SELECT * FROM pr_body_edits").fetchall()
+        conn.close()
+        assert len(rows) == 1
+
+    def test_duplicate_insert_idempotent(self, tmp_path):
+        db = tmp_path / "github.db"
+        insert_pr_body_edit("owner/repo", 10, "2024-01-21T10:00:00Z", "diff", "carol", db)
+        insert_pr_body_edit("owner/repo", 10, "2024-01-21T10:00:00Z", "diff", "carol", db)
+
+        conn = sqlite3.connect(str(db))
+        rows = conn.execute("SELECT * FROM pr_body_edits").fetchall()
+        conn.close()
+        assert len(rows) == 1
+
+
+class TestInsertPrReviewCommentEdit:
+    def test_insert_creates_row(self, tmp_path):
+        db = tmp_path / "github.db"
+        insert_pr_review_comment_edit("owner/repo", 10, 456, "2024-01-21T11:00:00Z", "- old\n+ new", "dave", db)
+
+        conn = sqlite3.connect(str(db))
+        rows = conn.execute("SELECT * FROM pr_review_comment_edits").fetchall()
+        conn.close()
+        assert len(rows) == 1
+
+    def test_duplicate_insert_idempotent(self, tmp_path):
+        db = tmp_path / "github.db"
+        insert_pr_review_comment_edit("owner/repo", 10, 456, "2024-01-21T11:00:00Z", "diff", "dave", db)
+        insert_pr_review_comment_edit("owner/repo", 10, 456, "2024-01-21T11:00:00Z", "diff", "dave", db)
+
+        conn = sqlite3.connect(str(db))
+        rows = conn.execute("SELECT * FROM pr_review_comment_edits").fetchall()
+        conn.close()
+        assert len(rows) == 1
+
+
+class TestUpsertIssueUpdatedAt:
+    def test_updated_at_stored(self, tmp_path):
+        db = tmp_path / "github.db"
+        issue = _make_issue(updated_at="2024-01-20T16:00:00Z")
+        upsert_issue("owner/repo", issue, db)
+
+        conn = sqlite3.connect(str(db))
+        val = conn.execute("SELECT updated_at FROM issues").fetchone()[0]
+        conn.close()
+        assert val == "2024-01-20T16:00:00Z"
+
+    def test_updated_at_defaults_to_none(self, tmp_path):
+        """Existing callers that don't pass updated_at still work."""
+        db = tmp_path / "github.db"
+        issue = _make_issue()  # no updated_at override
+        upsert_issue("owner/repo", issue, db)
+
+        conn = sqlite3.connect(str(db))
+        val = conn.execute("SELECT updated_at FROM issues").fetchone()[0]
+        conn.close()
+        assert val is None
+
+
+class TestUpsertPrUpdatedAt:
+    def test_updated_at_stored(self, tmp_path):
+        db = tmp_path / "github.db"
+        pr = _make_pr(updated_at="2024-01-22T10:00:00Z")
+        upsert_pr("owner/repo", pr, db)
+
+        conn = sqlite3.connect(str(db))
+        val = conn.execute("SELECT updated_at FROM pull_requests").fetchone()[0]
+        conn.close()
+        assert val == "2024-01-22T10:00:00Z"
+
+    def test_updated_at_defaults_to_none(self, tmp_path):
+        """Existing callers that don't pass updated_at still work."""
+        db = tmp_path / "github.db"
+        pr = _make_pr()  # no updated_at override
+        upsert_pr("owner/repo", pr, db)
+
+        conn = sqlite3.connect(str(db))
+        val = conn.execute("SELECT updated_at FROM pull_requests").fetchone()[0]
+        conn.close()
+        assert val is None

--- a/tests/test_init_db.py
+++ b/tests/test_init_db.py
@@ -85,8 +85,32 @@ class TestInitDb:
         }
         conn.close()
 
-        expected = {"issues", "pull_requests", "pr_issues", "pr_sessions", "poll_cursor"}
+        expected = {
+            "issues", "pull_requests", "pr_issues", "pr_sessions", "poll_cursor",
+            "issue_body_edits", "issue_comment_edits",
+            "pr_body_edits", "pr_review_comment_edits",
+        }
         assert expected.issubset(tables)
+
+    def test_issues_has_updated_at_column(self, tmp_path):
+        config = _make_config(tmp_path)
+        init_all(config)
+
+        conn = sqlite3.connect(str(tmp_path / "data" / "github.db"))
+        cursor = conn.execute("PRAGMA table_info(issues)")
+        columns = {row[1] for row in cursor.fetchall()}
+        conn.close()
+        assert "updated_at" in columns
+
+    def test_pull_requests_has_updated_at_column(self, tmp_path):
+        config = _make_config(tmp_path)
+        init_all(config)
+
+        conn = sqlite3.connect(str(tmp_path / "data" / "github.db"))
+        cursor = conn.execute("PRAGMA table_info(pull_requests)")
+        columns = {row[1] for row in cursor.fetchall()}
+        conn.close()
+        assert "updated_at" in columns
 
     def test_appswitch_db_schema(self, tmp_path):
         config = _make_config(tmp_path)


### PR DESCRIPTION
Closes #10

## Summary

- Adds `gh_graphql` to `gh_client.py` with same retry/backoff as `gh_api`
- Captures `comment_id` and `updated_at` in REST fetch results for issues and PRs
- Adds `fetch_issue_edit_history` / `fetch_pr_edit_history` (single) and `fetch_issue_edit_history_batch` (20 issues per GraphQL call)
- Adds four append-only edit history tables: `issue_body_edits`, `issue_comment_edits`, `pr_body_edits`, `pr_review_comment_edits`
- Adds `updated_at` column to existing `issues` and `pull_requests` tables (with migration)
- Wires `updated_at` gating into the poll loop: GraphQL edit history fetched only when `updated_at` changes; backfill uses batch calls
- 179 unit tests pass; E2E test updated to assert edit history rows are recorded

## Deferred
- `fetch_pr_edit_history_batch` — PR backfill still fetches one at a time; noted as follow-up optimization (m2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)