### PR TITLE
fix(#15): Add resource limiters for background-safe operation

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,26 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Run Collectors (if stale)",
+      "type": "shell",
+      "command": "python3",
+      "args": [
+        "-c",
+        "import json, sys; from pathlib import Path; from datetime import datetime, timezone, timedelta; h = Path('data/health.json'); fresh = False;\nif h.exists():\n    try:\n        d = json.loads(h.read_text()); ts = max((e.get('last_success','') for e in d.values() if isinstance(e,dict)), default='');\n        if ts: fresh = (datetime.now(timezone.utc) - datetime.fromisoformat(ts)) < timedelta(hours=4)\n    except Exception: pass\nif fresh: print('Skipping: data is fresh'); sys.exit(0)\nimport subprocess; sys.exit(subprocess.call(['bash', 'run_collectors.sh']))"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared",
+        "close": true
+      },
+      "runOptions": {
+        "runOn": "folderOpen"
+      },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/am_i_shipping/config_loader.py
+++ b/am_i_shipping/config_loader.py
@@ -14,16 +14,31 @@ class ConfigError(Exception):
 
 
 @dataclass
+class SessionLimiterConfig:
+    max_files_per_run: int = 200
+    inter_file_delay_seconds: float = 0.05
+
+
+@dataclass
 class SessionConfig:
     projects_path: str
     session_gap_minutes: int = 30
     reprompt_threshold: int = 3
+    limiter: SessionLimiterConfig = field(default_factory=SessionLimiterConfig)
+
+
+@dataclass
+class GitHubLimiterConfig:
+    inter_request_delay_seconds: float = 1.0
+    max_items_per_repo: int = 500
+    process_nice_increment: int = 10
 
 
 @dataclass
 class GitHubConfig:
     repos: List[str]
     backfill_days: int = 90
+    limiter: GitHubLimiterConfig = field(default_factory=GitHubLimiterConfig)
 
 
 @dataclass
@@ -91,6 +106,20 @@ def load_config(config_path: str | Path | None = None) -> Config:
             "Missing required field: session.projects_path "
             "(path to ~/.claude/projects)"
         )
+    session_limiter_raw = session_raw.get("limiter", {}) or {}
+    session_limiter = SessionLimiterConfig(
+        max_files_per_run=int(
+            session_limiter_raw.get(
+                "max_files_per_run", SessionLimiterConfig.max_files_per_run
+            )
+        ),
+        inter_file_delay_seconds=float(
+            session_limiter_raw.get(
+                "inter_file_delay_seconds",
+                SessionLimiterConfig.inter_file_delay_seconds,
+            )
+        ),
+    )
     session_cfg = SessionConfig(
         projects_path=str(projects_path),
         session_gap_minutes=int(
@@ -99,6 +128,7 @@ def load_config(config_path: str | Path | None = None) -> Config:
         reprompt_threshold=int(
             session_raw.get("reprompt_threshold", SessionConfig.reprompt_threshold)
         ),
+        limiter=session_limiter,
     )
 
     # --- github (required section) ---
@@ -112,11 +142,32 @@ def load_config(config_path: str | Path | None = None) -> Config:
             "Missing required field: github.repos "
             "(list of owner/repo strings to poll)"
         )
+    github_limiter_raw = github_raw.get("limiter", {}) or {}
+    github_limiter = GitHubLimiterConfig(
+        inter_request_delay_seconds=float(
+            github_limiter_raw.get(
+                "inter_request_delay_seconds",
+                GitHubLimiterConfig.inter_request_delay_seconds,
+            )
+        ),
+        max_items_per_repo=int(
+            github_limiter_raw.get(
+                "max_items_per_repo", GitHubLimiterConfig.max_items_per_repo
+            )
+        ),
+        process_nice_increment=int(
+            github_limiter_raw.get(
+                "process_nice_increment",
+                GitHubLimiterConfig.process_nice_increment,
+            )
+        ),
+    )
     github_cfg = GitHubConfig(
         repos=[str(r) for r in repos],
         backfill_days=int(
             github_raw.get("backfill_days", GitHubConfig.backfill_days)
         ),
+        limiter=github_limiter,
     )
 
     # --- appswitch (optional section — defaults are fine) ---

--- a/am_i_shipping/config_loader.py
+++ b/am_i_shipping/config_loader.py
@@ -32,6 +32,7 @@ class GitHubLimiterConfig:
     inter_request_delay_seconds: float = 1.0
     max_items_per_repo: int = 500
     process_nice_increment: int = 10
+    max_calls_per_hour: int = 2500
 
 
 @dataclass
@@ -159,6 +160,11 @@ def load_config(config_path: str | Path | None = None) -> Config:
             github_limiter_raw.get(
                 "process_nice_increment",
                 GitHubLimiterConfig.process_nice_increment,
+            )
+        ),
+        max_calls_per_hour=int(
+            github_limiter_raw.get(
+                "max_calls_per_hour", GitHubLimiterConfig.max_calls_per_hour
             )
         ),
     )

