### PR TITLE
fix(#5): Integration gate, README, and auto-launch scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,145 @@
+# am-i-shipping
+
+A workflow monitor that collects data from your Claude Code sessions, GitHub activity, and application usage patterns. It runs weekly synthesis to identify gaps between what you expected Claude to deliver and what it actually delivered, then proposes experiments to close those gaps. The unit of improvement is your behavior — your setup, your prompts, your plans, your review habits — not Claude's.
+
+This is **not** a dashboard. It is a feedback loop: collect signals, find patterns, change one precondition, measure the result.
+
+---
+
+## Collectors
+
+| # | Collector | What it captures | Data store |
+|---|-----------|-----------------|------------|
+| C1 | **Session Parser** | Turn counts, tool failures, re-prompt counts, session duration from Claude Code JSONL transcripts | `data/sessions.db` |
+| C2 | **GitHub Poller** | Issues, PRs, push counts, issue-PR linkage for configured repos | `data/github.db` |
+| C3 | **App-Switch Logger** | Window-focus events from ActivityWatch — context switching patterns during coding sessions | `data/appswitch.db` |
+
+---
+
+## Prerequisites
+
+- **Python 3.11+**
+- **`gh` CLI** — installed and authenticated (`gh auth login`). Required for the GitHub poller.
+- **ActivityWatch** — installed and running (only required for C3, the app-switch logger). Optional if you only use C1 and C2.
+
+---
+
+## Quick Start
+
+1. **Clone and install:**
+
+   ```bash
+   git clone https://github.com/hyang0129/am-i-shipping.git
+   cd am-i-shipping
+   pip install -e .
+   ```
+
+2. **Create your config:**
+
+   ```bash
+   cp config.yaml.example config.yaml
+   ```
+
+   Edit `config.yaml` and set the required fields:
+
+   ```yaml
+   session:
+     projects_path: "/Users/<you>/.claude/projects"   # path to Claude Code projects
+
+   github:
+     repos:
+       - "your-org/your-repo"
+   ```
+
+3. **Initialize databases:**
+
+   ```bash
+   python -m am_i_shipping.db
+   ```
+
+4. **Register the Claude Code hook** (see [setup.md](setup.md) Step 1) so sessions are parsed automatically after each Claude Code session.
+
+5. **Install the scheduled service** so collectors run daily:
+
+   ```bash
+   # Linux
+   bash scripts/install-cron.sh
+
+   # macOS
+   bash scripts/install-launchd.sh
+
+   # Windows (PowerShell)
+   .\scripts\install-task.ps1
+   ```
+
+   See [setup.md](setup.md) Step 2 for manual alternatives and details.
+
+---
+
+## Manual Run
+
+Run all collectors once:
+
+```bash
+# Linux / macOS
+bash run_collectors.sh
+
+# Windows
+.\run_collectors.ps1
+```
+
+---
+
+## Verification
+
+After a collector run, verify everything is healthy:
+
+```bash
+python -m am_i_shipping.health_check
+```
+
+Exit code 0 means all collectors reported recently. Exit code 1 means one or more collectors are stale or have never run — check the output for details.
+
+---
+
+## Project Structure
+
+```
+am-i-shipping/
+├── am_i_shipping/           # Core package: config, DB schema, health check
+│   ├── config_loader.py     # Loads and validates config.yaml
+│   ├── db.py                # SQLite schema initialization
+│   ├── health_check.py      # Verifies collector freshness
+│   └── health_writer.py     # Writes health.json after each collector run
+├── collector/               # Data collectors
+│   ├── session_parser.py    # C1: Claude Code session parser
+│   ├── store.py             # Session storage layer
+│   ├── reprompt.py          # Re-prompt detection logic
+│   ├── github_poller/       # C2: GitHub issue/PR poller
+│   └── appswitch/           # C3: ActivityWatch app-switch logger
+├── scripts/                 # Service install/uninstall scripts
+│   ├── install-cron.sh      # Linux: register crontab entry
+│   ├── uninstall-cron.sh    # Linux: remove crontab entry
+│   ├── install-launchd.sh   # macOS: register launchd agent
+│   ├── uninstall-launchd.sh # macOS: remove launchd agent
+│   ├── install-task.ps1     # Windows: register Task Scheduler task
+│   └── uninstall-task.ps1   # Windows: remove Task Scheduler task
+├── tests/                   # Test suite
+├── run_collectors.sh        # Entry point (Linux/macOS)
+├── run_collectors.ps1       # Entry point (Windows)
+├── config.yaml.example      # Example configuration
+├── setup.md                 # Detailed setup guide
+└── data/                    # Runtime data (gitignored)
+    ├── sessions.db
+    ├── github.db
+    ├── appswitch.db
+    └── health.json
+```
+
+---
+
+## Further Reading
+
+- [setup.md](setup.md) — Detailed platform-specific setup instructions, hook configuration, and troubleshooting
+- [idealized-workflow.md](idealized-workflow.md) — The workflow model that frames all analysis
+- [config.yaml.example](config.yaml.example) — Full configuration reference with comments

--- a/scripts/install-cron.sh
+++ b/scripts/install-cron.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Install a crontab entry to run am-i-shipping collectors daily at 02:00.
+# Idempotent: re-running this script will not create duplicate entries.
+#
+# Usage:
+#   bash scripts/install-cron.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+CRON_TAG="am-i-shipping-collectors"
+CRON_CMD="cd \"$REPO_ROOT\" && bash run_collectors.sh >> logs/cron.log 2>&1"
+CRON_LINE="0 2 * * * $CRON_CMD # $CRON_TAG"
+
+# Check if the entry already exists
+if crontab -l 2>/dev/null | grep -qF "$CRON_TAG"; then
+    echo "Crontab entry already exists — skipping (idempotent)."
+    echo "To update, run uninstall-cron.sh first, then re-run this script."
+    exit 0
+fi
+
+# Append the new entry
+(crontab -l 2>/dev/null || true; echo "$CRON_LINE") | crontab -
+
+echo "Crontab entry installed: daily at 02:00"
+echo "Verify with: crontab -l | grep am-i-shipping"

--- a/scripts/install-cron.sh
+++ b/scripts/install-cron.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Install a crontab entry to run am-i-shipping collectors daily at 02:00.
+# Install crontab entries to run am-i-shipping collectors daily at 02:00,
+# with a boot-time fallback so missed runs are recovered on next login.
 # Idempotent: re-running this script will not create duplicate entries.
 #
 # Usage:
@@ -16,16 +17,22 @@ mkdir -p "$REPO_ROOT/logs"
 CRON_TAG="am-i-shipping-collectors"
 CRON_CMD="cd \"$REPO_ROOT\" && bash run_collectors.sh >> logs/cron.log 2>&1"
 CRON_LINE="0 2 * * * $CRON_CMD # $CRON_TAG"
+# Boot-time fallback: runs 60s after login in case the 02:00 window was missed
+# (e.g. PC was off overnight). Collectors are idempotent so a same-day double-run
+# produces no duplicate rows.
+REBOOT_LINE="@reboot sleep 60 && $CRON_CMD # $CRON_TAG"
 
-# Check if the entry already exists
+# Check if the entries already exist
 if crontab -l 2>/dev/null | grep -qF "$CRON_TAG"; then
-    echo "Crontab entry already exists — skipping (idempotent)."
+    echo "Crontab entries already exist — skipping (idempotent)."
     echo "To update, run uninstall-cron.sh first, then re-run this script."
     exit 0
 fi
 
-# Append the new entry
-(crontab -l 2>/dev/null || true; echo "$CRON_LINE") | crontab -
+# Append both entries
+(crontab -l 2>/dev/null || true; echo "$CRON_LINE"; echo "$REBOOT_LINE") | crontab -
 
-echo "Crontab entry installed: daily at 02:00"
+echo "Crontab entries installed:"
+echo "  - daily at 02:00"
+echo "  - at boot (60s delay) to recover missed runs"
 echo "Verify with: crontab -l | grep am-i-shipping"

--- a/scripts/install-cron.sh
+++ b/scripts/install-cron.sh
@@ -10,6 +10,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# Ensure logs directory exists (cron command redirects output there)
+mkdir -p "$REPO_ROOT/logs"
+
 CRON_TAG="am-i-shipping-collectors"
 CRON_CMD="cd \"$REPO_ROOT\" && bash run_collectors.sh >> logs/cron.log 2>&1"
 CRON_LINE="0 2 * * * $CRON_CMD # $CRON_TAG"

--- a/scripts/install-launchd.sh
+++ b/scripts/install-launchd.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Install a macOS launchd agent to run am-i-shipping collectors daily at 02:00.
+# Install a macOS launchd agent to run am-i-shipping collectors daily at 02:00,
+# with a login-time trigger so missed runs (e.g. Mac was off overnight) are
+# recovered on next login. Collectors are idempotent so same-day double-runs are safe.
 # Idempotent: re-running this script will update the plist and reload the agent.
 #
 # Usage:
@@ -52,7 +54,7 @@ cat > "$PLIST_PATH" <<PLIST
     <key>StandardErrorPath</key>
     <string>$REPO_ROOT/logs/launchd.err.log</string>
     <key>RunAtLoad</key>
-    <false/>
+    <true/>
 </dict>
 </plist>
 PLIST

--- a/scripts/install-launchd.sh
+++ b/scripts/install-launchd.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Install a macOS launchd agent to run am-i-shipping collectors daily at 02:00.
+# Idempotent: re-running this script will update the plist and reload the agent.
+#
+# Usage:
+#   bash scripts/install-launchd.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+LABEL="com.am-i-shipping.collectors"
+PLIST_PATH="$HOME/Library/LaunchAgents/$LABEL.plist"
+AGENTS_DIR="$HOME/Library/LaunchAgents"
+
+# Ensure LaunchAgents directory exists
+mkdir -p "$AGENTS_DIR"
+
+# Ensure logs directory exists
+mkdir -p "$REPO_ROOT/logs"
+
+# Unload existing agent if present (ignore errors if not loaded)
+if launchctl list 2>/dev/null | grep -qF "$LABEL"; then
+    launchctl unload "$PLIST_PATH" 2>/dev/null || true
+fi
+
+# Write the plist
+cat > "$PLIST_PATH" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$LABEL</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>$REPO_ROOT/run_collectors.sh</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>$REPO_ROOT</string>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>2</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>$REPO_ROOT/logs/launchd.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>$REPO_ROOT/logs/launchd.err.log</string>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>
+PLIST
+
+# Load the agent
+launchctl load "$PLIST_PATH"
+
+echo "launchd agent installed: $LABEL"
+echo "Schedule: daily at 02:00"
+echo "Plist: $PLIST_PATH"
+echo "Verify with: launchctl list | grep am-i-shipping"

--- a/scripts/install-task.ps1
+++ b/scripts/install-task.ps1
@@ -1,0 +1,51 @@
+<#
+.SYNOPSIS
+    Register a Windows Task Scheduler task to run am-i-shipping collectors daily at 02:00.
+
+.DESCRIPTION
+    Idempotent: if the task already exists it is removed and re-created.
+
+.EXAMPLE
+    .\scripts\install-task.ps1
+#>
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = (Resolve-Path (Join-Path $ScriptDir "..")).Path
+
+$TaskName = "am-i-shipping-collectors"
+$RunScript = Join-Path $RepoRoot "run_collectors.ps1"
+
+# Remove existing task if present (idempotent)
+$existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($existing) {
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+    Write-Host "Existing task removed — will re-create."
+}
+
+# Create the task
+$Action = New-ScheduledTaskAction `
+    -Execute "powershell.exe" `
+    -Argument "-ExecutionPolicy Bypass -File `"$RunScript`"" `
+    -WorkingDirectory $RepoRoot
+
+$Trigger = New-ScheduledTaskTrigger -Daily -At "02:00"
+
+$Settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable `
+    -RestartCount 3 `
+    -RestartInterval (New-TimeSpan -Minutes 5)
+
+Register-ScheduledTask `
+    -TaskName $TaskName `
+    -Action $Action `
+    -Trigger $Trigger `
+    -Settings $Settings `
+    -Description "Run am-i-shipping collectors daily at 02:00" | Out-Null
+
+Write-Host "Task Scheduler task installed: $TaskName"
+Write-Host "Schedule: daily at 02:00"
+Write-Host "Verify with: schtasks /query /tn $TaskName"

--- a/scripts/uninstall-cron.sh
+++ b/scripts/uninstall-cron.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Remove the am-i-shipping crontab entry.
+# Idempotent: safe to run even if no entry exists.
+#
+# Usage:
+#   bash scripts/uninstall-cron.sh
+
+set -euo pipefail
+
+CRON_TAG="am-i-shipping-collectors"
+
+if ! crontab -l 2>/dev/null | grep -qF "$CRON_TAG"; then
+    echo "No am-i-shipping crontab entry found — nothing to remove."
+    exit 0
+fi
+
+crontab -l 2>/dev/null | grep -vF "$CRON_TAG" | crontab -
+
+echo "Crontab entry removed."
+echo "Verify with: crontab -l"

--- a/scripts/uninstall-launchd.sh
+++ b/scripts/uninstall-launchd.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Remove the am-i-shipping macOS launchd agent.
+# Idempotent: safe to run even if the agent is not installed.
+#
+# Usage:
+#   bash scripts/uninstall-launchd.sh
+
+set -euo pipefail
+
+LABEL="com.am-i-shipping.collectors"
+PLIST_PATH="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+# Unload if currently loaded
+if launchctl list 2>/dev/null | grep -qF "$LABEL"; then
+    launchctl unload "$PLIST_PATH" 2>/dev/null || true
+    echo "launchd agent unloaded: $LABEL"
+else
+    echo "launchd agent not loaded — skipping unload."
+fi
+
+# Remove the plist file
+if [ -f "$PLIST_PATH" ]; then
+    rm "$PLIST_PATH"
+    echo "Plist removed: $PLIST_PATH"
+else
+    echo "Plist not found — nothing to remove."
+fi
+
+echo "Done. Verify with: launchctl list | grep am-i-shipping"

--- a/scripts/uninstall-task.ps1
+++ b/scripts/uninstall-task.ps1
@@ -1,0 +1,24 @@
+<#
+.SYNOPSIS
+    Remove the am-i-shipping Windows Task Scheduler task.
+
+.DESCRIPTION
+    Idempotent: safe to run even if the task does not exist.
+
+.EXAMPLE
+    .\scripts\uninstall-task.ps1
+#>
+
+$ErrorActionPreference = "Stop"
+
+$TaskName = "am-i-shipping-collectors"
+
+$existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($existing) {
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+    Write-Host "Task Scheduler task removed: $TaskName"
+} else {
+    Write-Host "Task '$TaskName' not found — nothing to remove."
+}
+
+Write-Host "Verify with: schtasks /query /tn $TaskName"

--- a/setup.md
+++ b/setup.md
@@ -41,9 +41,45 @@ Add a `SessionEnd` hook that triggers the session parser after every Claude Code
 
 ## Step 2 — Schedule Nightly Collection
 
-### macOS — launchd
+The easiest way to set up scheduled collection is with the provided install scripts. Each script is idempotent — safe to re-run.
 
-1. Create a file at `~/Library/LaunchAgents/com.<yourname>.am-i-shipping.plist`:
+### Quick install (recommended)
+
+```bash
+# Linux
+bash scripts/install-cron.sh
+
+# macOS
+bash scripts/install-launchd.sh
+
+# Windows (PowerShell, run as Administrator)
+.\scripts\install-task.ps1
+```
+
+To remove the scheduled task later:
+
+```bash
+# Linux
+bash scripts/uninstall-cron.sh
+
+# macOS
+bash scripts/uninstall-launchd.sh
+
+# Windows (PowerShell)
+.\scripts\uninstall-task.ps1
+```
+
+All install scripts default to daily at 02:00 and run the full entry point (`run_collectors.sh` or `run_collectors.ps1`), which executes all collectors sequentially.
+
+---
+
+### Manual setup (alternative)
+
+If you prefer to configure the service manually instead of using the scripts above:
+
+#### macOS — launchd
+
+1. Create a file at `~/Library/LaunchAgents/com.am-i-shipping.collectors.plist`:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -51,23 +87,14 @@ Add a `SessionEnd` hook that triggers the session parser after every Claude Code
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.<yourname>.am-i-shipping</string>
+    <string>com.am-i-shipping.collectors</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/usr/bin/env</string>
-        <string>python3</string>
-        <string>-m</string>
-        <string>collector.session_parser</string>
-        <string>--mode</string>
-        <string>batch</string>
-        <string>--config</string>
-        <string><REPO_ROOT>/config.yaml</string>
+        <string>/bin/bash</string>
+        <string><REPO_ROOT>/run_collectors.sh</string>
     </array>
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>PYTHONPATH</key>
-        <string><REPO_ROOT></string>
-    </dict>
+    <key>WorkingDirectory</key>
+    <string><REPO_ROOT></string>
     <key>StartCalendarInterval</key>
     <dict>
         <key>Hour</key>
@@ -79,8 +106,6 @@ Add a `SessionEnd` hook that triggers the session parser after every Claude Code
     <string><REPO_ROOT>/logs/launchd.out.log</string>
     <key>StandardErrorPath</key>
     <string><REPO_ROOT>/logs/launchd.err.log</string>
-    <key>WorkingDirectory</key>
-    <string><REPO_ROOT></string>
     <key>RunAtLoad</key>
     <false/>
 </dict>
@@ -90,14 +115,14 @@ Add a `SessionEnd` hook that triggers the session parser after every Claude Code
 2. Load it:
 
 ```bash
-launchctl load ~/Library/LaunchAgents/com.<yourname>.am-i-shipping.plist
+launchctl load ~/Library/LaunchAgents/com.am-i-shipping.collectors.plist
 ```
 
-**Verify:** `launchctl list | grep am-i-shipping` should show an entry. To test immediately: `launchctl start com.<yourname>.am-i-shipping`, then check `logs/` for output.
+**Verify:** `launchctl list | grep am-i-shipping` should show an entry. To test immediately: `launchctl start com.am-i-shipping.collectors`, then check `logs/` for output.
 
 ---
 
-### Windows — Task Scheduler
+#### Windows — Task Scheduler
 
 1. Open Task Scheduler (`taskschd.msc`).
 2. Click **Create Task** (not "Create Basic Task").
@@ -120,19 +145,13 @@ Replace `<REPO_ROOT>` with the absolute path to this repository.
 
 ---
 
-### Linux — cron
+#### Linux — cron
 
 Add a crontab entry:
 
 ```bash
 crontab -e
 ```
-
-```
-0 2 * * * PYTHONPATH=<REPO_ROOT> python3 <REPO_ROOT>/run_collectors.sh
-```
-
-Or use `run_collectors.sh` directly:
 
 ```
 0 2 * * * cd <REPO_ROOT> && bash run_collectors.sh >> logs/cron.log 2>&1

--- a/setup.md
+++ b/setup.md
@@ -69,7 +69,7 @@ bash scripts/uninstall-launchd.sh
 .\scripts\uninstall-task.ps1
 ```
 
-All install scripts default to daily at 02:00 and run the full entry point (`run_collectors.sh` or `run_collectors.ps1`), which executes all collectors sequentially.
+All install scripts default to daily at 02:00. They also install a boot-time fallback trigger so that if your PC is off at 02:00, the run happens automatically the next time you log in. Collectors are idempotent — running twice in one day produces no duplicate data.
 
 ---
 
@@ -107,7 +107,7 @@ If you prefer to configure the service manually instead of using the scripts abo
     <key>StandardErrorPath</key>
     <string><REPO_ROOT>/logs/launchd.err.log</string>
     <key>RunAtLoad</key>
-    <false/>
+    <true/>
 </dict>
 </plist>
 ```
@@ -155,7 +155,10 @@ crontab -e
 
 ```
 0 2 * * * cd <REPO_ROOT> && bash run_collectors.sh >> logs/cron.log 2>&1
+@reboot sleep 60 && cd <REPO_ROOT> && bash run_collectors.sh >> logs/cron.log 2>&1
 ```
+
+The `@reboot` line recovers missed runs when the PC was off at 02:00. Both entries are safe to have simultaneously — collectors are idempotent.
 
 ---
 

--- a/tests/test_integration_gate.py
+++ b/tests/test_integration_gate.py
@@ -1,0 +1,196 @@
+"""Integration gate: smoke test for run_collectors end-to-end pipeline.
+
+Gated by the AMIS_INTEGRATION environment variable. Tests are skipped
+unless AMIS_INTEGRATION=1 is set:
+
+    AMIS_INTEGRATION=1 pytest tests/test_integration_gate.py -v
+
+These tests run the actual collectors against real (or configured) data
+sources. They require:
+  - config.yaml with valid settings
+  - gh CLI authenticated (for GitHub poller)
+  - ActivityWatch running (for appswitch — absence is tolerated)
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SKIP_REASON = "Set AMIS_INTEGRATION=1 to run integration tests"
+pytestmark = pytest.mark.skipif(
+    os.environ.get("AMIS_INTEGRATION") != "1",
+    reason=SKIP_REASON,
+)
+
+
+def _run_collectors() -> subprocess.CompletedProcess:
+    """Run run_collectors.sh and return the result."""
+    script = REPO_ROOT / "run_collectors.sh"
+    return subprocess.run(
+        ["bash", str(script)],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+
+class TestIntegrationGate:
+    """Smoke tests for the full collector pipeline."""
+
+    def test_run_collectors_produces_log(self, tmp_path: Path) -> None:
+        """run_collectors.sh creates a dated log file under logs/."""
+        result = _run_collectors()
+        log_dir = REPO_ROOT / "logs"
+        assert log_dir.exists(), "logs/ directory was not created"
+        log_files = sorted(log_dir.glob("run_*.log"))
+        assert len(log_files) > 0, "No log file created by run_collectors.sh"
+
+    def test_health_check_passes(self) -> None:
+        """health_check.py exits 0 after a clean collector run."""
+        _run_collectors()
+        result = subprocess.run(
+            [sys.executable, "-m", "am_i_shipping.health_check"],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, (
+            f"health_check exited {result.returncode}:\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_databases_have_data(self) -> None:
+        """After a run, implemented collector DBs contain rows."""
+        _run_collectors()
+        data_dir = REPO_ROOT / "data"
+
+        # sessions.db — session parser
+        sessions_db = data_dir / "sessions.db"
+        if sessions_db.exists():
+            conn = sqlite3.connect(str(sessions_db))
+            count = conn.execute(
+                "SELECT COUNT(*) FROM sessions"
+            ).fetchone()[0]
+            conn.close()
+            assert count > 0, "sessions.db has no rows after collector run"
+
+        # github.db — GitHub poller
+        github_db = data_dir / "github.db"
+        if github_db.exists():
+            conn = sqlite3.connect(str(github_db))
+            # Check any table has data
+            tables = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+            has_data = False
+            for (table_name,) in tables:
+                count = conn.execute(
+                    f"SELECT COUNT(*) FROM [{table_name}]"
+                ).fetchone()[0]
+                if count > 0:
+                    has_data = True
+                    break
+            conn.close()
+            assert has_data, "github.db has no data in any table after collector run"
+
+    def test_no_duplicate_rows_on_rerun(self) -> None:
+        """Re-running collectors over the same period produces no duplicates."""
+        # First run
+        _run_collectors()
+        data_dir = REPO_ROOT / "data"
+
+        # Capture row counts before second run
+        counts_before: dict[str, int] = {}
+
+        sessions_db = data_dir / "sessions.db"
+        if sessions_db.exists():
+            conn = sqlite3.connect(str(sessions_db))
+            counts_before["sessions"] = conn.execute(
+                "SELECT COUNT(*) FROM sessions"
+            ).fetchone()[0]
+            conn.close()
+
+        github_db = data_dir / "github.db"
+        if github_db.exists():
+            conn = sqlite3.connect(str(github_db))
+            tables = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+            for (table_name,) in tables:
+                counts_before[f"github.{table_name}"] = conn.execute(
+                    f"SELECT COUNT(*) FROM [{table_name}]"
+                ).fetchone()[0]
+            conn.close()
+
+        # Second run
+        _run_collectors()
+
+        # Verify counts are unchanged (idempotency)
+        if sessions_db.exists():
+            conn = sqlite3.connect(str(sessions_db))
+            count_after = conn.execute(
+                "SELECT COUNT(*) FROM sessions"
+            ).fetchone()[0]
+            conn.close()
+            assert count_after == counts_before.get("sessions", 0), (
+                f"sessions.db row count changed: "
+                f"{counts_before.get('sessions', 0)} -> {count_after}"
+            )
+
+        if github_db.exists():
+            conn = sqlite3.connect(str(github_db))
+            tables = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+            for (table_name,) in tables:
+                count_after = conn.execute(
+                    f"SELECT COUNT(*) FROM [{table_name}]"
+                ).fetchone()[0]
+                expected = counts_before.get(f"github.{table_name}", 0)
+                assert count_after == expected, (
+                    f"github.db.{table_name} row count changed: "
+                    f"{expected} -> {count_after}"
+                )
+            conn.close()
+
+    def test_health_json_updated(self) -> None:
+        """data/health.json is updated after every collector run."""
+        import json
+        from datetime import datetime, timezone, timedelta
+
+        _run_collectors()
+        health_path = REPO_ROOT / "data" / "health.json"
+        assert health_path.exists(), "health.json not found after collector run"
+
+        with open(health_path) as f:
+            data = json.load(f)
+
+        now = datetime.now(timezone.utc)
+        threshold = timedelta(minutes=5)
+
+        # At least one collector should have a recent last_success
+        found_recent = False
+        for collector_name, entry in data.items():
+            last_success_str = entry.get("last_success")
+            if last_success_str:
+                last_success = datetime.fromisoformat(last_success_str)
+                if last_success.tzinfo is None:
+                    last_success = last_success.replace(tzinfo=timezone.utc)
+                if now - last_success < threshold:
+                    found_recent = True
+                    break
+
+        assert found_recent, (
+            "No collector has a last_success within the last 5 minutes "
+            f"in health.json: {data}"
+        )

--- a/tests/test_integration_gate.py
+++ b/tests/test_integration_gate.py
@@ -46,9 +46,13 @@ def _run_collectors() -> subprocess.CompletedProcess:
 class TestIntegrationGate:
     """Smoke tests for the full collector pipeline."""
 
-    def test_run_collectors_produces_log(self, tmp_path: Path) -> None:
+    def test_run_collectors_produces_log(self) -> None:
         """run_collectors.sh creates a dated log file under logs/."""
         result = _run_collectors()
+        assert result.returncode == 0, (
+            f"run_collectors.sh exited {result.returncode}:\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
         log_dir = REPO_ROOT / "logs"
         assert log_dir.exists(), "logs/ directory was not created"
         log_files = sorted(log_dir.glob("run_*.log"))
@@ -56,7 +60,11 @@ class TestIntegrationGate:
 
     def test_health_check_passes(self) -> None:
         """health_check.py exits 0 after a clean collector run."""
-        _run_collectors()
+        run_result = _run_collectors()
+        assert run_result.returncode == 0, (
+            f"run_collectors.sh exited {run_result.returncode}:\n"
+            f"stdout: {run_result.stdout}\nstderr: {run_result.stderr}"
+        )
         result = subprocess.run(
             [sys.executable, "-m", "am_i_shipping.health_check"],
             cwd=str(REPO_ROOT),
@@ -69,9 +77,16 @@ class TestIntegrationGate:
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
 
+    # Known tables for each database — avoids dynamic SQL construction
+    GITHUB_TABLES = ("issues", "pull_requests", "pushes", "issue_pr_links")
+
     def test_databases_have_data(self) -> None:
         """After a run, implemented collector DBs contain rows."""
-        _run_collectors()
+        run_result = _run_collectors()
+        assert run_result.returncode == 0, (
+            f"run_collectors.sh exited {run_result.returncode}:\n"
+            f"stdout: {run_result.stdout}\nstderr: {run_result.stderr}"
+        )
         data_dir = REPO_ROOT / "data"
 
         # sessions.db — session parser
@@ -88,25 +103,29 @@ class TestIntegrationGate:
         github_db = data_dir / "github.db"
         if github_db.exists():
             conn = sqlite3.connect(str(github_db))
-            # Check any table has data
-            tables = conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table'"
-            ).fetchall()
             has_data = False
-            for (table_name,) in tables:
-                count = conn.execute(
-                    f"SELECT COUNT(*) FROM [{table_name}]"
-                ).fetchone()[0]
-                if count > 0:
-                    has_data = True
-                    break
+            for table_name in self.GITHUB_TABLES:
+                try:
+                    count = conn.execute(
+                        f"SELECT COUNT(*) FROM [{table_name}]"
+                    ).fetchone()[0]
+                    if count > 0:
+                        has_data = True
+                        break
+                except sqlite3.OperationalError:
+                    # Table may not exist yet
+                    continue
             conn.close()
             assert has_data, "github.db has no data in any table after collector run"
 
     def test_no_duplicate_rows_on_rerun(self) -> None:
         """Re-running collectors over the same period produces no duplicates."""
         # First run
-        _run_collectors()
+        run_result = _run_collectors()
+        assert run_result.returncode == 0, (
+            f"First run_collectors.sh exited {run_result.returncode}:\n"
+            f"stdout: {run_result.stdout}\nstderr: {run_result.stderr}"
+        )
         data_dir = REPO_ROOT / "data"
 
         # Capture row counts before second run
@@ -123,17 +142,21 @@ class TestIntegrationGate:
         github_db = data_dir / "github.db"
         if github_db.exists():
             conn = sqlite3.connect(str(github_db))
-            tables = conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table'"
-            ).fetchall()
-            for (table_name,) in tables:
-                counts_before[f"github.{table_name}"] = conn.execute(
-                    f"SELECT COUNT(*) FROM [{table_name}]"
-                ).fetchone()[0]
+            for table_name in self.GITHUB_TABLES:
+                try:
+                    counts_before[f"github.{table_name}"] = conn.execute(
+                        f"SELECT COUNT(*) FROM [{table_name}]"
+                    ).fetchone()[0]
+                except sqlite3.OperationalError:
+                    continue
             conn.close()
 
         # Second run
-        _run_collectors()
+        run_result2 = _run_collectors()
+        assert run_result2.returncode == 0, (
+            f"Second run_collectors.sh exited {run_result2.returncode}:\n"
+            f"stdout: {run_result2.stdout}\nstderr: {run_result2.stderr}"
+        )
 
         # Verify counts are unchanged (idempotency)
         if sessions_db.exists():
@@ -149,13 +172,13 @@ class TestIntegrationGate:
 
         if github_db.exists():
             conn = sqlite3.connect(str(github_db))
-            tables = conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table'"
-            ).fetchall()
-            for (table_name,) in tables:
-                count_after = conn.execute(
-                    f"SELECT COUNT(*) FROM [{table_name}]"
-                ).fetchone()[0]
+            for table_name in self.GITHUB_TABLES:
+                try:
+                    count_after = conn.execute(
+                        f"SELECT COUNT(*) FROM [{table_name}]"
+                    ).fetchone()[0]
+                except sqlite3.OperationalError:
+                    continue
                 expected = counts_before.get(f"github.{table_name}", 0)
                 assert count_after == expected, (
                     f"github.db.{table_name} row count changed: "
@@ -168,7 +191,11 @@ class TestIntegrationGate:
         import json
         from datetime import datetime, timezone, timedelta
 
-        _run_collectors()
+        run_result = _run_collectors()
+        assert run_result.returncode == 0, (
+            f"run_collectors.sh exited {run_result.returncode}:\n"
+            f"stdout: {run_result.stdout}\nstderr: {run_result.stderr}"
+        )
         health_path = REPO_ROOT / "data" / "health.json"
         assert health_path.exists(), "health.json not found after collector run"
 


### PR DESCRIPTION
Closes #5

## What changed

This PR delivers the three final deliverables for the data collection epic: user-facing documentation, automated service registration, and an integration smoke test. Together they ensure a new user can clone the repo, follow the README to configure and install, and have collectors running automatically with no further manual steps after the initial setup.

## Implementation walkthrough

### New files

**`README.md`** — The project's user-facing entry point. It explains what am-i-shipping is (a workflow monitor, not a dashboard), lists all three collectors and what each captures, documents prerequisites (Python 3.11+, `gh` CLI, optionally ActivityWatch), and provides a five-step quick-start that takes a user from clone to verified health check. The structure section maps the directory layout so users can orient themselves. It links to `setup.md` for platform-specific service details rather than duplicating them.

**`scripts/install-cron.sh`** — Registers a crontab entry that runs `run_collectors.sh` daily at 02:00. Uses a tag comment (`am-i-shipping-collectors`) as a sentinel: if the tag already exists in the crontab, the script exits without modification (idempotency). The companion `scripts/uninstall-cron.sh` filters the crontab to remove lines matching the tag.

**`scripts/install-launchd.sh`** — Writes a launchd plist to `~/Library/LaunchAgents/com.am-i-shipping.collectors.plist` and loads it. The plist runs `/bin/bash run_collectors.sh` (the full entry point), not just session_parser. Before writing, it unloads any existing agent with the same label. The companion `scripts/uninstall-launchd.sh` unloads the agent and deletes the plist.

**`scripts/install-task.ps1`** — Registers a Windows Task Scheduler task named `am-i-shipping-collectors` that runs `run_collectors.ps1` daily at 02:00 via `powershell.exe -ExecutionPolicy Bypass`. If the task already exists it is removed and re-created (idempotent). The companion `scripts/uninstall-task.ps1` removes the task if it exists.

**`tests/test_integration_gate.py`** — Five smoke tests gated behind the `AMIS_INTEGRATION=1` environment variable (never run in normal `pytest` invocations). Tests verify: (1) `run_collectors.sh` creates a dated log file, (2) `health_check.py` exits 0 after a run, (3) implemented DBs contain data rows, (4) re-running over the same period produces zero duplicate rows (idempotency), and (5) `health.json` has a `last_success` timestamp within the last 5 minutes.

### Modified files

**`setup.md`** — Fixed the macOS launchd plist which previously ran only `python3 -m collector.session_parser --mode batch` instead of the full `run_collectors.sh` entry point. This was inconsistent with the Windows Task Scheduler entry which already ran `run_collectors.ps1`. Added a "Quick install" section at the top of Step 2 that points users to the new install/uninstall scripts, with the manual setup preserved below as an alternative.

### Default execution path

**Before**: A new user had to manually create crontab entries, launchd plists, or Task Scheduler tasks by following multi-step instructions in `setup.md`. The macOS launchd plist only ran the session parser, not the full collector pipeline. There was no README to explain what the project does or how to get started.

**After**: A new user reads `README.md` → copies `config.yaml.example` → edits two required fields → runs `pip install -e .` and `python -m am_i_shipping.db` → runs one install script (`install-cron.sh`, `install-launchd.sh`, or `install-task.ps1`). Collectors now run automatically on all three platforms via the full entry point script. The integration test validates the end-to-end pipeline produces expected artifacts.

### What was intentionally not changed

- `run_collectors.sh` and `run_collectors.ps1` were not modified — they already handle missing collectors gracefully.
- `health_check.py` was not modified — its existing behavior (exit 0 when healthy, exit 1 when stale) is exactly what the integration test validates.
- The appswitch collector (C3) is out of scope — its absence is logged by the entry point scripts, not treated as a failure.

## Tier / approach

Tier 2 — Planner → parallel Coders (README+setup.md, scripts, integration test) → Reviewer

## Acceptance criteria

- [x] README.md exists at repo root with project summary, collector overview, prerequisites, quick-start, manual run, verification, project structure, link to setup.md
- [x] setup.md launchd plist fixed to run run_collectors.sh instead of just session_parser
- [x] setup.md references the new install/uninstall scripts
- [x] scripts/install-cron.sh registers a crontab entry; idempotent
- [x] scripts/uninstall-cron.sh removes the entry
- [x] scripts/install-launchd.sh writes and loads a plist running run_collectors.sh
- [x] scripts/uninstall-launchd.sh unloads and removes the plist
- [x] scripts/install-task.ps1 registers a Windows Task Scheduler task
- [x] scripts/uninstall-task.ps1 removes the task
- [x] All install scripts default to daily at 02:00; all are idempotent
- [x] tests/test_integration_gate.py exists as smoke test gated by env var
- [x] All 203 existing tests pass (10 skipped as expected)

## Outstanding items

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)