--- a/am_i_shipping/db.py
+++ b/am_i_shipping/db.py
@@ -73,6 +73,7 @@ CREATE TABLE IF NOT EXISTS pull_requests (
     head_ref            TEXT,
     title               TEXT,
     body                TEXT,
+    comments_json        TEXT,
     review_comments_json TEXT,
     review_comment_count INTEGER DEFAULT 0,
     push_count          INTEGER DEFAULT 0,
@@ -158,6 +159,7 @@ CREATE TABLE IF NOT EXISTS pr_review_comment_edits (
 _GITHUB_MIGRATIONS = [
     "ALTER TABLE issues ADD COLUMN updated_at TEXT",
     "ALTER TABLE pull_requests ADD COLUMN updated_at TEXT",
+    "ALTER TABLE pull_requests ADD COLUMN comments_json TEXT",
 ]
 
 APPSWITCH_SCHEMA = """

--- a/am_i_shipping/health_check.py
+++ b/am_i_shipping/health_check.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import List, Tuple, Union
 
 
-EXPECTED_COLLECTORS = ["session_parser", "github_poller", "appswitch_export"]
+EXPECTED_COLLECTORS = ["session_parser", "github_poller"]
 STALE_THRESHOLD = timedelta(hours=48)
 
 

--- a/am_i_shipping/health_writer.py
+++ b/am_i_shipping/health_writer.py
@@ -15,6 +15,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Union
 
+from loguru import logger
+
 
 def write_health(
     collector_name: str,
@@ -76,6 +78,7 @@ def write_health(
         # os.replace is atomic on POSIX; on Windows it is atomic if
         # the destination is on the same volume (which it is here).
         os.replace(tmp_path, str(health_path))
+        logger.debug("health updated: {} — {} records", collector_name, record_count)
     except BaseException:
         # Clean up temp file on failure
         try:

--- a/am_i_shipping/health_writer.py
+++ b/am_i_shipping/health_writer.py
@@ -32,7 +32,7 @@ def write_health(
     Parameters
     ----------
     collector_name:
-        One of ``session_parser``, ``github_poller``, ``appswitch_export``.
+        One of ``session_parser``, ``github_poller``.
     record_count:
         Number of records processed in this run.
     data_dir:

--- a/am_i_shipping/logging_config.py
+++ b/am_i_shipping/logging_config.py
@@ -1,0 +1,58 @@
+"""Loguru logging configuration for am-i-shipping collectors.
+
+Call ``setup_logging()`` once at the top of each entry-point's ``main()``
+function.  Individual modules should only do::
+
+    from loguru import logger
+
+and never configure sinks themselves.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Union
+
+from loguru import logger
+
+_LOG_FORMAT = (
+    "{time:YYYY-MM-DD HH:mm:ss} | {level:<8} | {name}:{function}:{line} | {message}"
+)
+
+
+def setup_logging(log_dir: Union[str, Path, None] = None) -> None:
+    """Configure loguru sinks.
+
+    Parameters
+    ----------
+    log_dir:
+        Directory for the rotating log file.  Defaults to ``logs/`` at
+        the repository root (detected as two levels up from this file).
+    """
+    if log_dir is None:
+        log_dir = Path(__file__).parent.parent / "logs"
+    else:
+        log_dir = Path(log_dir)
+
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    # Remove the default loguru sink (stderr at DEBUG level)
+    logger.remove()
+
+    # Rotating file sink — DEBUG and above
+    logger.add(
+        log_dir / "github_poller.log",
+        format=_LOG_FORMAT,
+        level="DEBUG",
+        rotation="10 MB",
+        retention=7,
+        encoding="utf-8",
+    )
+
+    # stderr sink — ERROR and above only (surfaces in cron/systemd logs)
+    logger.add(
+        sys.stderr,
+        format=_LOG_FORMAT,
+        level="ERROR",
+    )

--- a/collector/github_poller/cursor.py
+++ b/collector/github_poller/cursor.py
@@ -12,6 +12,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional, Union
 
+from loguru import logger
+
 
 def read_cursor(
     repo: str,
@@ -32,7 +34,9 @@ def read_cursor(
             "SELECT last_polled_at FROM poll_cursor WHERE repo = ?",
             (repo,),
         ).fetchone()
-        return row[0] if row else None
+        value = row[0] if row else None
+        logger.debug("{} cursor: {}", repo, value or 'none (backfill)')
+        return value
     finally:
         conn.close()
 
@@ -84,5 +88,6 @@ def advance_cursor(
             (repo, today),
         )
         conn.commit()
+        logger.debug("{} cursor advanced → {}", repo, today)
     finally:
         conn.close()

--- a/collector/github_poller/fetch_issues.py
+++ b/collector/github_poller/fetch_issues.py
@@ -112,6 +112,7 @@ def fetch_issue_comments(
 
 _ISSUE_EDIT_HISTORY_QUERY = """
 query($owner: String!, $name: String!, $number: Int!) {
+  rateLimit { cost remaining }
   repository(owner: $owner, name: $name) {
     issue(number: $number) {
       userContentEdits(first: 100) {
@@ -257,6 +258,7 @@ def fetch_issue_edit_history_batch(
 
         query = (
             "query($owner: String!, $name: String!) {\n"
+            "  rateLimit { cost remaining }\n"
             "  repository(owner: $owner, name: $name) {"
             + "".join(alias_blocks)
             + "\n  }\n}"

--- a/collector/github_poller/fetch_issues.py
+++ b/collector/github_poller/fetch_issues.py
@@ -19,6 +19,7 @@ def fetch_issues(
     since: Optional[str] = None,
     state: str = "all",
     limit: int = 500,
+    include_comments: bool = False,
 ) -> List[Dict[str, Any]]:
     """Fetch issues for *repo* (``owner/repo``).
 
@@ -33,10 +34,16 @@ def fetch_issues(
         Issue state filter: ``open``, ``closed``, or ``all`` (default).
     limit:
         Maximum number of issues to fetch (default 500).
+    include_comments:
+        If True, fetch comments for every issue in the returned list.
+        Leave False (default) when the caller will apply a cap first and
+        then fetch comments only for the kept subset via
+        :func:`fetch_issue_comments`.
 
     Returns
     -------
-    List of normalized issue dicts.
+    List of normalized issue dicts.  When *include_comments* is False the
+    ``"comments"`` key is present but set to an empty list.
     """
     args = [
         "issue", "list",
@@ -54,8 +61,8 @@ def fetch_issues(
 
     results: List[Dict[str, Any]] = []
     for issue in raw_issues:
-        comments = _fetch_issue_comments(repo, issue["number"])
         type_label = _extract_type_label(issue.get("labels", []))
+        comments = fetch_issue_comments(repo, issue["number"]) if include_comments else []
 
         results.append({
             "number": issue["number"],
@@ -72,11 +79,15 @@ def fetch_issues(
     return results
 
 
-def _fetch_issue_comments(
+def fetch_issue_comments(
     repo: str,
     issue_number: int,
-) -> List[Dict[str, str]]:
-    """Fetch comments for a single issue via ``gh api``."""
+) -> List[Dict[str, Any]]:
+    """Fetch comments for a single issue via ``gh api``.
+
+    Exported so callers can fetch comments after applying an item cap,
+    avoiding wasted API calls for items that will be discarded.
+    """
     owner, name = repo.split("/", 1)
     endpoint = f"/repos/{owner}/{name}/issues/{issue_number}/comments"
 

--- a/collector/github_poller/fetch_prs.py
+++ b/collector/github_poller/fetch_prs.py
@@ -77,11 +77,49 @@ def fetch_prs(
     return results
 
 
+def fetch_pr_comments(
+    repo: str,
+    pr_number: int,
+) -> List[Dict[str, Any]]:
+    """Fetch thread (issue-style) comments for a single PR via ``gh api``.
+
+    These are the regular conversation comments on a PR, as distinct from
+    inline review comments on specific lines of code.  Uses the issues
+    endpoint because GitHub models PR thread comments as issue comments.
+
+    Exported so callers can fetch comments after applying an item cap,
+    avoiding wasted API calls for PRs that will be discarded.
+    """
+    owner, name = repo.split("/", 1)
+    endpoint = f"/repos/{owner}/{name}/issues/{pr_number}/comments"
+
+    try:
+        raw = gh_api(endpoint, paginate=True)
+    except GhCliError:
+        return []
+
+    if not isinstance(raw, list):
+        return []
+
+    comments: List[Dict[str, Any]] = []
+    for c in raw:
+        comments.append({
+            "id": c.get("id"),
+            "author": (c.get("user") or {}).get("login", ""),
+            "body": c.get("body", ""),
+            "created_at": c.get("created_at", ""),
+        })
+    return comments
+
+
 def fetch_pr_review_comments(
     repo: str,
     pr_number: int,
 ) -> List[Dict[str, Any]]:
-    """Fetch review comments for a single PR via ``gh api``.
+    """Fetch inline review comments for a single PR via ``gh api``.
+
+    These are comments attached to specific lines of code in a review,
+    as distinct from thread (issue-style) comments on the PR conversation.
 
     Exported so callers can fetch review comments after applying an item
     cap, avoiding wasted API calls for PRs that will be discarded.
@@ -110,6 +148,7 @@ def fetch_pr_review_comments(
 
 _PR_EDIT_HISTORY_QUERY = """
 query($owner: String!, $name: String!, $number: Int!) {
+  rateLimit { cost remaining }
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
       userContentEdits(first: 100) {
@@ -119,12 +158,12 @@ query($owner: String!, $name: String!, $number: Int!) {
           editor { login }
         }
       }
-      reviews(first: 100) {
+      reviews(first: 20) {
         nodes {
-          comments(first: 100) {
+          comments(first: 20) {
             nodes {
               databaseId
-              userContentEdits(first: 100) {
+              userContentEdits(first: 20) {
                 nodes {
                   editedAt
                   diff

--- a/collector/github_poller/fetch_prs.py
+++ b/collector/github_poller/fetch_prs.py
@@ -18,6 +18,7 @@ def fetch_prs(
     since: Optional[str] = None,
     state: str = "all",
     limit: int = 500,
+    include_comments: bool = False,
 ) -> List[Dict[str, Any]]:
     """Fetch pull requests for *repo* (``owner/repo``).
 
@@ -31,10 +32,17 @@ def fetch_prs(
         PR state filter: ``open``, ``closed``, ``merged``, or ``all``.
     limit:
         Maximum number of PRs to fetch (default 500).
+    include_comments:
+        If True, fetch review comments for every PR in the returned list.
+        Leave False (default) when the caller will apply a cap first and
+        then fetch review comments only for the kept subset via
+        :func:`fetch_pr_review_comments`.
 
     Returns
     -------
-    List of normalized PR dicts.
+    List of normalized PR dicts.  When *include_comments* is False the
+    ``"review_comments"`` key is present but set to an empty list and
+    ``"review_comment_count"`` is 0.
     """
     args = [
         "pr", "list",
@@ -52,7 +60,7 @@ def fetch_prs(
 
     results: List[Dict[str, Any]] = []
     for pr in raw_prs:
-        review_comments = _fetch_review_comments(repo, pr["number"])
+        review_comments = fetch_pr_review_comments(repo, pr["number"]) if include_comments else []
 
         results.append({
             "number": pr["number"],
@@ -69,11 +77,15 @@ def fetch_prs(
     return results
 
 
-def _fetch_review_comments(
+def fetch_pr_review_comments(
     repo: str,
     pr_number: int,
-) -> List[Dict[str, str]]:
-    """Fetch review comments for a single PR via ``gh api``."""
+) -> List[Dict[str, Any]]:
+    """Fetch review comments for a single PR via ``gh api``.
+
+    Exported so callers can fetch review comments after applying an item
+    cap, avoiding wasted API calls for PRs that will be discarded.
+    """
     owner, name = repo.split("/", 1)
     endpoint = f"/repos/{owner}/{name}/pulls/{pr_number}/comments"
 

--- a/collector/github_poller/gh_client.py
+++ b/collector/github_poller/gh_client.py
@@ -115,7 +115,16 @@ class BudgetExhausted(Exception):
 
 
 class _HourlyBudget:
-    """Sliding-window call counter that raises when the hourly cap is hit."""
+    """Fixed-window call counter that raises when the hourly cap is hit.
+
+    Note: uses a fixed (not sliding) window — the counter resets to zero
+    at the start of each 3600-second window.  In theory, a burst at the
+    end of one window followed by a burst at the start of the next could
+    allow up to 2× max_per_hour calls within any 60-minute span.  In
+    practice, ``_SecondaryRateLimiter`` enforces a tighter per-minute cap
+    (50 % of GitHub's 900 req/min) that prevents sustained bursting well
+    below this theoretical maximum.
+    """
 
     def __init__(self, max_per_hour: int) -> None:
         self._max = max_per_hour
@@ -272,6 +281,10 @@ def run_gh(
         After exhausting retries.
     """
     # Proactive secondary rate limit guard — delays if needed before the call.
+    # Note: these are called once before the retry loop, so retries are not
+    # individually re-checked or re-recorded.  This is an acceptable
+    # approximation: retries are rare and short-sleeped, so the under-count
+    # is negligible compared to the budget windows (1 hour / 60 seconds).
     _secondary.check()
     # Check hourly budget.
     _budget.record()

--- a/collector/github_poller/gh_client.py
+++ b/collector/github_poller/gh_client.py
@@ -1,26 +1,128 @@
 """Thin wrapper around the ``gh`` CLI for GitHub API calls.
 
 Handles subprocess invocation, JSON deserialization, pagination via
-``--paginate``, and rate-limit back-off (simple retry with exponential
-delay on 403/429 exit codes).
+``--paginate``, rate-limit back-off (retry with reset-aware sleep on
+403/429 exit codes), and an hourly call budget so the poller never
+consumes more than a configured fraction of the user's GitHub API quota.
 """
 
 from __future__ import annotations
 
 import json
 import subprocess
+import sys
 import time
 from typing import Any, Dict, List, Optional
 
 
 _inter_request_delay: float = 0.0
 
+# ---------------------------------------------------------------------------
+# Hourly call budget
+# ---------------------------------------------------------------------------
 
-def configure_limiter(delay: float) -> None:
-    """Set the inter-request delay applied after each successful ``gh`` call."""
+class BudgetExhausted(Exception):
+    """Raised when the hourly call budget has been reached."""
+
+    def __init__(self, used: int, limit: int, resets_in: float) -> None:
+        self.used = used
+        self.limit = limit
+        self.resets_in = resets_in
+        super().__init__(
+            f"GitHub API hourly budget exhausted ({used}/{limit} calls used). "
+            f"Budget resets in {resets_in:.0f}s."
+        )
+
+
+class _HourlyBudget:
+    """Sliding-window call counter that raises when the hourly cap is hit."""
+
+    def __init__(self, max_per_hour: int) -> None:
+        self._max = max_per_hour
+        self._window_start = time.monotonic()
+        self._count = 0
+
+    def configure(self, max_per_hour: int) -> None:
+        self._max = max_per_hour
+        # Reset the window so a config change takes effect immediately.
+        self._window_start = time.monotonic()
+        self._count = 0
+
+    def record(self) -> None:
+        """Record one call.  Raises BudgetExhausted if the cap is reached."""
+        now = time.monotonic()
+        elapsed = now - self._window_start
+        if elapsed >= 3600:
+            # New hour window — reset.
+            self._window_start = now
+            self._count = 0
+
+        self._count += 1
+        if self._count >= self._max:
+            resets_in = max(0.0, 3600 - elapsed)
+            raise BudgetExhausted(self._count, self._max, resets_in)
+
+
+_budget = _HourlyBudget(max_per_hour=2500)
+
+
+def configure_limiter(delay: float, max_calls_per_hour: int = 2500) -> None:
+    """Set the inter-request delay and hourly call budget.
+
+    Parameters
+    ----------
+    delay:
+        Seconds to sleep after each successful ``gh`` call.
+    max_calls_per_hour:
+        Maximum ``gh`` calls allowed per rolling hour (default 2 500,
+        half of a standard PAT's 5 000 req/hr primary limit).
+    """
     global _inter_request_delay
     _inter_request_delay = delay
+    _budget.configure(max_calls_per_hour)
 
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _is_rate_limit_error(stderr: str) -> bool:
+    """Return True if stderr looks like a GitHub primary/secondary rate limit."""
+    lower = stderr.lower()
+    return any(
+        phrase in lower
+        for phrase in ("rate limit", "secondary rate", "429", "403")
+    )
+
+
+def _rate_limit_reset_wait() -> float:
+    """Query ``/rate_limit`` and return seconds until the REST quota resets.
+
+    Returns 0 if the quota is not exhausted or the query itself fails.
+    The ``/rate_limit`` endpoint is free — it does not consume quota.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "api", "/rate_limit"],
+            capture_output=True, text=True, timeout=15,
+        )
+        if result.returncode != 0:
+            return 0.0
+        data = json.loads(result.stdout)
+        core = data.get("resources", {}).get("core", {})
+        remaining = core.get("remaining", 1)
+        if remaining > 0:
+            return 0.0
+        reset_epoch = core.get("reset", 0)
+        wait = reset_epoch - time.time()
+        return max(0.0, wait)
+    except Exception:
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
 
 class GhCliError(Exception):
     """Raised when a ``gh`` subprocess exits with a non-zero code."""
@@ -34,6 +136,10 @@ class GhCliError(Exception):
         )
 
 
+# ---------------------------------------------------------------------------
+# Core runner
+# ---------------------------------------------------------------------------
+
 def run_gh(
     args: List[str],
     *,
@@ -42,14 +148,21 @@ def run_gh(
 ) -> str:
     """Run ``gh`` with *args* and return stdout.
 
-    Retries up to *max_retries* times with exponential back-off when the
-    process exits non-zero (covers transient rate-limit 403/429 errors).
+    On failure, checks whether the error is a rate-limit exhaustion and
+    sleeps until the GitHub quota resets before retrying (up to
+    *max_retries* times).  Falls back to exponential back-off for other
+    transient errors.
 
     Raises
     ------
+    BudgetExhausted
+        When the configured hourly call budget is reached.
     GhCliError
         After exhausting retries.
     """
+    # Check budget before issuing the call.
+    _budget.record()
+
     cmd = ["gh"] + args
     last_err: Optional[GhCliError] = None
 
@@ -65,9 +178,20 @@ def run_gh(
         last_err = GhCliError(cmd, result.returncode, result.stderr)
 
         if attempt < max_retries:
-            time.sleep(backoff_base ** attempt)
+            if _is_rate_limit_error(result.stderr):
+                wait = _rate_limit_reset_wait()
+                if wait > 0:
+                    print(
+                        f"  rate limit hit — sleeping {wait:.0f}s until reset",
+                        file=sys.stderr,
+                    )
+                    time.sleep(wait + 5)  # +5s buffer
+                else:
+                    # Secondary limit or unknown 403 — short back-off.
+                    time.sleep(backoff_base ** attempt)
+            else:
+                time.sleep(backoff_base ** attempt)
 
-    # Should never be None here, but satisfy type checker
     assert last_err is not None
     raise last_err
 

--- a/collector/github_poller/gh_client.py
+++ b/collector/github_poller/gh_client.py
@@ -13,6 +13,15 @@ import time
 from typing import Any, Dict, List, Optional
 
 
+_inter_request_delay: float = 0.0
+
+
+def configure_limiter(delay: float) -> None:
+    """Set the inter-request delay applied after each successful ``gh`` call."""
+    global _inter_request_delay
+    _inter_request_delay = delay
+
+
 class GhCliError(Exception):
     """Raised when a ``gh`` subprocess exits with a non-zero code."""
 
@@ -49,6 +58,8 @@ def run_gh(
             cmd, capture_output=True, text=True, timeout=120
         )
         if result.returncode == 0:
+            if _inter_request_delay > 0:
+                time.sleep(_inter_request_delay)
             return result.stdout
 
         last_err = GhCliError(cmd, result.returncode, result.stderr)

--- a/collector/github_poller/gh_client.py
+++ b/collector/github_poller/gh_client.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 
 import json
 import subprocess
-import sys
 import time
 from typing import Any, Dict, List, Optional
+
+from loguru import logger
 
 
 _inter_request_delay: float = 0.0
@@ -58,12 +59,22 @@ class _HourlyBudget:
             self._count = 0
 
         self._count += 1
+        pct = self._count / self._max
+        if pct >= 0.95:
+            logger.warning("API budget {}/{} ({:.0f}%)", self._count, self._max, pct * 100)
+        elif pct >= 0.80:
+            logger.info("API budget {}/{} ({:.0f}%)", self._count, self._max, pct * 100)
         if self._count >= self._max:
             resets_in = max(0.0, 3600 - elapsed)
             raise BudgetExhausted(self._count, self._max, resets_in)
 
 
 _budget = _HourlyBudget(max_per_hour=2500)
+
+
+def calls_made() -> int:
+    """Return the number of API calls made in the current hour window."""
+    return _budget._count
 
 
 def configure_limiter(delay: float, max_calls_per_hour: int = 2500) -> None:
@@ -80,6 +91,7 @@ def configure_limiter(delay: float, max_calls_per_hour: int = 2500) -> None:
     global _inter_request_delay
     _inter_request_delay = delay
     _budget.configure(max_calls_per_hour)
+    logger.info("limiter configured: {:.2f}s delay, {}/hr cap", delay, max_calls_per_hour)
 
 
 # ---------------------------------------------------------------------------
@@ -164,6 +176,7 @@ def run_gh(
     _budget.record()
 
     cmd = ["gh"] + args
+    logger.debug("→ gh {}", ' '.join(args))
     last_err: Optional[GhCliError] = None
 
     for attempt in range(max_retries + 1):
@@ -178,13 +191,17 @@ def run_gh(
         last_err = GhCliError(cmd, result.returncode, result.stderr)
 
         if attempt < max_retries:
+            logger.warning(
+                "retry {}/{}: {} — {}",
+                attempt + 1,
+                max_retries,
+                ' '.join(cmd[1:3]),
+                result.stderr.strip()[:120],
+            )
             if _is_rate_limit_error(result.stderr):
                 wait = _rate_limit_reset_wait()
                 if wait > 0:
-                    print(
-                        f"  rate limit hit — sleeping {wait:.0f}s until reset",
-                        file=sys.stderr,
-                    )
+                    logger.info("rate limit — sleeping {:.0f}s until reset", wait)
                     time.sleep(wait + 5)  # +5s buffer
                 else:
                     # Secondary limit or unknown 403 — short back-off.

--- a/collector/github_poller/gh_client.py
+++ b/collector/github_poller/gh_client.py
@@ -2,8 +2,10 @@
 
 Handles subprocess invocation, JSON deserialization, pagination via
 ``--paginate``, rate-limit back-off (retry with reset-aware sleep on
-403/429 exit codes), and an hourly call budget so the poller never
-consumes more than a configured fraction of the user's GitHub API quota.
+403/429 exit codes), an hourly call budget so the poller never consumes
+more than a configured fraction of the user's GitHub API quota, and a
+proactive secondary-rate-limit guard that delays calls before they would
+exceed a configured fraction of GitHub's per-minute cap.
 """
 
 from __future__ import annotations
@@ -17,6 +19,83 @@ from loguru import logger
 
 
 _inter_request_delay: float = 0.0
+_graphql_points_used: int = 0
+
+# ---------------------------------------------------------------------------
+# Secondary rate limit guard (proactive, sliding 60-second window)
+# ---------------------------------------------------------------------------
+
+# GitHub's authenticated REST secondary rate limit.
+_GITHUB_SECONDARY_LIMIT_PER_MINUTE: int = 900
+
+
+class _SecondaryRateLimiter:
+    """Proactive sliding-window guard against GitHub's secondary rate limit.
+
+    Before each API call, ``check()`` inspects how many calls have been
+    made in the last 60 seconds.  If issuing one more call would push
+    usage above *max_fraction* of GitHub's per-minute cap, it sleeps
+    until the oldest in-window call ages out and capacity is restored.
+
+    This prevents secondary rate limit errors entirely rather than
+    reacting to them after the fact.
+    """
+
+    WINDOW_SECONDS: float = 60.0
+
+    def __init__(
+        self,
+        github_limit: int = _GITHUB_SECONDARY_LIMIT_PER_MINUTE,
+        max_fraction: float = 0.50,
+    ) -> None:
+        self._limit = github_limit
+        self._threshold = max(1, int(github_limit * max_fraction))
+        self._timestamps: List[float] = []  # monotonic call times
+
+    def configure(self, max_fraction: float) -> None:
+        self._threshold = max(1, int(self._limit * max_fraction))
+        self._timestamps = []
+
+    @property
+    def window_count(self) -> int:
+        """Calls made in the current 60-second window."""
+        cutoff = time.monotonic() - self.WINDOW_SECONDS
+        return sum(1 for t in self._timestamps if t > cutoff)
+
+    def check(self) -> None:
+        """Block until issuing the next call stays within the threshold.
+
+        Trims the timestamp list on each invocation so it never grows
+        beyond *threshold* entries.
+        """
+        now = time.monotonic()
+        cutoff = now - self.WINDOW_SECONDS
+        # Drop timestamps outside the window.
+        self._timestamps = [t for t in self._timestamps if t > cutoff]
+
+        if len(self._timestamps) >= self._threshold:
+            # Sleep until the oldest call exits the window.
+            oldest = self._timestamps[0]
+            wait = (oldest + self.WINDOW_SECONDS) - time.monotonic()
+            if wait > 0:
+                logger.info(
+                    "secondary rate limit: {}/{} calls in 60s window — "
+                    "sleeping {:.1f}s to stay ≤{:.0f}% of GitHub cap",
+                    len(self._timestamps),
+                    self._threshold,
+                    wait,
+                    (self._threshold / self._limit) * 100,
+                )
+                time.sleep(wait + 0.1)  # +0.1s to ensure the slot has cleared
+            # Re-trim after sleeping.
+            now = time.monotonic()
+            cutoff = now - self.WINDOW_SECONDS
+            self._timestamps = [t for t in self._timestamps if t > cutoff]
+
+        self._timestamps.append(time.monotonic())
+
+
+_secondary = _SecondaryRateLimiter()
 
 # ---------------------------------------------------------------------------
 # Hourly call budget
@@ -77,8 +156,17 @@ def calls_made() -> int:
     return _budget._count
 
 
-def configure_limiter(delay: float, max_calls_per_hour: int = 2500) -> None:
-    """Set the inter-request delay and hourly call budget.
+def graphql_points_used() -> int:
+    """Return the total GraphQL primary-rate-limit points consumed this run."""
+    return _graphql_points_used
+
+
+def configure_limiter(
+    delay: float,
+    max_calls_per_hour: int = 2500,
+    secondary_max_fraction: float = 0.50,
+) -> None:
+    """Set the inter-request delay, hourly call budget, and secondary rate limit guard.
 
     Parameters
     ----------
@@ -87,11 +175,22 @@ def configure_limiter(delay: float, max_calls_per_hour: int = 2500) -> None:
     max_calls_per_hour:
         Maximum ``gh`` calls allowed per rolling hour (default 2 500,
         half of a standard PAT's 5 000 req/hr primary limit).
+    secondary_max_fraction:
+        Maximum fraction of GitHub's 900 req/min secondary rate limit to
+        use before proactively delaying.  Default 0.50 (450 calls/min).
     """
     global _inter_request_delay
     _inter_request_delay = delay
     _budget.configure(max_calls_per_hour)
-    logger.info("limiter configured: {:.2f}s delay, {}/hr cap", delay, max_calls_per_hour)
+    _secondary.configure(secondary_max_fraction)
+    logger.info(
+        "limiter configured: {:.2f}s delay, {}/hr cap, "
+        "secondary guard ≤{:.0f}% of {}/min",
+        delay,
+        max_calls_per_hour,
+        secondary_max_fraction * 100,
+        _GITHUB_SECONDARY_LIMIT_PER_MINUTE,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -172,7 +271,9 @@ def run_gh(
     GhCliError
         After exhausting retries.
     """
-    # Check budget before issuing the call.
+    # Proactive secondary rate limit guard — delays if needed before the call.
+    _secondary.check()
+    # Check hourly budget.
     _budget.record()
 
     cmd = ["gh"] + args
@@ -269,7 +370,20 @@ def gh_graphql(
             args.extend(["-F", f"{k}={v}"])
 
     stdout = run_gh(args, max_retries=max_retries, backoff_base=backoff_base)
-    return json.loads(stdout)
+    response = json.loads(stdout)
+
+    global _graphql_points_used
+    rate_limit = (response.get("data") or {}).get("rateLimit")
+    if rate_limit:
+        cost = rate_limit.get("cost", 0)
+        remaining = rate_limit.get("remaining")
+        _graphql_points_used += cost
+        logger.debug(
+            "graphql cost={} remaining={} total_this_run={}",
+            cost, remaining, _graphql_points_used,
+        )
+
+    return response
 
 
 def gh_api(

--- a/collector/github_poller/run.py
+++ b/collector/github_poller/run.py
@@ -23,12 +23,16 @@ import argparse
 import os
 import sqlite3
 import sys
+from datetime import date
 from pathlib import Path
 from typing import Optional
+
+from loguru import logger
 
 from am_i_shipping.config_loader import GitHubLimiterConfig, load_config
 from am_i_shipping.db import init_github_db
 from am_i_shipping.health_writer import write_health
+from am_i_shipping.logging_config import setup_logging
 
 from .cursor import advance_cursor, compute_since, read_cursor
 from .fetch_issues import (
@@ -38,7 +42,7 @@ from .fetch_issues import (
     fetch_issues,
 )
 from .fetch_prs import fetch_pr_edit_history, fetch_pr_review_comments, fetch_prs
-from .gh_client import BudgetExhausted, configure_limiter
+from .gh_client import BudgetExhausted, calls_made, configure_limiter
 from .link_resolver import resolve_link
 from .push_counter import count_pushes_after_review
 from .session_linker import link_sessions
@@ -58,7 +62,7 @@ def _apply_nice(increment: int) -> None:
     try:
         os.nice(increment)
     except (OSError, AttributeError) as exc:
-        print(f"WARNING: os.nice({increment}) skipped: {exc}", file=sys.stderr)
+        logger.warning("os.nice({}) skipped: {}", increment, exc)
 
 
 def _get_stored_updated_at(
@@ -113,6 +117,14 @@ def run(
     github_db = data_dir / "github.db"
     sessions_db = data_dir / "sessions.db"
 
+    logger.info(
+        "polling {} repos: {} | backfill_days={} max_calls_per_hour={}",
+        len(config.github.repos),
+        config.github.repos,
+        config.github.backfill_days,
+        config.github.limiter.max_calls_per_hour,
+    )
+
     # Apply resource limiters
     limiter = config.github.limiter
     _apply_nice(limiter.process_nice_increment)
@@ -135,15 +147,15 @@ def run(
                 max_items_per_repo=limiter.max_items_per_repo,
             )
             total_records += count
-            print(f"OK: {repo} — {count} records", file=sys.stderr)
+            logger.info("OK: {} — {} records", repo, count)
         except BudgetExhausted as exc:
             # Stop processing further repos — the hourly budget is shared
             # across all repos and will not recover mid-run.
-            print(f"BUDGET: {exc} — stopping early, remaining repos skipped.", file=sys.stderr)
+            logger.error("BUDGET: {} — stopping early, remaining repos skipped.", exc)
             all_succeeded = False
             break
         except Exception as exc:
-            print(f"ERROR: {repo} — {exc}", file=sys.stderr)
+            logger.error("ERROR: {} — {}", repo, exc)
             all_succeeded = False
 
     # Write health only if all repos succeeded and not in dry-run mode
@@ -166,14 +178,14 @@ def _poll_repo(
     cursor_value = None if dry_run else read_cursor(repo, github_db)
     since = compute_since(cursor_value, backfill_days=backfill_days)
 
-    print(f"  {repo}: fetching since {since} (cursor={'backfill' if cursor_value is None else 'delta'})", file=sys.stderr)
+    logger.info("{}  mode={} since={}", repo, 'backfill' if cursor_value is None else 'delta', since)
 
     # 2. Fetch issues and PRs (without comments — fetched after cap to avoid
     #    wasting API calls on items that will be discarded).
     issues = fetch_issues(repo, since=since, include_comments=False)
     prs = fetch_prs(repo, since=since, include_comments=False)
 
-    print(f"  {repo}: fetched {len(issues)} issues, {len(prs)} PRs", file=sys.stderr)
+    logger.info("{}  fetched {} issues, {} PRs (uncapped)", repo, len(issues), len(prs))
 
     if dry_run:
         return len(issues) + len(prs)
@@ -187,10 +199,9 @@ def _poll_repo(
         else:
             remaining = max_items_per_repo - len(issues)
             prs = prs[:remaining]
-        print(
-            f"  {repo}: capped to {len(issues)} issues + {len(prs)} PRs "
-            f"(max_items_per_repo={max_items_per_repo})",
-            file=sys.stderr,
+        logger.info(
+            "{}  capped to {} issues + {} PRs (max_items_per_repo={})",
+            repo, len(issues), len(prs), max_items_per_repo,
         )
 
     # Fetch comments only for the capped set.
@@ -198,10 +209,10 @@ def _poll_repo(
         try:
             issue["comments"] = fetch_issue_comments(repo, issue["number"])
         except BudgetExhausted as exc:
-            print(f"  {repo}: {exc}", file=sys.stderr)
+            logger.error("{}  budget exhausted fetching comments for issue #{}: {}", repo, issue["number"], exc)
             raise
         except Exception as exc:
-            print(f"  {repo}: comment fetch error (issue #{issue['number']}): {exc}", file=sys.stderr)
+            logger.warning("{}  comment fetch error (issue #{}): {}", repo, issue["number"], exc)
             issue["comments"] = []
 
     for pr in prs:
@@ -210,10 +221,10 @@ def _poll_repo(
             pr["review_comments"] = review_comments
             pr["review_comment_count"] = len(review_comments)
         except BudgetExhausted as exc:
-            print(f"  {repo}: {exc}", file=sys.stderr)
+            logger.error("{}  budget exhausted fetching review comments for PR #{}: {}", repo, pr["number"], exc)
             raise
         except Exception as exc:
-            print(f"  {repo}: review comment fetch error (PR #{pr['number']}): {exc}", file=sys.stderr)
+            logger.warning("{}  review comment fetch error (PR #{}): {}", repo, pr["number"], exc)
             pr["review_comments"] = []
             pr["review_comment_count"] = 0
 
@@ -236,7 +247,7 @@ def _poll_repo(
                 try:
                     batch_results = fetch_issue_edit_history_batch(repo, issue_numbers)
                 except Exception as exc:
-                    print(f"  {repo}: edit history batch fetch error: {exc}", file=sys.stderr)
+                    logger.warning("{}  edit history batch fetch error: {}", repo, exc)
                     batch_results = {}
 
                 for issue_number, edits in batch_results.items():
@@ -252,7 +263,7 @@ def _poll_repo(
                                 conn=conn,
                             )
                         except Exception as exc:
-                            print(f"  {repo}: insert issue body edit error (issue #{issue_number}): {exc}", file=sys.stderr)
+                            logger.warning("{}  insert issue body edit error (issue #{}): {}", repo, issue_number, exc)
 
                     for edit in edits.get("comment_edits", []):
                         try:
@@ -267,7 +278,7 @@ def _poll_repo(
                                 conn=conn,
                             )
                         except Exception as exc:
-                            print(f"  {repo}: insert issue comment edit error (issue #{issue_number}): {exc}", file=sys.stderr)
+                            logger.warning("{}  insert issue comment edit error (issue #{}): {}", repo, issue_number, exc)
         else:
             # Delta: upsert each issue and fetch edit history if updated_at changed
             for issue in issues:
@@ -282,7 +293,7 @@ def _poll_repo(
                     try:
                         edits = fetch_issue_edit_history(repo, issue["number"])
                     except Exception as exc:
-                        print(f"  {repo}: edit history fetch error (issue #{issue['number']}): {exc}", file=sys.stderr)
+                        logger.warning("{}  edit history fetch error (issue #{}): {}", repo, issue["number"], exc)
                         continue
 
                     for edit in edits.get("body_edits", []):
@@ -297,7 +308,7 @@ def _poll_repo(
                                 conn=conn,
                             )
                         except Exception as exc:
-                            print(f"  {repo}: insert issue body edit error (issue #{issue['number']}): {exc}", file=sys.stderr)
+                            logger.warning("{}  insert issue body edit error (issue #{}): {}", repo, issue["number"], exc)
 
                     for edit in edits.get("comment_edits", []):
                         try:
@@ -312,7 +323,7 @@ def _poll_repo(
                                 conn=conn,
                             )
                         except Exception as exc:
-                            print(f"  {repo}: insert issue comment edit error (issue #{issue['number']}): {exc}", file=sys.stderr)
+                            logger.warning("{}  insert issue comment edit error (issue #{}): {}", repo, issue["number"], exc)
 
         # 3–5. Process PRs: resolve links, derive push counts, upsert, edit history
         for pr in prs:
@@ -342,7 +353,7 @@ def _poll_repo(
                     try:
                         edits = fetch_pr_edit_history(repo, pr["number"])
                     except Exception as exc:
-                        print(f"  {repo}: edit history fetch error (PR #{pr['number']}): {exc}", file=sys.stderr)
+                        logger.warning("{}  edit history fetch error (PR #{}): {}", repo, pr["number"], exc)
                     else:
                         for edit in edits.get("body_edits", []):
                             try:
@@ -356,7 +367,7 @@ def _poll_repo(
                                     conn=conn,
                                 )
                             except Exception as exc:
-                                print(f"  {repo}: insert PR body edit error (PR #{pr['number']}): {exc}", file=sys.stderr)
+                                logger.warning("{}  insert PR body edit error (PR #{}): {}", repo, pr["number"], exc)
 
                         for edit in edits.get("review_comment_edits", []):
                             try:
@@ -371,7 +382,7 @@ def _poll_repo(
                                     conn=conn,
                                 )
                             except Exception as exc:
-                                print(f"  {repo}: insert PR review comment edit error (PR #{pr['number']}): {exc}", file=sys.stderr)
+                                logger.warning("{}  insert PR review comment edit error (PR #{}): {}", repo, pr["number"], exc)
 
             # Insert PR→issue link if resolved
             if linked_issue is not None:
@@ -383,7 +394,7 @@ def _poll_repo(
                 try:
                     edits = fetch_pr_edit_history(repo, pr["number"])
                 except Exception as exc:
-                    print(f"  {repo}: edit history fetch error (PR #{pr['number']}): {exc}", file=sys.stderr)
+                    logger.warning("{}  edit history fetch error (PR #{}): {}", repo, pr["number"], exc)
                     continue
 
                 for edit in edits.get("body_edits", []):
@@ -398,7 +409,7 @@ def _poll_repo(
                             conn=conn,
                         )
                     except Exception as exc:
-                        print(f"  {repo}: insert PR body edit error (PR #{pr['number']}): {exc}", file=sys.stderr)
+                        logger.warning("{}  insert PR body edit error (PR #{}): {}", repo, pr["number"], exc)
 
                 for edit in edits.get("review_comment_edits", []):
                     try:
@@ -413,7 +424,7 @@ def _poll_repo(
                             conn=conn,
                         )
                     except Exception as exc:
-                        print(f"  {repo}: insert PR review comment edit error (PR #{pr['number']}): {exc}", file=sys.stderr)
+                        logger.warning("{}  insert PR review comment edit error (PR #{}): {}", repo, pr["number"], exc)
 
         # Commit all writes for this repo
         conn.commit()
@@ -423,11 +434,16 @@ def _poll_repo(
     # 6. Link PRs to sessions
     session_links = link_sessions(repo, github_db, sessions_db)
     if session_links:
-        print(f"  {repo}: linked {session_links} PR-session pairs", file=sys.stderr)
+        logger.info("{}  linked {} PR-session pairs", repo, session_links)
 
     # 7. Advance cursor
     advance_cursor(repo, github_db)
+    logger.info("{}  cursor advanced to {}", repo, date.today().isoformat())
 
+    logger.info(
+        "{}  done: {} issues + {} PRs | {} API calls used this hour",
+        repo, len(issues), len(prs), calls_made(),
+    )
     # Return post-cap count (actual records written).  The uncapped fetch
     # count was already logged above; dry-run returns the uncapped count
     # earlier (before the cap is applied).
@@ -450,6 +466,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    setup_logging()
     _total, ok = run(config_path=args.config, dry_run=args.dry_run)
     sys.exit(0 if ok else 1)
 

--- a/collector/github_poller/run.py
+++ b/collector/github_poller/run.py
@@ -20,12 +20,13 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import os
 import sqlite3
 import sys
 from pathlib import Path
 from typing import Optional
 
-from am_i_shipping.config_loader import load_config
+from am_i_shipping.config_loader import GitHubLimiterConfig, load_config
 from am_i_shipping.db import init_github_db
 from am_i_shipping.health_writer import write_health
 
@@ -36,6 +37,7 @@ from .fetch_issues import (
     fetch_issues,
 )
 from .fetch_prs import fetch_pr_edit_history, fetch_prs
+from .gh_client import configure_limiter
 from .link_resolver import resolve_link
 from .push_counter import count_pushes_after_review
 from .session_linker import link_sessions
@@ -50,26 +52,36 @@ from .store import (
 )
 
 
+def _apply_nice(increment: int) -> None:
+    """Apply OS process deprioritization. Skips with a warning on failure."""
+    try:
+        os.nice(increment)
+    except (OSError, AttributeError) as exc:
+        print(f"WARNING: os.nice({increment}) skipped: {exc}", file=sys.stderr)
+
+
 def _get_stored_updated_at(
     table: str,
     repo: str,
     number_col: str,
     number: int,
     db_path: Path,
+    conn: Optional[sqlite3.Connection] = None,
 ) -> Optional[str]:
     """Return the stored ``updated_at`` value for a row, or None if not found."""
     assert table in ("issues", "pull_requests"), f"unexpected table: {table}"
     assert number_col in ("issue_number", "pr_number"), f"unexpected number_col: {number_col}"
     try:
-        conn = sqlite3.connect(str(db_path))
+        use_conn = conn if conn is not None else sqlite3.connect(str(db_path))
         try:
-            row = conn.execute(
+            row = use_conn.execute(
                 f"SELECT updated_at FROM {table} WHERE repo = ? AND {number_col} = ?",
                 (repo, number),
             ).fetchone()
             return row[0] if row else None
         finally:
-            conn.close()
+            if conn is None:
+                use_conn.close()
     except Exception:
         return None
 
@@ -100,6 +112,11 @@ def run(
     github_db = data_dir / "github.db"
     sessions_db = data_dir / "sessions.db"
 
+    # Apply resource limiters
+    limiter = config.github.limiter
+    _apply_nice(limiter.process_nice_increment)
+    configure_limiter(limiter.inter_request_delay_seconds)
+
     if not dry_run:
         init_github_db(github_db)
 
@@ -114,6 +131,7 @@ def run(
                 sessions_db=sessions_db,
                 backfill_days=config.github.backfill_days,
                 dry_run=dry_run,
+                max_items_per_repo=limiter.max_items_per_repo,
             )
             total_records += count
             print(f"OK: {repo} — {count} records", file=sys.stderr)
@@ -134,6 +152,7 @@ def _poll_repo(
     sessions_db: Path,
     backfill_days: int,
     dry_run: bool,
+    max_items_per_repo: int = 500,
 ) -> int:
     """Poll a single repo.  Returns the number of records processed."""
     # 1. Read cursor
@@ -151,188 +170,222 @@ def _poll_repo(
     if dry_run:
         return len(issues) + len(prs)
 
-    # 3–5. Process and upsert issues
-    is_backfill = cursor_value is None
-
-    if is_backfill:
-        # Backfill: upsert all issues first, then batch-fetch edit history
-        for issue in issues:
-            upsert_issue(repo, issue, github_db)
-
-        # Batch-fetch edit history for all issues in chunks of 20
-        issue_numbers = [issue["number"] for issue in issues]
-        if issue_numbers:
-            try:
-                batch_results = fetch_issue_edit_history_batch(repo, issue_numbers)
-            except Exception as exc:
-                print(f"  {repo}: edit history batch fetch error: {exc}", file=sys.stderr)
-                batch_results = {}
-
-            for issue_number, edits in batch_results.items():
-                for edit in edits.get("body_edits", []):
-                    try:
-                        insert_issue_body_edit(
-                            repo,
-                            issue_number,
-                            edit["edited_at"],
-                            edit.get("diff"),
-                            edit.get("editor"),
-                            github_db,
-                        )
-                    except Exception as exc:
-                        print(f"  {repo}: insert issue body edit error (issue #{issue_number}): {exc}", file=sys.stderr)
-
-                for edit in edits.get("comment_edits", []):
-                    try:
-                        insert_issue_comment_edit(
-                            repo,
-                            issue_number,
-                            edit["comment_id"],
-                            edit["edited_at"],
-                            edit.get("diff"),
-                            edit.get("editor"),
-                            github_db,
-                        )
-                    except Exception as exc:
-                        print(f"  {repo}: insert issue comment edit error (issue #{issue_number}): {exc}", file=sys.stderr)
-    else:
-        # Delta: upsert each issue and fetch edit history if updated_at changed
-        for issue in issues:
-            prev_updated_at = _get_stored_updated_at(
-                "issues", repo, "issue_number", issue["number"], github_db
-            )
-            upsert_issue(repo, issue, github_db)
-
-            current_updated_at = issue.get("updated_at")
-            if current_updated_at and current_updated_at != prev_updated_at:
-                try:
-                    edits = fetch_issue_edit_history(repo, issue["number"])
-                except Exception as exc:
-                    print(f"  {repo}: edit history fetch error (issue #{issue['number']}): {exc}", file=sys.stderr)
-                    continue
-
-                for edit in edits.get("body_edits", []):
-                    try:
-                        insert_issue_body_edit(
-                            repo,
-                            issue["number"],
-                            edit["edited_at"],
-                            edit.get("diff"),
-                            edit.get("editor"),
-                            github_db,
-                        )
-                    except Exception as exc:
-                        print(f"  {repo}: insert issue body edit error (issue #{issue['number']}): {exc}", file=sys.stderr)
-
-                for edit in edits.get("comment_edits", []):
-                    try:
-                        insert_issue_comment_edit(
-                            repo,
-                            issue["number"],
-                            edit["comment_id"],
-                            edit["edited_at"],
-                            edit.get("diff"),
-                            edit.get("editor"),
-                            github_db,
-                        )
-                    except Exception as exc:
-                        print(f"  {repo}: insert issue comment edit error (issue #{issue['number']}): {exc}", file=sys.stderr)
-
-    # 3–5. Process PRs: resolve links, derive push counts, upsert, edit history
-    for pr in prs:
-        # Resolve PR→issue link
-        linked_issue = resolve_link(
-            head_ref=pr.get("head_ref", ""),
-            body=pr.get("body", ""),
+    # Apply item cap: issues first, PRs get remaining capacity
+    total_fetched = len(issues) + len(prs)
+    if total_fetched > max_items_per_repo:
+        if len(issues) >= max_items_per_repo:
+            issues = issues[:max_items_per_repo]
+            prs = []
+        else:
+            remaining = max_items_per_repo - len(issues)
+            prs = prs[:remaining]
+        print(
+            f"  {repo}: capped to {len(issues)} issues + {len(prs)} PRs "
+            f"(max_items_per_repo={max_items_per_repo})",
+            file=sys.stderr,
         )
 
-        # Derive push count
-        push_count = count_pushes_after_review(repo, pr["number"])
-        pr["push_count"] = push_count
+    # Ensure schema exists, then open a single connection for all writes
+    init_github_db(github_db)
+    conn = sqlite3.connect(str(github_db))
+    try:
+        # 3–5. Process and upsert issues
+        is_backfill = cursor_value is None
 
         if is_backfill:
-            # Backfill: upsert without updated_at gating
-            upsert_pr(repo, pr, github_db)
-        else:
-            # Delta: check updated_at before upsert
-            prev_updated_at = _get_stored_updated_at(
-                "pull_requests", repo, "pr_number", pr["number"], github_db
-            )
-            upsert_pr(repo, pr, github_db)
+            # Backfill: upsert all issues first, then batch-fetch edit history
+            for issue in issues:
+                upsert_issue(repo, issue, github_db, conn=conn)
 
-            current_updated_at = pr.get("updated_at")
-            if current_updated_at and current_updated_at != prev_updated_at:
+            # Batch-fetch edit history for all issues in chunks of 20
+            issue_numbers = [issue["number"] for issue in issues]
+            if issue_numbers:
                 try:
-                    edits = fetch_pr_edit_history(repo, pr["number"])
+                    batch_results = fetch_issue_edit_history_batch(repo, issue_numbers)
                 except Exception as exc:
-                    print(f"  {repo}: edit history fetch error (PR #{pr['number']}): {exc}", file=sys.stderr)
-                else:
+                    print(f"  {repo}: edit history batch fetch error: {exc}", file=sys.stderr)
+                    batch_results = {}
+
+                for issue_number, edits in batch_results.items():
                     for edit in edits.get("body_edits", []):
                         try:
-                            insert_pr_body_edit(
+                            insert_issue_body_edit(
                                 repo,
-                                pr["number"],
+                                issue_number,
                                 edit["edited_at"],
                                 edit.get("diff"),
                                 edit.get("editor"),
                                 github_db,
+                                conn=conn,
                             )
                         except Exception as exc:
-                            print(f"  {repo}: insert PR body edit error (PR #{pr['number']}): {exc}", file=sys.stderr)
+                            print(f"  {repo}: insert issue body edit error (issue #{issue_number}): {exc}", file=sys.stderr)
 
-                    for edit in edits.get("review_comment_edits", []):
+                    for edit in edits.get("comment_edits", []):
                         try:
-                            insert_pr_review_comment_edit(
+                            insert_issue_comment_edit(
                                 repo,
-                                pr["number"],
+                                issue_number,
                                 edit["comment_id"],
                                 edit["edited_at"],
                                 edit.get("diff"),
                                 edit.get("editor"),
                                 github_db,
+                                conn=conn,
                             )
                         except Exception as exc:
-                            print(f"  {repo}: insert PR review comment edit error (PR #{pr['number']}): {exc}", file=sys.stderr)
+                            print(f"  {repo}: insert issue comment edit error (issue #{issue_number}): {exc}", file=sys.stderr)
+        else:
+            # Delta: upsert each issue and fetch edit history if updated_at changed
+            for issue in issues:
+                prev_updated_at = _get_stored_updated_at(
+                    "issues", repo, "issue_number", issue["number"], github_db,
+                    conn=conn,
+                )
+                upsert_issue(repo, issue, github_db, conn=conn)
 
-        # Insert PR→issue link if resolved
-        if linked_issue is not None:
-            upsert_pr_issue_link(repo, pr["number"], linked_issue, github_db)
+                current_updated_at = issue.get("updated_at")
+                if current_updated_at and current_updated_at != prev_updated_at:
+                    try:
+                        edits = fetch_issue_edit_history(repo, issue["number"])
+                    except Exception as exc:
+                        print(f"  {repo}: edit history fetch error (issue #{issue['number']}): {exc}", file=sys.stderr)
+                        continue
 
-    # Backfill: fetch PR edit history in bulk after all upserts
-    if is_backfill and prs:
+                    for edit in edits.get("body_edits", []):
+                        try:
+                            insert_issue_body_edit(
+                                repo,
+                                issue["number"],
+                                edit["edited_at"],
+                                edit.get("diff"),
+                                edit.get("editor"),
+                                github_db,
+                                conn=conn,
+                            )
+                        except Exception as exc:
+                            print(f"  {repo}: insert issue body edit error (issue #{issue['number']}): {exc}", file=sys.stderr)
+
+                    for edit in edits.get("comment_edits", []):
+                        try:
+                            insert_issue_comment_edit(
+                                repo,
+                                issue["number"],
+                                edit["comment_id"],
+                                edit["edited_at"],
+                                edit.get("diff"),
+                                edit.get("editor"),
+                                github_db,
+                                conn=conn,
+                            )
+                        except Exception as exc:
+                            print(f"  {repo}: insert issue comment edit error (issue #{issue['number']}): {exc}", file=sys.stderr)
+
+        # 3–5. Process PRs: resolve links, derive push counts, upsert, edit history
         for pr in prs:
-            try:
-                edits = fetch_pr_edit_history(repo, pr["number"])
-            except Exception as exc:
-                print(f"  {repo}: edit history fetch error (PR #{pr['number']}): {exc}", file=sys.stderr)
-                continue
+            # Resolve PR→issue link
+            linked_issue = resolve_link(
+                head_ref=pr.get("head_ref", ""),
+                body=pr.get("body", ""),
+            )
 
-            for edit in edits.get("body_edits", []):
-                try:
-                    insert_pr_body_edit(
-                        repo,
-                        pr["number"],
-                        edit["edited_at"],
-                        edit.get("diff"),
-                        edit.get("editor"),
-                        github_db,
-                    )
-                except Exception as exc:
-                    print(f"  {repo}: insert PR body edit error (PR #{pr['number']}): {exc}", file=sys.stderr)
+            # Derive push count
+            push_count = count_pushes_after_review(repo, pr["number"])
+            pr["push_count"] = push_count
 
-            for edit in edits.get("review_comment_edits", []):
+            if is_backfill:
+                # Backfill: upsert without updated_at gating
+                upsert_pr(repo, pr, github_db, conn=conn)
+            else:
+                # Delta: check updated_at before upsert
+                prev_updated_at = _get_stored_updated_at(
+                    "pull_requests", repo, "pr_number", pr["number"], github_db,
+                    conn=conn,
+                )
+                upsert_pr(repo, pr, github_db, conn=conn)
+
+                current_updated_at = pr.get("updated_at")
+                if current_updated_at and current_updated_at != prev_updated_at:
+                    try:
+                        edits = fetch_pr_edit_history(repo, pr["number"])
+                    except Exception as exc:
+                        print(f"  {repo}: edit history fetch error (PR #{pr['number']}): {exc}", file=sys.stderr)
+                    else:
+                        for edit in edits.get("body_edits", []):
+                            try:
+                                insert_pr_body_edit(
+                                    repo,
+                                    pr["number"],
+                                    edit["edited_at"],
+                                    edit.get("diff"),
+                                    edit.get("editor"),
+                                    github_db,
+                                    conn=conn,
+                                )
+                            except Exception as exc:
+                                print(f"  {repo}: insert PR body edit error (PR #{pr['number']}): {exc}", file=sys.stderr)
+
+                        for edit in edits.get("review_comment_edits", []):
+                            try:
+                                insert_pr_review_comment_edit(
+                                    repo,
+                                    pr["number"],
+                                    edit["comment_id"],
+                                    edit["edited_at"],
+                                    edit.get("diff"),
+                                    edit.get("editor"),
+                                    github_db,
+                                    conn=conn,
+                                )
+                            except Exception as exc:
+                                print(f"  {repo}: insert PR review comment edit error (PR #{pr['number']}): {exc}", file=sys.stderr)
+
+            # Insert PR→issue link if resolved
+            if linked_issue is not None:
+                upsert_pr_issue_link(repo, pr["number"], linked_issue, github_db, conn=conn)
+
+        # Backfill: fetch PR edit history in bulk after all upserts
+        if is_backfill and prs:
+            for pr in prs:
                 try:
-                    insert_pr_review_comment_edit(
-                        repo,
-                        pr["number"],
-                        edit["comment_id"],
-                        edit["edited_at"],
-                        edit.get("diff"),
-                        edit.get("editor"),
-                        github_db,
-                    )
+                    edits = fetch_pr_edit_history(repo, pr["number"])
                 except Exception as exc:
-                    print(f"  {repo}: insert PR review comment edit error (PR #{pr['number']}): {exc}", file=sys.stderr)
+                    print(f"  {repo}: edit history fetch error (PR #{pr['number']}): {exc}", file=sys.stderr)
+                    continue
+
+                for edit in edits.get("body_edits", []):
+                    try:
+                        insert_pr_body_edit(
+                            repo,
+                            pr["number"],
+                            edit["edited_at"],
+                            edit.get("diff"),
+                            edit.get("editor"),
+                            github_db,
+                            conn=conn,
+                        )
+                    except Exception as exc:
+                        print(f"  {repo}: insert PR body edit error (PR #{pr['number']}): {exc}", file=sys.stderr)
+
+                for edit in edits.get("review_comment_edits", []):
+                    try:
+                        insert_pr_review_comment_edit(
+                            repo,
+                            pr["number"],
+                            edit["comment_id"],
+                            edit["edited_at"],
+                            edit.get("diff"),
+                            edit.get("editor"),
+                            github_db,
+                            conn=conn,
+                        )
+                    except Exception as exc:
+                        print(f"  {repo}: insert PR review comment edit error (PR #{pr['number']}): {exc}", file=sys.stderr)
+
+        # Commit all writes for this repo
+        conn.commit()
+    finally:
+        conn.close()
 
     # 6. Link PRs to sessions
     session_links = link_sessions(repo, github_db, sessions_db)

--- a/collector/github_poller/run.py
+++ b/collector/github_poller/run.py
@@ -32,12 +32,13 @@ from am_i_shipping.health_writer import write_health
 
 from .cursor import advance_cursor, compute_since, read_cursor
 from .fetch_issues import (
+    fetch_issue_comments,
     fetch_issue_edit_history,
     fetch_issue_edit_history_batch,
     fetch_issues,
 )
-from .fetch_prs import fetch_pr_edit_history, fetch_prs
-from .gh_client import configure_limiter
+from .fetch_prs import fetch_pr_edit_history, fetch_pr_review_comments, fetch_prs
+from .gh_client import BudgetExhausted, configure_limiter
 from .link_resolver import resolve_link
 from .push_counter import count_pushes_after_review
 from .session_linker import link_sessions
@@ -115,7 +116,7 @@ def run(
     # Apply resource limiters
     limiter = config.github.limiter
     _apply_nice(limiter.process_nice_increment)
-    configure_limiter(limiter.inter_request_delay_seconds)
+    configure_limiter(limiter.inter_request_delay_seconds, limiter.max_calls_per_hour)
 
     if not dry_run:
         init_github_db(github_db)
@@ -135,6 +136,12 @@ def run(
             )
             total_records += count
             print(f"OK: {repo} — {count} records", file=sys.stderr)
+        except BudgetExhausted as exc:
+            # Stop processing further repos — the hourly budget is shared
+            # across all repos and will not recover mid-run.
+            print(f"BUDGET: {exc} — stopping early, remaining repos skipped.", file=sys.stderr)
+            all_succeeded = False
+            break
         except Exception as exc:
             print(f"ERROR: {repo} — {exc}", file=sys.stderr)
             all_succeeded = False
@@ -161,16 +168,17 @@ def _poll_repo(
 
     print(f"  {repo}: fetching since {since} (cursor={'backfill' if cursor_value is None else 'delta'})", file=sys.stderr)
 
-    # 2. Fetch issues and PRs
-    issues = fetch_issues(repo, since=since)
-    prs = fetch_prs(repo, since=since)
+    # 2. Fetch issues and PRs (without comments — fetched after cap to avoid
+    #    wasting API calls on items that will be discarded).
+    issues = fetch_issues(repo, since=since, include_comments=False)
+    prs = fetch_prs(repo, since=since, include_comments=False)
 
     print(f"  {repo}: fetched {len(issues)} issues, {len(prs)} PRs", file=sys.stderr)
 
     if dry_run:
         return len(issues) + len(prs)
 
-    # Apply item cap: issues first, PRs get remaining capacity
+    # Apply item cap: issues first, PRs get remaining capacity.
     total_fetched = len(issues) + len(prs)
     if total_fetched > max_items_per_repo:
         if len(issues) >= max_items_per_repo:
@@ -184,6 +192,30 @@ def _poll_repo(
             f"(max_items_per_repo={max_items_per_repo})",
             file=sys.stderr,
         )
+
+    # Fetch comments only for the capped set.
+    for issue in issues:
+        try:
+            issue["comments"] = fetch_issue_comments(repo, issue["number"])
+        except BudgetExhausted as exc:
+            print(f"  {repo}: {exc}", file=sys.stderr)
+            raise
+        except Exception as exc:
+            print(f"  {repo}: comment fetch error (issue #{issue['number']}): {exc}", file=sys.stderr)
+            issue["comments"] = []
+
+    for pr in prs:
+        try:
+            review_comments = fetch_pr_review_comments(repo, pr["number"])
+            pr["review_comments"] = review_comments
+            pr["review_comment_count"] = len(review_comments)
+        except BudgetExhausted as exc:
+            print(f"  {repo}: {exc}", file=sys.stderr)
+            raise
+        except Exception as exc:
+            print(f"  {repo}: review comment fetch error (PR #{pr['number']}): {exc}", file=sys.stderr)
+            pr["review_comments"] = []
+            pr["review_comment_count"] = 0
 
     # Ensure schema exists (also called by run(), but _poll_repo may be
     # invoked directly in tests), then open a single connection for all writes.

--- a/collector/github_poller/run.py
+++ b/collector/github_poller/run.py
@@ -41,8 +41,8 @@ from .fetch_issues import (
     fetch_issue_edit_history_batch,
     fetch_issues,
 )
-from .fetch_prs import fetch_pr_edit_history, fetch_pr_review_comments, fetch_prs
-from .gh_client import BudgetExhausted, calls_made, configure_limiter
+from .fetch_prs import fetch_pr_comments, fetch_pr_edit_history, fetch_pr_review_comments, fetch_prs
+from .gh_client import BudgetExhausted, calls_made, configure_limiter, graphql_points_used
 from .link_resolver import resolve_link
 from .push_counter import count_pushes_after_review
 from .session_linker import link_sessions
@@ -216,6 +216,15 @@ def _poll_repo(
             issue["comments"] = []
 
     for pr in prs:
+        try:
+            pr["comments"] = fetch_pr_comments(repo, pr["number"])
+        except BudgetExhausted as exc:
+            logger.error("{}  budget exhausted fetching comments for PR #{}: {}", repo, pr["number"], exc)
+            raise
+        except Exception as exc:
+            logger.warning("{}  comment fetch error (PR #{}): {}", repo, pr["number"], exc)
+            pr["comments"] = []
+
         try:
             review_comments = fetch_pr_review_comments(repo, pr["number"])
             pr["review_comments"] = review_comments
@@ -441,8 +450,8 @@ def _poll_repo(
     logger.info("{}  cursor advanced to {}", repo, date.today().isoformat())
 
     logger.info(
-        "{}  done: {} issues + {} PRs | {} API calls used this hour",
-        repo, len(issues), len(prs), calls_made(),
+        "{}  done: {} issues + {} PRs | {} REST calls, {} GraphQL points used this run",
+        repo, len(issues), len(prs), calls_made(), graphql_points_used(),
     )
     # Return post-cap count (actual records written).  The uncapped fetch
     # count was already logged above; dry-run returns the uncapped count

--- a/collector/github_poller/run.py
+++ b/collector/github_poller/run.py
@@ -185,7 +185,8 @@ def _poll_repo(
             file=sys.stderr,
         )
 
-    # Ensure schema exists, then open a single connection for all writes
+    # Ensure schema exists (also called by run(), but _poll_repo may be
+    # invoked directly in tests), then open a single connection for all writes.
     init_github_db(github_db)
     conn = sqlite3.connect(str(github_db))
     try:
@@ -395,6 +396,9 @@ def _poll_repo(
     # 7. Advance cursor
     advance_cursor(repo, github_db)
 
+    # Return post-cap count (actual records written).  The uncapped fetch
+    # count was already logged above; dry-run returns the uncapped count
+    # earlier (before the cap is applied).
     return len(issues) + len(prs)
 
 

--- a/collector/github_poller/session_linker.py
+++ b/collector/github_poller/session_linker.py
@@ -15,6 +15,8 @@ import sqlite3
 from pathlib import Path
 from typing import Union
 
+from loguru import logger
+
 
 def link_sessions(
     repo: str,
@@ -42,6 +44,7 @@ def link_sessions(
 
     # Exit cleanly if sessions.db does not exist
     if not sessions_db_path.exists():
+        logger.warning("sessions.db not found at {} — session linkage skipped for {}", sessions_db_path, repo)
         return 0
 
     # Get all PRs for this repo that have a head_ref
@@ -117,4 +120,10 @@ def link_sessions(
     finally:
         gh_conn.close()
 
+    pr_count = len(prs)
+    session_count = sum(len(v) for v in sessions_by_branch.values())
+    logger.info(
+        "{}  session links: {} PRs queried, {} sessions in DB, {} inserted",
+        repo, pr_count, session_count, count,
+    )
     return count

--- a/collector/github_poller/store.py
+++ b/collector/github_poller/store.py
@@ -6,6 +6,12 @@ Provides idempotent upsert operations that use ``INSERT OR REPLACE``
 Validates required fields before writing — raises ``ValueError`` on
 missing repo, number, or other mandatory columns rather than silently
 inserting NULLs.
+
+All public functions accept an optional ``conn`` parameter.  When
+provided, the caller owns the connection lifecycle (open/commit/close)
+and the function skips ``_connect()``/commit/close.  When ``None``
+(default), each function opens its own connection, commits, and closes
+— preserving backward compatibility.
 """
 
 from __future__ import annotations
@@ -29,6 +35,7 @@ def upsert_issue(
     repo: str,
     issue: Dict[str, Any],
     db_path: Union[str, Path],
+    conn: Optional[sqlite3.Connection] = None,
 ) -> None:
     """Insert or update a single issue row.
 
@@ -39,8 +46,10 @@ def upsert_issue(
     if "number" not in issue or issue["number"] is None:
         raise ValueError("issue number is required")
 
-    db_path = Path(db_path)
-    conn = _connect(db_path)
+    own_conn = conn is None
+    if own_conn:
+        db_path = Path(db_path)
+        conn = _connect(db_path)
     try:
         conn.execute(
             """
@@ -71,15 +80,18 @@ def upsert_issue(
                 issue.get("updated_at"),
             ),
         )
-        conn.commit()
+        if own_conn:
+            conn.commit()
     finally:
-        conn.close()
+        if own_conn:
+            conn.close()
 
 
 def upsert_pr(
     repo: str,
     pr: Dict[str, Any],
     db_path: Union[str, Path],
+    conn: Optional[sqlite3.Connection] = None,
 ) -> None:
     """Insert or update a single PR row.
 
@@ -90,8 +102,10 @@ def upsert_pr(
     if "number" not in pr or pr["number"] is None:
         raise ValueError("pr number is required")
 
-    db_path = Path(db_path)
-    conn = _connect(db_path)
+    own_conn = conn is None
+    if own_conn:
+        db_path = Path(db_path)
+        conn = _connect(db_path)
     try:
         conn.execute(
             """
@@ -125,9 +139,11 @@ def upsert_pr(
                 pr.get("updated_at"),
             ),
         )
-        conn.commit()
+        if own_conn:
+            conn.commit()
     finally:
-        conn.close()
+        if own_conn:
+            conn.close()
 
 
 def upsert_pr_issue_link(
@@ -135,10 +151,13 @@ def upsert_pr_issue_link(
     pr_number: int,
     issue_number: int,
     db_path: Union[str, Path],
+    conn: Optional[sqlite3.Connection] = None,
 ) -> None:
     """Link a PR to an issue.  Idempotent (INSERT OR IGNORE)."""
-    db_path = Path(db_path)
-    conn = _connect(db_path)
+    own_conn = conn is None
+    if own_conn:
+        db_path = Path(db_path)
+        conn = _connect(db_path)
     try:
         conn.execute(
             """
@@ -147,9 +166,11 @@ def upsert_pr_issue_link(
             """,
             (repo, pr_number, issue_number),
         )
-        conn.commit()
+        if own_conn:
+            conn.commit()
     finally:
-        conn.close()
+        if own_conn:
+            conn.close()
 
 
 def insert_issue_body_edit(
@@ -159,10 +180,13 @@ def insert_issue_body_edit(
     diff: Optional[str],
     editor: Optional[str],
     db_path: Union[str, Path],
+    conn: Optional[sqlite3.Connection] = None,
 ) -> None:
     """Record an issue body edit.  Idempotent (INSERT OR IGNORE)."""
-    db_path = Path(db_path)
-    conn = _connect(db_path)
+    own_conn = conn is None
+    if own_conn:
+        db_path = Path(db_path)
+        conn = _connect(db_path)
     try:
         conn.execute(
             """
@@ -172,9 +196,11 @@ def insert_issue_body_edit(
             """,
             (repo, issue_number, edited_at, diff, editor),
         )
-        conn.commit()
+        if own_conn:
+            conn.commit()
     finally:
-        conn.close()
+        if own_conn:
+            conn.close()
 
 
 def insert_issue_comment_edit(
@@ -185,10 +211,13 @@ def insert_issue_comment_edit(
     diff: Optional[str],
     editor: Optional[str],
     db_path: Union[str, Path],
+    conn: Optional[sqlite3.Connection] = None,
 ) -> None:
     """Record an issue comment edit.  Idempotent (INSERT OR IGNORE)."""
-    db_path = Path(db_path)
-    conn = _connect(db_path)
+    own_conn = conn is None
+    if own_conn:
+        db_path = Path(db_path)
+        conn = _connect(db_path)
     try:
         conn.execute(
             """
@@ -198,9 +227,11 @@ def insert_issue_comment_edit(
             """,
             (repo, issue_number, comment_id, edited_at, diff, editor),
         )
-        conn.commit()
+        if own_conn:
+            conn.commit()
     finally:
-        conn.close()
+        if own_conn:
+            conn.close()
 
 
 def insert_pr_body_edit(
@@ -210,10 +241,13 @@ def insert_pr_body_edit(
     diff: Optional[str],
     editor: Optional[str],
     db_path: Union[str, Path],
+    conn: Optional[sqlite3.Connection] = None,
 ) -> None:
     """Record a PR body edit.  Idempotent (INSERT OR IGNORE)."""
-    db_path = Path(db_path)
-    conn = _connect(db_path)
+    own_conn = conn is None
+    if own_conn:
+        db_path = Path(db_path)
+        conn = _connect(db_path)
     try:
         conn.execute(
             """
@@ -223,9 +257,11 @@ def insert_pr_body_edit(
             """,
             (repo, pr_number, edited_at, diff, editor),
         )
-        conn.commit()
+        if own_conn:
+            conn.commit()
     finally:
-        conn.close()
+        if own_conn:
+            conn.close()
 
 
 def insert_pr_review_comment_edit(
@@ -236,10 +272,13 @@ def insert_pr_review_comment_edit(
     diff: Optional[str],
     editor: Optional[str],
     db_path: Union[str, Path],
+    conn: Optional[sqlite3.Connection] = None,
 ) -> None:
     """Record a PR review comment edit.  Idempotent (INSERT OR IGNORE)."""
-    db_path = Path(db_path)
-    conn = _connect(db_path)
+    own_conn = conn is None
+    if own_conn:
+        db_path = Path(db_path)
+        conn = _connect(db_path)
     try:
         conn.execute(
             """
@@ -249,6 +288,8 @@ def insert_pr_review_comment_edit(
             """,
             (repo, pr_number, comment_id, edited_at, diff, editor),
         )
-        conn.commit()
+        if own_conn:
+            conn.commit()
     finally:
-        conn.close()
+        if own_conn:
+            conn.close()

--- a/collector/github_poller/store.py
+++ b/collector/github_poller/store.py
@@ -111,13 +111,14 @@ def upsert_pr(
             """
             INSERT INTO pull_requests (
                 repo, pr_number, head_ref, title, body,
-                review_comments_json, review_comment_count,
+                comments_json, review_comments_json, review_comment_count,
                 push_count, created_at, merged_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(repo, pr_number) DO UPDATE SET
                 head_ref = excluded.head_ref,
                 title = excluded.title,
                 body = excluded.body,
+                comments_json = excluded.comments_json,
                 review_comments_json = excluded.review_comments_json,
                 review_comment_count = excluded.review_comment_count,
                 push_count = excluded.push_count,
@@ -131,6 +132,7 @@ def upsert_pr(
                 pr.get("head_ref", ""),
                 pr.get("title", ""),
                 pr.get("body", ""),
+                json.dumps(pr.get("comments", []), ensure_ascii=False),
                 json.dumps(pr.get("review_comments", []), ensure_ascii=False),
                 pr.get("review_comment_count", 0),
                 pr.get("push_count", 0),

--- a/collector/session_parser.py
+++ b/collector/session_parser.py
@@ -18,6 +18,7 @@ import argparse
 import json
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -384,6 +385,10 @@ def run_batch(config_path: Optional[str] = None) -> None:
     db_path = config.data_path / "sessions.db"
     data_dir = config.data_path
 
+    # Read limiter config
+    max_files = config.session.limiter.max_files_per_run
+    inter_delay = config.session.limiter.inter_file_delay_seconds
+
     # Ensure DB exists
     from am_i_shipping.db import init_sessions_db
 
@@ -407,6 +412,14 @@ def run_batch(config_path: Optional[str] = None) -> None:
     errors = 0
 
     for sf in session_files:
+        # Enforce per-run file cap
+        if processed >= max_files:
+            print(
+                f"  Reached max_files_per_run={max_files}, deferring rest to next run",
+                file=sys.stderr,
+            )
+            break
+
         # Quick check: extract UUID and skip if already in DB
         uuid = _extract_uuid_from_file(sf)
         if uuid and uuid in existing:
@@ -414,17 +427,25 @@ def run_batch(config_path: Optional[str] = None) -> None:
             continue
 
         try:
-            result_uuid = process_session(
-                sf,
+            record = parse_session(
+                sf, threshold=config.session.reprompt_threshold
+            )
+            upsert_session(
+                record,
                 db_path=db_path,
                 data_dir=data_dir,
-                threshold=config.session.reprompt_threshold,
+                skip_init=True,
+                skip_health=True,
             )
-            existing.add(result_uuid)
+            existing.add(record.session_uuid)
             processed += 1
         except SessionParseError as exc:
             print(f"WARN: {sf}: {exc}", file=sys.stderr)
             errors += 1
+
+        # Inter-file delay
+        if inter_delay > 0:
+            time.sleep(inter_delay)
 
     print(
         f"Batch complete: {processed} processed, {skipped} skipped, {errors} errors",

--- a/collector/store.py
+++ b/collector/store.py
@@ -20,6 +20,8 @@ def upsert_session(
     record: "SessionRecord",
     db_path: Optional[Union[str, Path]] = None,
     data_dir: Optional[Union[str, Path]] = None,
+    skip_init: bool = False,
+    skip_health: bool = False,
 ) -> None:
     """Insert or update a session record in sessions.db.
 
@@ -34,6 +36,12 @@ def upsert_session(
         Path to sessions.db. If None, uses data_dir / "sessions.db".
     data_dir:
         Directory for health.json. Defaults to repo-root/data/.
+    skip_init:
+        If True, skip ``init_sessions_db()`` call. Use when the caller
+        has already initialized the schema (e.g. batch mode).
+    skip_health:
+        If True, skip ``write_health()`` call. Use when the caller
+        writes health once at the end of a batch.
     """
     if data_dir is None:
         data_dir = Path(__file__).resolve().parent.parent / "data"
@@ -48,10 +56,11 @@ def upsert_session(
     # Ensure the DB directory exists
     db_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Ensure table exists
-    from am_i_shipping.db import init_sessions_db
+    # Ensure table exists (unless caller already did this)
+    if not skip_init:
+        from am_i_shipping.db import init_sessions_db
 
-    init_sessions_db(db_path)
+        init_sessions_db(db_path)
 
     conn = sqlite3.connect(str(db_path))
     try:
@@ -103,4 +112,5 @@ def upsert_session(
     finally:
         conn.close()
 
-    write_health("session_parser", 1, data_dir=data_dir)
+    if not skip_health:
+        write_health("session_parser", 1, data_dir=data_dir)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -51,6 +51,13 @@ github:
     # Ignored on platforms where os.nice() is unavailable.
     process_nice_increment: 10
 
+    # Hard cap on total gh CLI calls per rolling hour across all repos.
+    # Default is 2 500 — half of a standard PAT's 5 000 req/hr primary
+    # limit — so the poller never crowds out other tools or browser
+    # sessions sharing the same token. Raise only if you've verified
+    # no other tooling competes for the same quota.
+    max_calls_per_hour: 2500
+
 # -------------------------------------------------------------------
 # App-switch logger (Collector 3) — DISABLED
 # Uncomment to re-enable. Code remains in collector/appswitch/.

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -16,6 +16,16 @@ session:
   # that trigger the bail-out flag
   reprompt_threshold: 3
 
+  # Resource limiters for batch mode
+  limiter:
+    # Max session files to parse per batch run. Remaining files are
+    # picked up on subsequent runs (UUID skip ensures idempotency).
+    max_files_per_run: 200
+
+    # Sleep between file parses in batch mode (seconds).
+    # Gives the CPU scheduler a chance to yield under load.
+    inter_file_delay_seconds: 0.05
+
 # -------------------------------------------------------------------
 # GitHub poller (Collector 2)
 # -------------------------------------------------------------------
@@ -26,15 +36,28 @@ github:
   # Days of history to fetch on first run (backfill window)
   backfill_days: 90
 
-# -------------------------------------------------------------------
-# App-switch logger (Collector 3)
-# -------------------------------------------------------------------
-appswitch:
-  # ActivityWatch REST API base URL
-  aw_endpoint: "http://localhost:5600"
+  # Resource limiters for background-safe operation
+  limiter:
+    # Sleep between gh CLI API calls (seconds). Prevents triggering
+    # GitHub's secondary rate limits during sustained bursts.
+    inter_request_delay_seconds: 1.0
 
-  # Polling interval in seconds for the bridge script
-  poll_interval_seconds: 30
+    # Max issues + PRs to process per repo per run. The cursor means
+    # subsequent runs pick up remaining items automatically.
+    max_items_per_repo: 500
+
+    # os.nice() increment applied at process startup. Higher values
+    # make the process yield more readily under load.
+    # Ignored on platforms where os.nice() is unavailable.
+    process_nice_increment: 10
+
+# -------------------------------------------------------------------
+# App-switch logger (Collector 3) — DISABLED
+# Uncomment to re-enable. Code remains in collector/appswitch/.
+# -------------------------------------------------------------------
+# appswitch:
+#   aw_endpoint: "http://localhost:5600"
+#   poll_interval_seconds: 30
 
 # -------------------------------------------------------------------
 # Storage

--- a/docs/github-api-rate-limits.md
+++ b/docs/github-api-rate-limits.md
@@ -1,0 +1,74 @@
+# GitHub API Rate Limits
+
+## REST API — Primary Limits (per hour)
+
+| Auth method | Standard | Enterprise Cloud |
+|---|---|---|
+| Unauthenticated | 60 req/hr | — |
+| Personal Access Token | 5,000 | 15,000 |
+| GitHub App installation | 5,000–12,500* | 15,000 |
+| OAuth App (client ID/secret) | 5,000 | 15,000 |
+| `GITHUB_TOKEN` (Actions) | 1,000/repo | 15,000/repo |
+
+*Non-Enterprise GitHub Apps scale: +50 req/hr per repo/user above 20, capped at 12,500.
+
+## REST API — Secondary Limits (hard caps)
+
+| Limit | Value |
+|---|---|
+| Concurrent requests | 100 |
+| Points per minute | 900 |
+| CPU time | 90s per 60s real time |
+| Content-creating requests | 80/min, 500/hr |
+| OAuth token requests | 2,000/hr |
+
+**Point cost:** GET/HEAD/OPTIONS = 1pt, POST/PATCH/PUT/DELETE = 5pts
+
+---
+
+## GraphQL API — Primary Limits (per hour, in points)
+
+| Auth method | Standard | Enterprise Cloud |
+|---|---|---|
+| User | 5,000 | 10,000 |
+| GitHub App installation | 5,000–12,500* | 10,000 |
+| OAuth App | 5,000 | 10,000 |
+| `GITHUB_TOKEN` (Actions) | 1,000/repo | 15,000/repo |
+
+*Same scaling formula as REST.
+
+## GraphQL API — Secondary Limits
+
+| Limit | Value |
+|---|---|
+| Concurrent requests (shared with REST) | 100 |
+| Points per minute | 2,000 |
+| CPU time | 90s per 60s real time, max 60s for GraphQL |
+| Content-creating requests | 80/min, 500/hr |
+
+**Point cost:** queries = 1pt, mutations = 5pts
+
+## GraphQL Query/Node Limits
+
+- Max nodes per call: 500,000
+- `first`/`last` pagination args: 1–100
+- Request timeout: 10 seconds
+
+---
+
+## gh CLI
+
+The `gh` CLI uses both REST and GraphQL depending on the command:
+
+- **Built-in commands** (`gh pr list`, `gh issue view`, etc.) use GraphQL internally for many operations.
+- **`gh api`** defaults to REST; pass `graphql` as the endpoint to use GraphQL.
+
+All `gh` commands consume from the same primary hourly bucket as direct API calls for whichever token is authenticated. If `gh` CLI calls and direct API calls share a token, they share the same 5,000 pts/hr limit.
+
+---
+
+## Sources
+
+- [Rate limits for the REST API — GitHub Docs](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api)
+- [Rate limits and query limits for the GraphQL API — GitHub Docs](https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api)
+- [gh api manual](https://cli.github.com/manual/gh_api)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml>=6.0
 pytest>=7.0
+loguru>=0.7

--- a/run_collectors.ps1
+++ b/run_collectors.ps1
@@ -53,10 +53,6 @@ $Collectors = @(
         Name = "GitHub Poller"
         Command = @("python", "-m", "collector.github_poller.run") + $ConfigArg
     },
-    @{
-        Name = "App-Switch Export"
-        Command = @("python", (Join-Path $ScriptDir "collector" "appswitch" "export.py")) + $ConfigArg
-    }
 )
 
 $FailCount = 0

--- a/run_collectors.sh
+++ b/run_collectors.sh
@@ -54,7 +54,6 @@ FAIL_COUNT=0
 
 run_collector "Session Parser" -m collector.session_parser --mode batch
 run_collector "GitHub Poller"  -m collector.github_poller.run
-run_collector "App-Switch Export" collector/appswitch/export.py
 
 log "=== Running health check ==="
 if python3 -m am_i_shipping.health_check >> "$LOG_FILE" 2>&1; then

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -80,7 +80,7 @@ class TestFetchIssues:
         mock_list.return_value = ISSUE_FIXTURE
         mock_api.return_value = ISSUE_COMMENTS_FIXTURE
 
-        results = fetch_issues("owner/repo", since="2024-01-01")
+        results = fetch_issues("owner/repo", since="2024-01-01", include_comments=True)
 
         assert len(results) == 2
         issue = results[0]
@@ -148,7 +148,7 @@ class TestFetchPRs:
         mock_list.return_value = PR_FIXTURE
         mock_api.return_value = PR_REVIEW_COMMENTS_FIXTURE
 
-        results = fetch_prs("owner/repo", since="2024-01-01")
+        results = fetch_prs("owner/repo", since="2024-01-01", include_comments=True)
 
         assert len(results) == 1
         pr = results[0]
@@ -193,7 +193,7 @@ class TestCommentIds:
         mock_list.return_value = [ISSUE_FIXTURE[0]]
         mock_api.return_value = ISSUE_COMMENTS_FIXTURE
 
-        results = fetch_issues("owner/repo")
+        results = fetch_issues("owner/repo", include_comments=True)
         assert results[0]["comments"][0]["id"] == 12345
 
     @patch("collector.github_poller.fetch_issues.gh_api")
@@ -214,7 +214,7 @@ class TestCommentIds:
         mock_list.return_value = [PR_FIXTURE[0]]
         mock_api.return_value = PR_REVIEW_COMMENTS_FIXTURE
 
-        results = fetch_prs("owner/repo")
+        results = fetch_prs("owner/repo", include_comments=True)
         assert results[0]["review_comments"][0]["id"] == 67890
 
     @patch("collector.github_poller.fetch_prs.gh_api")

--- a/tests/test_gh_client.py
+++ b/tests/test_gh_client.py
@@ -113,9 +113,10 @@ class TestGhGraphql:
         result = gh_graphql("query { ... }", {"owner": "test", "name": "repo"})
         assert result == response
 
+    @patch("collector.github_poller.gh_client._rate_limit_reset_wait", return_value=0.0)
     @patch("collector.github_poller.gh_client.time.sleep")
     @patch("collector.github_poller.gh_client.subprocess.run")
-    def test_retries_on_failure(self, mock_run, mock_sleep):
+    def test_retries_on_failure(self, mock_run, mock_sleep, mock_rl_wait):
         """gh_graphql retries with backoff like run_gh."""
         mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="rate limited")
         with pytest.raises(GhCliError):

--- a/tests/test_github_poller_run.py
+++ b/tests/test_github_poller_run.py
@@ -86,10 +86,15 @@ class TestDryRun:
 class TestPollRepo:
     @patch("collector.github_poller.run.link_sessions")
     @patch("collector.github_poller.run.count_pushes_after_review")
+    @patch("collector.github_poller.run.fetch_pr_edit_history", return_value={})
+    @patch("collector.github_poller.run.fetch_issue_edit_history_batch", return_value={})
+    @patch("collector.github_poller.run.fetch_pr_review_comments", return_value=[])
+    @patch("collector.github_poller.run.fetch_issue_comments", return_value=[])
     @patch("collector.github_poller.run.fetch_prs")
     @patch("collector.github_poller.run.fetch_issues")
     def test_full_poll_produces_rows(
-        self, mock_issues, mock_prs, mock_push, mock_link,
+        self, mock_issues, mock_prs, mock_issue_comments, mock_pr_comments,
+        mock_edit_batch, mock_pr_edit, mock_push, mock_link,
         tmp_path
     ):
         mock_issues.return_value = [
@@ -130,10 +135,16 @@ class TestPollRepo:
 
     @patch("collector.github_poller.run.link_sessions")
     @patch("collector.github_poller.run.count_pushes_after_review")
+    @patch("collector.github_poller.run.fetch_pr_edit_history", return_value={})
+    @patch("collector.github_poller.run.fetch_issue_edit_history", return_value={})
+    @patch("collector.github_poller.run.fetch_issue_edit_history_batch", return_value={})
+    @patch("collector.github_poller.run.fetch_pr_review_comments", return_value=[])
+    @patch("collector.github_poller.run.fetch_issue_comments", return_value=[])
     @patch("collector.github_poller.run.fetch_prs")
     @patch("collector.github_poller.run.fetch_issues")
     def test_rerun_produces_same_row_count(
-        self, mock_issues, mock_prs, mock_push, mock_link,
+        self, mock_issues, mock_prs, mock_issue_comments, mock_pr_comments,
+        mock_edit_batch, mock_issue_edit, mock_pr_edit, mock_push, mock_link,
         tmp_path
     ):
         """Re-running poll with same data produces identical row count."""

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -74,7 +74,6 @@ class TestCheckHealth:
         health = {
             "session_parser": {"last_success": now, "last_record_count": 10},
             "github_poller": {"last_success": now, "last_record_count": 20},
-            "appswitch_export": {"last_success": now, "last_record_count": 5},
         }
         (data_dir / "health.json").write_text(json.dumps(health))
 
@@ -91,7 +90,6 @@ class TestCheckHealth:
         health = {
             "session_parser": {"last_success": stale, "last_record_count": 10},
             "github_poller": {"last_success": fresh, "last_record_count": 20},
-            "appswitch_export": {"last_success": fresh, "last_record_count": 5},
         }
         (data_dir / "health.json").write_text(json.dumps(health))
 
@@ -103,10 +101,9 @@ class TestCheckHealth:
         data_dir = tmp_path / "data"
         data_dir.mkdir()
         now = datetime.now(timezone.utc).isoformat()
-        # Only two of three collectors present
+        # Only one of two expected collectors present
         health = {
             "session_parser": {"last_success": now, "last_record_count": 10},
-            "github_poller": {"last_success": now, "last_record_count": 20},
         }
         (data_dir / "health.json").write_text(json.dumps(health))
 

--- a/tests/test_limiters.py
+++ b/tests/test_limiters.py
@@ -139,14 +139,15 @@ class TestItemCap:
         mock_issues.return_value = [
             {"number": i, "title": f"Issue {i}", "state": "OPEN",
              "body": "", "comments": [], "type_label": None,
-             "created_at": "2024-01-01", "closed_at": None}
+             "created_at": "2024-01-01", "closed_at": None,
+             "updated_at": "2024-01-01T00:00:00Z"}
             for i in range(800)
         ]
         mock_prs.return_value = [
             {"number": 1000 + i, "title": f"PR {1000+i}", "head_ref": "main",
-             "body": "", "review_comments": [],
+             "body": "", "review_comments": [], "comments": [],
              "review_comment_count": 0, "created_at": "2024-01-02",
-             "merged_at": None}
+             "merged_at": None, "updated_at": "2024-01-02T00:00:00Z"}
             for i in range(400)
         ]
         mock_push.return_value = 0
@@ -186,13 +187,14 @@ class TestItemCap:
         mock_issues.return_value = [
             {"number": 1, "title": "Issue 1", "state": "OPEN",
              "body": "", "comments": [], "type_label": None,
-             "created_at": "2024-01-01", "closed_at": None}
+             "created_at": "2024-01-01", "closed_at": None,
+             "updated_at": "2024-01-01T00:00:00Z"}
         ]
         mock_prs.return_value = [
             {"number": 10, "title": "PR 10", "head_ref": "main",
-             "body": "", "review_comments": [],
+             "body": "", "review_comments": [], "comments": [],
              "review_comment_count": 0, "created_at": "2024-01-02",
-             "merged_at": None}
+             "merged_at": None, "updated_at": "2024-01-02T00:00:00Z"}
         ]
         mock_push.return_value = 0
         mock_link.return_value = 0

--- a/tests/test_limiters.py
+++ b/tests/test_limiters.py
@@ -123,10 +123,15 @@ class TestGhClientDelay:
 class TestItemCap:
     @patch("collector.github_poller.run.link_sessions")
     @patch("collector.github_poller.run.count_pushes_after_review")
+    @patch("collector.github_poller.run.fetch_pr_edit_history", return_value={})
+    @patch("collector.github_poller.run.fetch_issue_edit_history_batch", return_value={})
+    @patch("collector.github_poller.run.fetch_pr_review_comments", return_value=[])
+    @patch("collector.github_poller.run.fetch_issue_comments", return_value=[])
     @patch("collector.github_poller.run.fetch_prs")
     @patch("collector.github_poller.run.fetch_issues")
     def test_item_cap_limits_processing(
-        self, mock_issues, mock_prs, mock_push, mock_link, tmp_path
+        self, mock_issues, mock_prs, mock_issue_comments, mock_pr_comments,
+        mock_edit_batch, mock_pr_edit, mock_push, mock_link, tmp_path
     ):
         from collector.github_poller.run import _poll_repo
 
@@ -166,10 +171,15 @@ class TestItemCap:
 
     @patch("collector.github_poller.run.link_sessions")
     @patch("collector.github_poller.run.count_pushes_after_review")
+    @patch("collector.github_poller.run.fetch_pr_edit_history", return_value={})
+    @patch("collector.github_poller.run.fetch_issue_edit_history_batch", return_value={})
+    @patch("collector.github_poller.run.fetch_pr_review_comments", return_value=[])
+    @patch("collector.github_poller.run.fetch_issue_comments", return_value=[])
     @patch("collector.github_poller.run.fetch_prs")
     @patch("collector.github_poller.run.fetch_issues")
     def test_no_cap_when_under_limit(
-        self, mock_issues, mock_prs, mock_push, mock_link, tmp_path
+        self, mock_issues, mock_prs, mock_issue_comments, mock_pr_comments,
+        mock_edit_batch, mock_pr_edit, mock_push, mock_link, tmp_path
     ):
         from collector.github_poller.run import _poll_repo
 

--- a/tests/test_limiters.py
+++ b/tests/test_limiters.py
@@ -1,0 +1,462 @@
+"""Tests for resource limiter functionality (issue #15).
+
+Covers config defaults, inter-request delay, item cap, connection
+batching, session parser batch limiters, and appswitch removal.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+import yaml
+
+from am_i_shipping.config_loader import (
+    Config,
+    GitHubConfig,
+    GitHubLimiterConfig,
+    SessionConfig,
+    SessionLimiterConfig,
+    load_config,
+)
+from am_i_shipping.health_check import EXPECTED_COLLECTORS, check_health
+
+
+def _write_config(tmp_path: Path, data: dict) -> Path:
+    p = tmp_path / "config.yaml"
+    p.write_text(yaml.dump(data), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Config defaults
+# ---------------------------------------------------------------------------
+
+class TestLimiterConfigDefaults:
+    """Limiter sections use correct defaults when absent from YAML."""
+
+    def test_no_limiter_section_uses_defaults(self, tmp_path):
+        cfg_path = _write_config(tmp_path, {
+            "session": {"projects_path": "/path"},
+            "github": {"repos": ["a/b"]},
+        })
+        cfg = load_config(cfg_path)
+
+        assert cfg.github.limiter.inter_request_delay_seconds == 1.0
+        assert cfg.github.limiter.max_items_per_repo == 500
+        assert cfg.github.limiter.process_nice_increment == 10
+        assert cfg.session.limiter.max_files_per_run == 200
+        assert cfg.session.limiter.inter_file_delay_seconds == 0.05
+
+    def test_limiter_values_override(self, tmp_path):
+        cfg_path = _write_config(tmp_path, {
+            "session": {
+                "projects_path": "/path",
+                "limiter": {
+                    "max_files_per_run": 50,
+                    "inter_file_delay_seconds": 0.1,
+                },
+            },
+            "github": {
+                "repos": ["a/b"],
+                "limiter": {
+                    "inter_request_delay_seconds": 2.0,
+                    "max_items_per_repo": 100,
+                    "process_nice_increment": 5,
+                },
+            },
+        })
+        cfg = load_config(cfg_path)
+
+        assert cfg.github.limiter.inter_request_delay_seconds == 2.0
+        assert cfg.github.limiter.max_items_per_repo == 100
+        assert cfg.github.limiter.process_nice_increment == 5
+        assert cfg.session.limiter.max_files_per_run == 50
+        assert cfg.session.limiter.inter_file_delay_seconds == 0.1
+
+    def test_partial_limiter_config_fills_defaults(self, tmp_path):
+        """Specifying only some limiter keys fills the rest with defaults."""
+        cfg_path = _write_config(tmp_path, {
+            "session": {"projects_path": "/path"},
+            "github": {
+                "repos": ["a/b"],
+                "limiter": {
+                    "inter_request_delay_seconds": 0.5,
+                },
+            },
+        })
+        cfg = load_config(cfg_path)
+
+        assert cfg.github.limiter.inter_request_delay_seconds == 0.5
+        assert cfg.github.limiter.max_items_per_repo == 500  # default
+        assert cfg.github.limiter.process_nice_increment == 10  # default
+
+
+# ---------------------------------------------------------------------------
+# gh_client inter-request delay
+# ---------------------------------------------------------------------------
+
+class TestGhClientDelay:
+    def test_configure_limiter_sets_delay(self):
+        from collector.github_poller.gh_client import (
+            configure_limiter,
+            _inter_request_delay,
+        )
+        import collector.github_poller.gh_client as gh_mod
+
+        configure_limiter(2.5)
+        assert gh_mod._inter_request_delay == 2.5
+
+        # Reset
+        configure_limiter(0.0)
+        assert gh_mod._inter_request_delay == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Item cap in _poll_repo
+# ---------------------------------------------------------------------------
+
+class TestItemCap:
+    @patch("collector.github_poller.run.link_sessions")
+    @patch("collector.github_poller.run.count_pushes_after_review")
+    @patch("collector.github_poller.run.fetch_prs")
+    @patch("collector.github_poller.run.fetch_issues")
+    def test_item_cap_limits_processing(
+        self, mock_issues, mock_prs, mock_push, mock_link, tmp_path
+    ):
+        from collector.github_poller.run import _poll_repo
+
+        # Return 800 issues and 400 PRs
+        mock_issues.return_value = [
+            {"number": i, "title": f"Issue {i}", "state": "OPEN",
+             "body": "", "comments": [], "type_label": None,
+             "created_at": "2024-01-01", "closed_at": None}
+            for i in range(800)
+        ]
+        mock_prs.return_value = [
+            {"number": 1000 + i, "title": f"PR {1000+i}", "head_ref": "main",
+             "body": "", "review_comments": [],
+             "review_comment_count": 0, "created_at": "2024-01-02",
+             "merged_at": None}
+            for i in range(400)
+        ]
+        mock_push.return_value = 0
+        mock_link.return_value = 0
+
+        gh_db = tmp_path / "github.db"
+        sess_db = tmp_path / "sessions.db"
+
+        count = _poll_repo(
+            "owner/repo", gh_db, sess_db,
+            backfill_days=30, dry_run=False,
+            max_items_per_repo=500,
+        )
+
+        # The item cap of 500 should limit actual DB writes
+        conn = sqlite3.connect(str(gh_db))
+        issue_count = conn.execute("SELECT COUNT(*) FROM issues").fetchone()[0]
+        pr_count = conn.execute("SELECT COUNT(*) FROM pull_requests").fetchone()[0]
+        conn.close()
+
+        assert issue_count + pr_count == 500
+
+    @patch("collector.github_poller.run.link_sessions")
+    @patch("collector.github_poller.run.count_pushes_after_review")
+    @patch("collector.github_poller.run.fetch_prs")
+    @patch("collector.github_poller.run.fetch_issues")
+    def test_no_cap_when_under_limit(
+        self, mock_issues, mock_prs, mock_push, mock_link, tmp_path
+    ):
+        from collector.github_poller.run import _poll_repo
+
+        mock_issues.return_value = [
+            {"number": 1, "title": "Issue 1", "state": "OPEN",
+             "body": "", "comments": [], "type_label": None,
+             "created_at": "2024-01-01", "closed_at": None}
+        ]
+        mock_prs.return_value = [
+            {"number": 10, "title": "PR 10", "head_ref": "main",
+             "body": "", "review_comments": [],
+             "review_comment_count": 0, "created_at": "2024-01-02",
+             "merged_at": None}
+        ]
+        mock_push.return_value = 0
+        mock_link.return_value = 0
+
+        gh_db = tmp_path / "github.db"
+        sess_db = tmp_path / "sessions.db"
+
+        count = _poll_repo(
+            "owner/repo", gh_db, sess_db,
+            backfill_days=30, dry_run=False,
+            max_items_per_repo=500,
+        )
+        assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# Connection batching in store.py
+# ---------------------------------------------------------------------------
+
+class TestConnectionBatching:
+    def test_conn_parameter_skips_connect(self, tmp_path):
+        """When conn is provided, _connect is not called."""
+        from am_i_shipping.db import init_github_db
+        from collector.github_poller.store import upsert_issue
+
+        db = tmp_path / "github.db"
+        init_github_db(db)
+        conn = sqlite3.connect(str(db))
+
+        with patch("collector.github_poller.store._connect") as mock_connect:
+            upsert_issue(
+                "owner/repo",
+                {"number": 1, "title": "t", "state": "OPEN", "body": "",
+                 "comments": [], "type_label": None,
+                 "created_at": None, "closed_at": None},
+                db,
+                conn=conn,
+            )
+            mock_connect.assert_not_called()
+
+        conn.commit()
+        # Verify the row was written
+        row = conn.execute("SELECT COUNT(*) FROM issues").fetchone()[0]
+        conn.close()
+        assert row == 1
+
+    def test_no_conn_uses_connect(self, tmp_path):
+        """When conn is None (default), _connect is called."""
+        from collector.github_poller.store import upsert_issue
+
+        db = tmp_path / "github.db"
+
+        with patch("collector.github_poller.store._connect", wraps=__import__(
+            'collector.github_poller.store', fromlist=['_connect']
+        )._connect) as mock_connect:
+            upsert_issue(
+                "owner/repo",
+                {"number": 1, "title": "t", "state": "OPEN", "body": "",
+                 "comments": [], "type_label": None,
+                 "created_at": None, "closed_at": None},
+                db,
+            )
+            mock_connect.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Session parser batch limiters
+# ---------------------------------------------------------------------------
+
+class TestSessionBatchLimiters:
+    def _make_session_file(self, path: Path, uuid: str) -> Path:
+        """Create a minimal JSONL session file."""
+        entry = json.dumps({
+            "type": "user",
+            "sessionId": uuid,
+            "timestamp": "2024-01-01T00:00:00Z",
+            "cwd": "/tmp",
+            "message": {"role": "user", "content": "hello"},
+        })
+        entry2 = json.dumps({
+            "type": "assistant",
+            "sessionId": uuid,
+            "timestamp": "2024-01-01T00:01:00Z",
+            "message": {"role": "assistant", "content": "hi", "usage": {}},
+        })
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"{entry}\n{entry2}\n")
+        return path
+
+    def test_max_files_per_run_caps_batch(self, tmp_path):
+        """run_batch stops after max_files_per_run new files."""
+        from collector.session_parser import run_batch
+
+        # Create projects dir with 10 session files
+        projects = tmp_path / "projects"
+        for i in range(10):
+            self._make_session_file(
+                projects / f"session_{i}.jsonl",
+                f"uuid-{i:04d}",
+            )
+
+        # Config with max_files_per_run=5 and zero delay for speed
+        cfg_path = _write_config(tmp_path, {
+            "session": {
+                "projects_path": str(projects),
+                "limiter": {
+                    "max_files_per_run": 5,
+                    "inter_file_delay_seconds": 0.0,
+                },
+            },
+            "github": {"repos": ["a/b"]},
+            "data": {"data_dir": str(tmp_path / "data")},
+        })
+
+        run_batch(config_path=str(cfg_path))
+
+        # Check DB has exactly 5 rows
+        db = tmp_path / "data" / "sessions.db"
+        conn = sqlite3.connect(str(db))
+        count = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        conn.close()
+        assert count == 5
+
+        # Run again — picks up the remaining 5
+        run_batch(config_path=str(cfg_path))
+        conn = sqlite3.connect(str(db))
+        count = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        conn.close()
+        assert count == 10
+
+
+# ---------------------------------------------------------------------------
+# Session store skip_init / skip_health
+# ---------------------------------------------------------------------------
+
+class TestSessionStoreFlags:
+    def test_skip_init_does_not_call_init(self, tmp_path):
+        """upsert_session with skip_init=True skips init_sessions_db."""
+        from am_i_shipping.db import init_sessions_db
+        from collector.session_parser import SessionRecord
+        from collector.store import upsert_session
+
+        db = tmp_path / "sessions.db"
+        init_sessions_db(db)  # init once manually
+
+        record = SessionRecord(
+            session_uuid="test-uuid",
+            turn_count=1,
+            tool_call_count=0,
+            tool_failure_count=0,
+            reprompt_count=0,
+            bail_out=False,
+            session_duration_seconds=10.0,
+            working_directory="/tmp",
+            git_branch="main",
+            raw_content_json="[]",
+            input_tokens=0,
+            output_tokens=0,
+            cache_creation_tokens=0,
+            cache_read_tokens=0,
+            fast_mode_turns=0,
+        )
+
+        # With skip_init=True, init_sessions_db is never imported/called.
+        # Verify the function works correctly with the schema already initialized.
+        upsert_session(record, db_path=db, data_dir=tmp_path,
+                        skip_init=True, skip_health=True)
+
+        conn = sqlite3.connect(str(db))
+        count = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        conn.close()
+        assert count == 1
+
+    def test_skip_health_does_not_write_health(self, tmp_path):
+        """upsert_session with skip_health=True skips write_health."""
+        from am_i_shipping.db import init_sessions_db
+        from collector.session_parser import SessionRecord
+        from collector.store import upsert_session
+
+        db = tmp_path / "sessions.db"
+        init_sessions_db(db)
+
+        record = SessionRecord(
+            session_uuid="test-uuid",
+            turn_count=1,
+            tool_call_count=0,
+            tool_failure_count=0,
+            reprompt_count=0,
+            bail_out=False,
+            session_duration_seconds=10.0,
+            working_directory="/tmp",
+            git_branch="main",
+            raw_content_json="[]",
+            input_tokens=0,
+            output_tokens=0,
+            cache_creation_tokens=0,
+            cache_read_tokens=0,
+            fast_mode_turns=0,
+        )
+
+        upsert_session(record, db_path=db, data_dir=tmp_path,
+                        skip_init=True, skip_health=True)
+
+        # health.json should NOT exist
+        health = tmp_path / "health.json"
+        assert not health.exists()
+
+
+# ---------------------------------------------------------------------------
+# Appswitch removal from health check
+# ---------------------------------------------------------------------------
+
+class TestAppswitchRemoved:
+    def test_expected_collectors_excludes_appswitch(self):
+        assert "appswitch_export" not in EXPECTED_COLLECTORS
+        assert "session_parser" in EXPECTED_COLLECTORS
+        assert "github_poller" in EXPECTED_COLLECTORS
+
+    def test_health_check_passes_without_appswitch(self, tmp_path):
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).isoformat()
+        health = {
+            "session_parser": {"last_success": now, "last_record_count": 10},
+            "github_poller": {"last_success": now, "last_record_count": 20},
+        }
+        (data_dir / "health.json").write_text(json.dumps(health))
+
+        healthy, messages = check_health(data_dir=data_dir)
+        assert healthy
+
+
+# ---------------------------------------------------------------------------
+# os.nice() in run.py
+# ---------------------------------------------------------------------------
+
+class TestProcessNice:
+    @patch("collector.github_poller.run.os.nice")
+    @patch("collector.github_poller.run.configure_limiter")
+    def test_nice_called_on_run(self, mock_limiter, mock_nice, tmp_path):
+        from collector.github_poller.run import run
+
+        cfg_path = _write_config(tmp_path, {
+            "session": {"projects_path": str(tmp_path / "projects")},
+            "github": {
+                "repos": ["a/b"],
+                "limiter": {"process_nice_increment": 10},
+            },
+            "data": {"data_dir": str(tmp_path / "data")},
+        })
+
+        with patch("collector.github_poller.run.fetch_issues", return_value=[]), \
+             patch("collector.github_poller.run.fetch_prs", return_value=[]), \
+             patch("collector.github_poller.run.link_sessions", return_value=0):
+            run(config_path=str(cfg_path))
+
+        mock_nice.assert_called_once_with(10)
+
+    @patch("collector.github_poller.run.os.nice", side_effect=OSError("not supported"))
+    @patch("collector.github_poller.run.configure_limiter")
+    def test_nice_failure_does_not_crash(self, mock_limiter, mock_nice, tmp_path):
+        """os.nice() failure is logged but does not abort the run."""
+        from collector.github_poller.run import run
+
+        cfg_path = _write_config(tmp_path, {
+            "session": {"projects_path": str(tmp_path / "projects")},
+            "github": {"repos": ["a/b"]},
+            "data": {"data_dir": str(tmp_path / "data")},
+        })
+
+        with patch("collector.github_poller.run.fetch_issues", return_value=[]), \
+             patch("collector.github_poller.run.fetch_prs", return_value=[]), \
+             patch("collector.github_poller.run.link_sessions", return_value=0):
+            _total, ok = run(config_path=str(cfg_path))
+
+        assert ok is True  # should not fail


### PR DESCRIPTION
## Summary

- Add configurable rate limiting (`inter_request_delay_seconds`), per-repo item caps (`max_items_per_repo`), and `os.nice()` deprioritization to `github_poller` so backfills don't burst GitHub's secondary rate limits or hog the CPU
- Eliminate per-write connection/schema-init overhead in `github_poller/store.py` by passing a single `sqlite3.Connection` through the entire repo processing loop (reduces thousands of open/init/commit/close cycles to one)
- Add batch limiters to `session_parser` (`max_files_per_run`, `inter_file_delay_seconds`) and suppress redundant `init_sessions_db()`/`write_health()` calls in batch mode
- Disable `appswitch` collector (remove from `run_collectors.sh`/`.ps1`, remove from `EXPECTED_COLLECTORS` in health check, comment out in `config.yaml.example`)
- Add `.vscode/tasks.json` with `folderOpen` task that runs collectors with a 4-hour staleness guard

## Test plan

- [x] All 218 existing + new tests pass (15 new tests in `test_limiters.py`)
- [ ] Verify `run_collectors.sh` completes without appswitch errors
- [ ] Verify `python -m am_i_shipping.health_check` returns exit 0 with only session_parser + github_poller
- [ ] Confirm config with no `limiter:` sections uses correct defaults (1.0s delay, 500 items, nice 10, 200 files, 0.05s inter-file)
- [ ] Confirm item cap truncates correctly when fetched items exceed `max_items_per_repo`

Closes #15

Generated with [Claude Code](https://claude.com/claude-code)