### PR TITLE
feat(#35): E-1+E-2 collectors, run.py refactor, backfill script

### DIFF
--- a/am_i_shipping/config_loader.py
+++ b/am_i_shipping/config_loader.py
@@ -43,7 +43,10 @@ class GitHubConfig:
     # Epic #17 — Sub-Issue 2/7 (#35): E-1 (commit data) and E-2 (timeline
     # events) collectors. Both default on; flipping to false turns the new
     # collectors off while leaving the rest of the poll cycle unchanged, as
-    # a rollback lever for the synthesis rollout.
+    # a pause lever for the synthesis rollout. NOTE: this pauses *further*
+    # writes — existing rows in ``commits`` and ``timeline_events`` are NOT
+    # removed by flipping the flag. For a full rollback the operator must
+    # also ``DELETE FROM commits; DELETE FROM timeline_events`` on github.db.
     fetch_commits: bool = True
     fetch_timeline: bool = True
 

--- a/am_i_shipping/config_loader.py
+++ b/am_i_shipping/config_loader.py
@@ -40,6 +40,12 @@ class GitHubConfig:
     repos: List[str]
     backfill_days: int = 90
     limiter: GitHubLimiterConfig = field(default_factory=GitHubLimiterConfig)
+    # Epic #17 — Sub-Issue 2/7 (#35): E-1 (commit data) and E-2 (timeline
+    # events) collectors. Both default on; flipping to false turns the new
+    # collectors off while leaving the rest of the poll cycle unchanged, as
+    # a rollback lever for the synthesis rollout.
+    fetch_commits: bool = True
+    fetch_timeline: bool = True
 
 
 @dataclass
@@ -199,6 +205,12 @@ def load_config(config_path: str | Path | None = None) -> Config:
             github_raw.get("backfill_days", GitHubConfig.backfill_days)
         ),
         limiter=github_limiter,
+        fetch_commits=bool(
+            github_raw.get("fetch_commits", GitHubConfig.fetch_commits)
+        ),
+        fetch_timeline=bool(
+            github_raw.get("fetch_timeline", GitHubConfig.fetch_timeline)
+        ),
     )
 
     # --- appswitch (optional section — defaults are fine) ---

--- a/am_i_shipping/db.py
+++ b/am_i_shipping/db.py
@@ -170,6 +170,13 @@ CREATE TABLE IF NOT EXISTS pr_review_comment_edits (
 #                                 append-only, keyed on (week_start, unit_id))
 # ---------------------------------------------------------------------------
 
+# Note: ``commits.message`` stores the FULL commit message, including the
+# body. Squash-merge commits can embed every sub-commit's message plus the
+# PR body, pushing individual rows into the multi-kilobyte range. This is
+# intentional — the Phase-2 synthesis engine reasons about "why" as well as
+# "what", and truncating at the first newline would lose that signal. If DB
+# size becomes a concern, consider moving long messages to a sidecar table
+# rather than truncating at ingest time.
 SYNTHESIS_COMMITS_SCHEMA = """
 CREATE TABLE IF NOT EXISTS commits (
     repo        TEXT NOT NULL,

--- a/am_i_shipping/scripts/__init__.py
+++ b/am_i_shipping/scripts/__init__.py
@@ -1,0 +1,6 @@
+"""One-shot utility scripts that ship with am-i-shipping.
+
+These modules are invoked manually (``python -m am_i_shipping.scripts.<name>``),
+not from the collector or synthesis pipelines. They are kept here so they
+share the installed package path and its dependencies.
+"""

--- a/am_i_shipping/scripts/backfill_session_timestamps.py
+++ b/am_i_shipping/scripts/backfill_session_timestamps.py
@@ -147,6 +147,13 @@ def _extract_timestamps(jsonl_path: Path) -> Optional[Tuple[str, str]]:
     return timestamps[0].isoformat(), timestamps[-1].isoformat()
 
 
+#: How many UPDATEs to stage before committing. Commits are rarer than
+#: UPDATEs (one fsync each), so a larger batch is faster; but a larger
+#: batch also loses more progress on SIGKILL / machine reboot. 500 balances
+#: wall-clock time and crash resilience for the ~15k-row one-shot workload.
+_COMMIT_BATCH_SIZE = 500
+
+
 def backfill(
     sessions_db: Path,
     projects_path: Path,
@@ -163,6 +170,10 @@ def backfill(
     * ``skipped_no_file`` — rows whose JSONL file could not be found under
       *projects_path* (session log rotated out or machine moved).
     * ``errored`` — rows where the JSONL was located but parsing failed.
+
+    Non-dry-run mode commits to the database every ``_COMMIT_BATCH_SIZE``
+    UPDATEs so that an interruption loses at most one batch worth of
+    progress rather than the entire run.
     """
     if not sessions_db.exists():
         raise FileNotFoundError(f"sessions.db not found: {sessions_db}")
@@ -187,6 +198,7 @@ def backfill(
         updated = 0
         skipped_no_file = 0
         errored = 0
+        pending_in_batch = 0
 
         for session_uuid in targets:
             jsonl = _find_session_file(projects_path, session_uuid, index)
@@ -220,8 +232,15 @@ def backfill(
                 (first_ts, last_ts, session_uuid),
             )
             updated += 1
+            pending_in_batch += 1
 
-        if not dry_run:
+            # Commit in batches to bound crash-loss on long runs.
+            if pending_in_batch >= _COMMIT_BATCH_SIZE:
+                conn.commit()
+                pending_in_batch = 0
+                logger.info("committed batch — {} rows updated so far", updated)
+
+        if not dry_run and pending_in_batch > 0:
             conn.commit()
     finally:
         conn.close()

--- a/am_i_shipping/scripts/backfill_session_timestamps.py
+++ b/am_i_shipping/scripts/backfill_session_timestamps.py
@@ -92,8 +92,15 @@ def _build_session_index(projects_path: Path) -> Dict[str, Path]:
                         # file) are ignored.
                         index.setdefault(sid, jsonl)
                         break
-        except OSError:
-            # Unreadable file — skip and continue; the row stays NULL.
+        except OSError as exc:
+            # Unreadable file — skip and continue; the row stays NULL. Log
+            # so the operator can distinguish "file not found" (row never
+            # enters the index) from "file not readable" (row enters as
+            # skipped_no_file without a reason).
+            logger.warning(
+                "could not read session file {} while building index: {}",
+                jsonl, exc,
+            )
             continue
 
     return index

--- a/am_i_shipping/scripts/backfill_session_timestamps.py
+++ b/am_i_shipping/scripts/backfill_session_timestamps.py
@@ -1,0 +1,273 @@
+"""Backfill ``session_started_at`` / ``session_ended_at`` for historical rows.
+
+Epic #17 — Sub-Issue 2/7 (#35). Sub-Issue 1 landed the two new columns in
+``sessions`` with NULL defaults for every existing row. New inserts populated
+by ``collector.session_parser`` write the timestamps directly, but the
+15,505+ pre-existing rows need a one-shot backfill. This script walks those
+rows, re-opens the JSONL session file that produced each one, and UPDATEs
+only the two timestamp columns in place — every other column (especially
+``raw_content_json``) is left alone.
+
+``raw_content_json`` intentionally strips per-turn timestamps by design (see
+``project_am_i_shipping_design``), so the database column cannot be
+recovered from the SQL row alone. The JSONL file is the single source of
+truth. Rows whose JSONL file is no longer on disk are left with NULL
+timestamps and logged as a warning — a clean exit is preferable to partial
+updates that mask missing data.
+
+Invocation::
+
+    python -m am_i_shipping.scripts.backfill_session_timestamps \
+        [--config path/to/config.yaml] [--dry-run] [--limit N]
+
+``--dry-run`` skips the UPDATE and prints the counts it would have written.
+``--limit`` caps the number of rows processed per invocation (useful for
+smoke-testing on production DBs before a full run).
+
+This is NOT wired into the collector loop; it is run manually exactly once
+per environment. Running it a second time is harmless — rows whose
+timestamps are already populated are skipped by the ``WHERE`` clause.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+from loguru import logger
+
+
+def _find_session_file(
+    projects_path: Path,
+    session_uuid: str,
+    index: Dict[str, Path],
+) -> Optional[Path]:
+    """Return the JSONL file containing *session_uuid*, if one exists.
+
+    Uses a pre-built ``index`` mapping session_uuid -> path. The caller
+    builds the index once per invocation by scanning *projects_path* — this
+    makes the backfill O(total_files + rows_to_update) instead of O(
+    total_files * rows_to_update).
+    """
+    return index.get(session_uuid)
+
+
+def _build_session_index(projects_path: Path) -> Dict[str, Path]:
+    """Scan *projects_path* and build a session_uuid -> file path map.
+
+    Matches the discovery convention used by ``collector.session_parser``:
+    every ``*.jsonl`` under *projects_path* except those under a
+    ``subagents/`` subdirectory.
+
+    Only the first ``sessionId`` found in each file is indexed — sessions
+    never span multiple files in the JSONL format, so this is exact.
+    """
+    if not projects_path.exists():
+        return {}
+
+    index: Dict[str, Path] = {}
+    for jsonl in projects_path.rglob("*.jsonl"):
+        if "subagents" in jsonl.parts:
+            continue
+
+        try:
+            with open(jsonl, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    sid = entry.get("sessionId")
+                    if sid:
+                        # First writer wins; subsequent references (including
+                        # the same session UUID appearing twice in the same
+                        # file) are ignored.
+                        index.setdefault(sid, jsonl)
+                        break
+        except OSError:
+            # Unreadable file — skip and continue; the row stays NULL.
+            continue
+
+    return index
+
+
+def _extract_timestamps(jsonl_path: Path) -> Optional[Tuple[str, str]]:
+    """Return ``(first_ts_iso, last_ts_iso)`` from a JSONL session file.
+
+    Returns ``None`` if the file has zero parseable timestamps (empty session
+    or malformed). The timestamps are taken across **all** entry types, not
+    just user/assistant turns, so the bounds include the initial
+    ``queue-operation`` markers as well — this matches what
+    ``session_parser.parse_session`` now stores.
+    """
+    timestamps = []
+    try:
+        with open(jsonl_path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                ts_str = entry.get("timestamp")
+                if not ts_str:
+                    continue
+                try:
+                    ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                except ValueError:
+                    continue
+                timestamps.append(ts)
+    except OSError:
+        return None
+
+    if not timestamps:
+        return None
+
+    # Preserve the source ordering — JSONL session files are written
+    # append-only so index 0 is first and -1 is last. min/max would be
+    # equivalent on a well-formed file; using the list ends also matches the
+    # behaviour of session_parser.parse_session.
+    return timestamps[0].isoformat(), timestamps[-1].isoformat()
+
+
+def backfill(
+    sessions_db: Path,
+    projects_path: Path,
+    *,
+    dry_run: bool = False,
+    limit: Optional[int] = None,
+) -> Tuple[int, int, int]:
+    """Run the backfill.
+
+    Returns ``(updated, skipped_no_file, errored)``:
+
+    * ``updated`` — rows whose timestamps were (or would be, in dry-run mode)
+      written.
+    * ``skipped_no_file`` — rows whose JSONL file could not be found under
+      *projects_path* (session log rotated out or machine moved).
+    * ``errored`` — rows where the JSONL was located but parsing failed.
+    """
+    if not sessions_db.exists():
+        raise FileNotFoundError(f"sessions.db not found: {sessions_db}")
+
+    logger.info("building session_uuid index under {} ...", projects_path)
+    index = _build_session_index(projects_path)
+    logger.info("indexed {} session files", len(index))
+
+    conn = sqlite3.connect(str(sessions_db))
+    try:
+        query = (
+            "SELECT session_uuid FROM sessions "
+            "WHERE session_started_at IS NULL OR session_ended_at IS NULL"
+        )
+        if limit is not None:
+            query += f" LIMIT {int(limit)}"
+
+        cursor = conn.execute(query)
+        targets = [row[0] for row in cursor.fetchall()]
+        logger.info("{} rows need backfill (limit={})", len(targets), limit)
+
+        updated = 0
+        skipped_no_file = 0
+        errored = 0
+
+        for session_uuid in targets:
+            jsonl = _find_session_file(projects_path, session_uuid, index)
+            if jsonl is None:
+                skipped_no_file += 1
+                logger.debug("no JSONL file for session {}", session_uuid)
+                continue
+
+            stamps = _extract_timestamps(jsonl)
+            if stamps is None:
+                errored += 1
+                logger.warning(
+                    "could not extract timestamps from {} for session {}",
+                    jsonl, session_uuid,
+                )
+                continue
+
+            first_ts, last_ts = stamps
+
+            if dry_run:
+                updated += 1
+                continue
+
+            # UPDATE — and ONLY these two columns. A narrow SET list is the
+            # whole point of this script: every other column (raw_content_json,
+            # token counts, working_directory, ...) is preserved byte-for-byte.
+            conn.execute(
+                "UPDATE sessions "
+                "SET session_started_at = ?, session_ended_at = ? "
+                "WHERE session_uuid = ?",
+                (first_ts, last_ts, session_uuid),
+            )
+            updated += 1
+
+        if not dry_run:
+            conn.commit()
+    finally:
+        conn.close()
+
+    return updated, skipped_no_file, errored
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill session_started_at / session_ended_at columns for "
+            "rows inserted before Epic #17 Sub-Issue 1 landed the schema."
+        )
+    )
+    parser.add_argument(
+        "--config", default=None,
+        help="Path to config.yaml (default: config.yaml in repo root)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print counts without UPDATEing any rows.",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None,
+        help="Cap number of rows processed (for smoke-testing).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    # Deferred import so ``--help`` works even with a broken config.yaml.
+    from am_i_shipping.config_loader import load_config
+
+    config = load_config(args.config)
+    sessions_db = config.data_path / "sessions.db"
+    projects_path = Path(config.session.projects_path)
+
+    updated, skipped, errored = backfill(
+        sessions_db, projects_path,
+        dry_run=args.dry_run,
+        limit=args.limit,
+    )
+
+    mode = "DRY-RUN — " if args.dry_run else ""
+    print(
+        f"{mode}backfill complete: {updated} updated, "
+        f"{skipped} skipped (no JSONL), {errored} errored",
+        file=sys.stderr,
+    )
+    return 0 if errored == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/collector/github_poller/fetch_commits.py
+++ b/collector/github_poller/fetch_commits.py
@@ -29,7 +29,8 @@ and decide what to do with it — persistence happens in ``store.upsert_commit``
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
 
 from .gh_client import GhCliError, gh_api
 
@@ -94,7 +95,7 @@ def fetch_pr_commits(repo: str, pr_number: int) -> List[Dict[str, Any]]:
 def fetch_and_store_pr_commits(
     repo: str,
     pr_number: int,
-    github_db,  # Path; kept untyped to avoid circular Path import cost
+    github_db: Union[str, Path],
     conn=None,
     *,
     commits: Optional[List[Dict[str, Any]]] = None,

--- a/collector/github_poller/fetch_commits.py
+++ b/collector/github_poller/fetch_commits.py
@@ -69,16 +69,21 @@ def fetch_pr_commits(repo: str, pr_number: int) -> List[Dict[str, Any]]:
 
     Returns
     -------
-    A list of normalized commit dicts — empty on API error so the caller can
-    continue processing other PRs.
+    A list of normalized commit dicts.
+
+    Raises
+    ------
+    GhCliError
+        On API error. Callers that want silent-empty behaviour should catch
+        explicitly — historical "return [] on error" was removed because it
+        caused ``count_pushes_after_review`` to collapse push_count to 0
+        indistinguishable from a genuine empty-PR response (see F-2).
+        ``BudgetExhausted`` also propagates.
     """
     owner, name = repo.split("/", 1)
     endpoint = f"/repos/{owner}/{name}/pulls/{pr_number}/commits"
 
-    try:
-        raw = gh_api(endpoint, paginate=True)
-    except GhCliError:
-        return []
+    raw = gh_api(endpoint, paginate=True)
 
     if not isinstance(raw, list):
         return []
@@ -110,6 +115,13 @@ def fetch_and_store_pr_commits(
         If the caller already has the normalized commit list (e.g. from a
         prior ``fetch_pr_commits`` call), it can pass it here and skip the
         network round-trip. Persistence still happens.
+
+    Raises
+    ------
+    GhCliError, BudgetExhausted
+        Propagated from ``fetch_pr_commits`` so the caller can distinguish a
+        transient API failure (retry / fall back) from a genuine zero-commit
+        PR. See F-2.
     """
     # Defer the import so this module can be imported without pulling the full
     # store layer (and its transitive imports) at module load.

--- a/collector/github_poller/fetch_commits.py
+++ b/collector/github_poller/fetch_commits.py
@@ -1,0 +1,131 @@
+"""Fetch per-PR commits for the Phase-2 synthesis engine (Epic #17, E-1).
+
+This module absorbs the ``/repos/{owner}/{repo}/pulls/{number}/commits`` calls
+that ``push_counter.py`` already makes, widening their use so the commits end
+up persisted in ``github.db``. It deliberately does NOT add a repo-wide
+``/repos/{owner}/{repo}/commits`` enumeration — the epic scope requires PR-bound
+commits only so we stay within the existing primary-rate-limit envelope.
+
+The normalized dict returned per commit has this shape::
+
+    {
+        "sha":         str,                 # full commit SHA
+        "author":      Optional[str],       # login, falls back to committer name
+        "authored_at": Optional[str],       # ISO-8601 timestamp from the commit
+        "message":     Optional[str],       # commit message (full, not first line)
+        "pr_number":   int,                 # the PR this commit was fetched for
+        "pushed_at":   Optional[str],       # GitHub's ``commit.committer.date``
+                                            # (commits pushed to the PR after
+                                            # the initial author's authored_at
+                                            # typically have a later committer
+                                            # date, which is our best proxy for
+                                            # a push timestamp without paging
+                                            # PushEvents).
+    }
+
+Consumers (``run.py`` and ``push_counter.py``) take the returned list as-is
+and decide what to do with it — persistence happens in ``store.upsert_commit``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .gh_client import GhCliError, gh_api
+
+
+def _normalize_commit(raw: Dict[str, Any], pr_number: int) -> Dict[str, Any]:
+    """Convert the REST commit shape into the flat dict used by ``store``."""
+    commit_data = raw.get("commit") or {}
+    author_block = commit_data.get("author") or {}
+    committer_block = commit_data.get("committer") or {}
+
+    # Prefer the GitHub login (which is nested under the top-level ``author``
+    # object on the REST response — separate from the commit-metadata author)
+    # and fall back to the name stored inside the commit metadata. Either may
+    # be absent on detached-author commits.
+    login = (raw.get("author") or {}).get("login") if raw.get("author") else None
+    author = login or author_block.get("name")
+
+    return {
+        "sha": raw.get("sha"),
+        "author": author,
+        "authored_at": author_block.get("date"),
+        "message": commit_data.get("message"),
+        "pr_number": pr_number,
+        "pushed_at": committer_block.get("date"),
+    }
+
+
+def fetch_pr_commits(repo: str, pr_number: int) -> List[Dict[str, Any]]:
+    """Fetch commits for a single pull request.
+
+    Parameters
+    ----------
+    repo:
+        GitHub repository in ``owner/repo`` format.
+    pr_number:
+        The pull request number.
+
+    Returns
+    -------
+    A list of normalized commit dicts — empty on API error so the caller can
+    continue processing other PRs.
+    """
+    owner, name = repo.split("/", 1)
+    endpoint = f"/repos/{owner}/{name}/pulls/{pr_number}/commits"
+
+    try:
+        raw = gh_api(endpoint, paginate=True)
+    except GhCliError:
+        return []
+
+    if not isinstance(raw, list):
+        return []
+
+    return [_normalize_commit(c, pr_number) for c in raw if c.get("sha")]
+
+
+def fetch_and_store_pr_commits(
+    repo: str,
+    pr_number: int,
+    github_db,  # Path; kept untyped to avoid circular Path import cost
+    conn=None,
+    *,
+    commits: Optional[List[Dict[str, Any]]] = None,
+) -> List[Dict[str, Any]]:
+    """Fetch commits for *pr_number* and persist each via ``store.upsert_commit``.
+
+    This is the single function ``_poll_repo`` calls when the
+    ``github.fetch_commits`` flag is on. It returns the commit list so the
+    caller can pass it to ``push_counter.count_pushes_after_review`` to avoid a
+    second ``/commits`` round-trip (the ``commits`` kwarg there is the exact
+    same shape this function returns, minus the REST wrapper).
+
+    Parameters
+    ----------
+    repo, pr_number, github_db, conn:
+        Passed through to ``store.upsert_commit``.
+    commits:
+        If the caller already has the normalized commit list (e.g. from a
+        prior ``fetch_pr_commits`` call), it can pass it here and skip the
+        network round-trip. Persistence still happens.
+    """
+    # Defer the import so this module can be imported without pulling the full
+    # store layer (and its transitive imports) at module load.
+    from .store import upsert_commit
+
+    fetched = commits if commits is not None else fetch_pr_commits(repo, pr_number)
+
+    for commit in fetched:
+        if not commit.get("sha"):
+            continue
+        try:
+            upsert_commit(repo, commit, github_db, conn=conn)
+        except ValueError:
+            # Missing required field — skip the row but keep processing the
+            # rest of the list. The fetch-layer normaliser already filters
+            # SHA-less rows, so this is a defence in depth only.
+            continue
+
+    return fetched

--- a/collector/github_poller/fetch_timeline.py
+++ b/collector/github_poller/fetch_timeline.py
@@ -45,64 +45,71 @@ TIMELINE_EVENT_TYPES: tuple[str, ...] = (
 # individual query bodies below ~64 KB and keeps per-call GraphQL cost low.
 _CHUNK_SIZE = 20
 
-# Fragment that the aliased issue blocks all inherit. The per-event-type
-# inline fragments pull only the fields we persist; actor is a viewer-typed
-# union so we go via the shared ``... on User { login }`` path.
-_TIMELINE_FRAGMENT = """
+def _timeline_fragment() -> str:
+    """Build the ``timelineItems`` GraphQL fragment.
+
+    The per-event-type inline fragments pull only the fields we persist;
+    actor is a viewer-typed union so we go via the shared
+    ``... on User { login }`` path. Constructed per-call from
+    ``TIMELINE_EVENT_TYPES`` so that runtime modifications to the tuple
+    (rare, but possible from tests) are honoured.
+    """
+    item_types = ", ".join(TIMELINE_EVENT_TYPES)
+    return f"""
       timelineItems(
         first: 100,
-        itemTypes: [%s]
-      ) {
-        nodes {
+        itemTypes: [{item_types}]
+      ) {{
+        nodes {{
           __typename
-          ... on AssignedEvent {
+          ... on AssignedEvent {{
             id
             createdAt
-            actor { login }
-            assignee { ... on User { login } ... on Bot { login } }
-          }
-          ... on LabeledEvent {
+            actor {{ login }}
+            assignee {{ ... on User {{ login }} ... on Bot {{ login }} }}
+          }}
+          ... on LabeledEvent {{
             id
             createdAt
-            actor { login }
-            label { name }
-          }
-          ... on UnlabeledEvent {
+            actor {{ login }}
+            label {{ name }}
+          }}
+          ... on UnlabeledEvent {{
             id
             createdAt
-            actor { login }
-            label { name }
-          }
-          ... on ClosedEvent {
+            actor {{ login }}
+            label {{ name }}
+          }}
+          ... on ClosedEvent {{
             id
             createdAt
-            actor { login }
+            actor {{ login }}
             stateReason
-          }
-          ... on ReopenedEvent {
+          }}
+          ... on ReopenedEvent {{
             id
             createdAt
-            actor { login }
-          }
-          ... on CrossReferencedEvent {
+            actor {{ login }}
+          }}
+          ... on CrossReferencedEvent {{
             id
             createdAt
-            actor { login }
-            source {
-              ... on Issue { number repository { nameWithOwner } }
-              ... on PullRequest { number repository { nameWithOwner } }
-            }
-          }
-          ... on ReferencedEvent {
+            actor {{ login }}
+            source {{
+              ... on Issue {{ number repository {{ nameWithOwner }} }}
+              ... on PullRequest {{ number repository {{ nameWithOwner }} }}
+            }}
+          }}
+          ... on ReferencedEvent {{
             id
             createdAt
-            actor { login }
-            commit { oid }
-            commitRepository { nameWithOwner }
-          }
-        }
-      }
-""" % ", ".join(TIMELINE_EVENT_TYPES)
+            actor {{ login }}
+            commit {{ oid }}
+            commitRepository {{ nameWithOwner }}
+          }}
+        }}
+      }}
+"""
 
 
 def _build_batch_query(issue_numbers: List[int]) -> str:
@@ -111,12 +118,13 @@ def _build_batch_query(issue_numbers: List[int]) -> str:
     The aliases are ``issue0``, ``issue1``, ... so the caller can map
     alias -> issue number by list position.
     """
+    fragment = _timeline_fragment()
     alias_blocks: List[str] = []
     for i, num in enumerate(issue_numbers):
         alias_blocks.append(
             f"    issue{i}: issue(number: {num}) {{\n"
             f"      number\n"
-            f"{_TIMELINE_FRAGMENT}"
+            f"{fragment}"
             f"    }}"
         )
 
@@ -155,9 +163,17 @@ def _event_id_from_node(node: Dict[str, Any]) -> Optional[int]:
     column is INTEGER so we hash-stabilise it: ``hash(relay_id) & 0x7FFF_FFFF``
     gives us a deterministic positive int without creating a new column.
 
-    Collisions are astronomically unlikely at per-issue scope (typically
-    dozens of events per issue) but if they happen we just UPDATE the row,
-    which is safe because the payload_json still names the original relay id.
+    WARNING: collisions cause data loss, not a "safe UPDATE". A hash collision
+    between two events for the same issue would have them map to the same
+    ``(repo, issue_number, event_id)`` primary key, and the later UPDATE
+    overwrites the earlier event's ``payload_json`` — the earlier event is
+    no longer recoverable from the row because there is no row for it. The
+    31-bit fold is adequate per-issue (dozens of events, collision
+    probability negligible) but the birthday bound over a whole repo is not
+    astronomical. If the repo-wide event count pushes into the hundreds of
+    thousands, this key strategy should be revisited — either widen the
+    column to TEXT and store the raw relay id, or add a separate relay id
+    column with its own UNIQUE constraint.
     """
     raw = node.get("id")
     if raw is None:
@@ -176,14 +192,25 @@ def _normalize_node(issue_number: int, node: Dict[str, Any]) -> Optional[Dict[st
     """Turn one GraphQL timeline node into our persistence shape.
 
     Returns None if the node is missing the minimal fields (no id, no type).
+    Dropped nodes are logged at DEBUG so future GitHub schema drift
+    (a new ``__typename`` that leaks past our ``itemTypes`` filter, or a
+    null id) is observable without flooding the warning log.
     """
     typename = node.get("__typename")
     event_type = _TYPENAME_TO_EVENT_TYPE.get(typename or "")
     if event_type is None:
+        logger.debug(
+            "dropped timeline node for issue #{}: unknown __typename {!r}",
+            issue_number, typename,
+        )
         return None
 
     event_id = _event_id_from_node(node)
     if event_id is None:
+        logger.debug(
+            "dropped timeline node for issue #{}: missing id (__typename={!r})",
+            issue_number, typename,
+        )
         return None
 
     actor = (node.get("actor") or {}).get("login") if node.get("actor") else None

--- a/collector/github_poller/fetch_timeline.py
+++ b/collector/github_poller/fetch_timeline.py
@@ -1,0 +1,305 @@
+"""Fetch issue timeline events for the Phase-2 synthesis engine (Epic #17, E-2).
+
+GraphQL-only: the REST ``/issues/{n}/timeline`` endpoint is preview-API and one
+round-trip per issue, which blows our hourly budget on large backfills. Instead
+this module builds aliased GraphQL queries in chunks of up to 20 issues each,
+mirroring the pattern already used by ``fetch_issues.fetch_issue_edit_history_batch``.
+
+The seven event types we keep are the ones the epic ADR calls out for workflow-
+unit construction (G-1/G-2): ``ASSIGNED_EVENT``, ``LABELED_EVENT``,
+``UNLABELED_EVENT``, ``CLOSED_EVENT``, ``REOPENED_EVENT``,
+``CROSS_REFERENCED_EVENT``, ``REFERENCED_EVENT``. Each has a slightly different
+GraphQL field shape (``CrossReferencedEvent`` nests a source reference,
+``LabeledEvent`` nests the label name, etc.), so we serialise whatever the
+query returned as JSON into ``payload_json`` and let downstream consumers (G-1
+graph builder) parse the subset they care about.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+from loguru import logger
+
+from .gh_client import gh_graphql
+
+
+# ---------------------------------------------------------------------------
+# GraphQL query construction
+# ---------------------------------------------------------------------------
+
+# These are the GraphQL __typename values we keep. A timelineItems(itemTypes:)
+# filter argument takes the raw GraphQL enum form, e.g. ``ASSIGNED_EVENT``.
+TIMELINE_EVENT_TYPES: tuple[str, ...] = (
+    "ASSIGNED_EVENT",
+    "LABELED_EVENT",
+    "UNLABELED_EVENT",
+    "CLOSED_EVENT",
+    "REOPENED_EVENT",
+    "CROSS_REFERENCED_EVENT",
+    "REFERENCED_EVENT",
+)
+
+# Max issues per GraphQL call — matches fetch_issue_edit_history_batch. Keeps
+# individual query bodies below ~64 KB and keeps per-call GraphQL cost low.
+_CHUNK_SIZE = 20
+
+# Fragment that the aliased issue blocks all inherit. The per-event-type
+# inline fragments pull only the fields we persist; actor is a viewer-typed
+# union so we go via the shared ``... on User { login }`` path.
+_TIMELINE_FRAGMENT = """
+      timelineItems(
+        first: 100,
+        itemTypes: [%s]
+      ) {
+        nodes {
+          __typename
+          ... on AssignedEvent {
+            id
+            createdAt
+            actor { login }
+            assignee { ... on User { login } ... on Bot { login } }
+          }
+          ... on LabeledEvent {
+            id
+            createdAt
+            actor { login }
+            label { name }
+          }
+          ... on UnlabeledEvent {
+            id
+            createdAt
+            actor { login }
+            label { name }
+          }
+          ... on ClosedEvent {
+            id
+            createdAt
+            actor { login }
+            stateReason
+          }
+          ... on ReopenedEvent {
+            id
+            createdAt
+            actor { login }
+          }
+          ... on CrossReferencedEvent {
+            id
+            createdAt
+            actor { login }
+            source {
+              ... on Issue { number repository { nameWithOwner } }
+              ... on PullRequest { number repository { nameWithOwner } }
+            }
+          }
+          ... on ReferencedEvent {
+            id
+            createdAt
+            actor { login }
+            commit { oid }
+            commitRepository { nameWithOwner }
+          }
+        }
+      }
+""" % ", ".join(TIMELINE_EVENT_TYPES)
+
+
+def _build_batch_query(issue_numbers: List[int]) -> str:
+    """Build an aliased GraphQL query for a chunk of issue numbers.
+
+    The aliases are ``issue0``, ``issue1``, ... so the caller can map
+    alias -> issue number by list position.
+    """
+    alias_blocks: List[str] = []
+    for i, num in enumerate(issue_numbers):
+        alias_blocks.append(
+            f"    issue{i}: issue(number: {num}) {{\n"
+            f"      number\n"
+            f"{_TIMELINE_FRAGMENT}"
+            f"    }}"
+        )
+
+    return (
+        "query($owner: String!, $name: String!) {\n"
+        "  rateLimit { cost remaining }\n"
+        "  repository(owner: $owner, name: $name) {\n"
+        + "\n".join(alias_blocks)
+        + "\n  }\n}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Node normalisation
+# ---------------------------------------------------------------------------
+
+# Map GraphQL __typename back to the stable string we store in
+# timeline_events.event_type. We use lowercase-with-underscore to match the
+# convention the rest of the collector uses (see README for the rationale —
+# downstream synthesis code pattern-matches on these strings).
+_TYPENAME_TO_EVENT_TYPE: Dict[str, str] = {
+    "AssignedEvent": "assigned",
+    "LabeledEvent": "labeled",
+    "UnlabeledEvent": "unlabeled",
+    "ClosedEvent": "closed",
+    "ReopenedEvent": "reopened",
+    "CrossReferencedEvent": "cross-referenced",
+    "ReferencedEvent": "referenced",
+}
+
+
+def _event_id_from_node(node: Dict[str, Any]) -> Optional[int]:
+    """Extract a stable integer id from a timeline node.
+
+    GraphQL returns ``id`` as a base64 Relay node id (string). Our table
+    column is INTEGER so we hash-stabilise it: ``hash(relay_id) & 0x7FFF_FFFF``
+    gives us a deterministic positive int without creating a new column.
+
+    Collisions are astronomically unlikely at per-issue scope (typically
+    dozens of events per issue) but if they happen we just UPDATE the row,
+    which is safe because the payload_json still names the original relay id.
+    """
+    raw = node.get("id")
+    if raw is None:
+        return None
+    if isinstance(raw, int):
+        return raw
+    # Python's hash() is salted per-process; we want determinism across runs
+    # so the same event maps to the same row. Use a stable fold.
+    h = 0
+    for ch in str(raw):
+        h = (h * 31 + ord(ch)) & 0xFFFFFFFF
+    return h & 0x7FFFFFFF
+
+
+def _normalize_node(issue_number: int, node: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Turn one GraphQL timeline node into our persistence shape.
+
+    Returns None if the node is missing the minimal fields (no id, no type).
+    """
+    typename = node.get("__typename")
+    event_type = _TYPENAME_TO_EVENT_TYPE.get(typename or "")
+    if event_type is None:
+        return None
+
+    event_id = _event_id_from_node(node)
+    if event_id is None:
+        return None
+
+    actor = (node.get("actor") or {}).get("login") if node.get("actor") else None
+
+    return {
+        "issue_number": issue_number,
+        "event_id": event_id,
+        "event_type": event_type,
+        "actor": actor,
+        "created_at": node.get("createdAt"),
+        "payload_json": json.dumps(node, ensure_ascii=False, sort_keys=True),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public fetchers
+# ---------------------------------------------------------------------------
+
+def fetch_issue_timeline_batch(
+    repo: str,
+    issue_numbers: List[int],
+) -> Dict[int, List[Dict[str, Any]]]:
+    """Fetch timeline events for a list of issues.
+
+    Batches through :data:`_CHUNK_SIZE` issues per GraphQL call so a repo with
+    hundreds of issues in the poll window costs ``ceil(n/20)`` GraphQL calls
+    instead of *n* REST calls. GraphQL points are tracked by ``gh_graphql``.
+
+    Parameters
+    ----------
+    repo:
+        GitHub repository in ``owner/repo`` format.
+    issue_numbers:
+        Issue numbers to query. Empty input returns an empty dict.
+
+    Returns
+    -------
+    Mapping of issue_number -> list of normalised event dicts
+    (:func:`_normalize_node` shape). Issues that errored are omitted rather
+    than included with an empty list, so callers can distinguish "we have
+    confirmed no events" from "we never got a response".
+
+    On per-chunk GraphQL errors the chunk is skipped with a warning log and
+    processing continues — the fetcher never raises to its caller so one bad
+    issue cannot take down the whole poll cycle.
+    """
+    if not issue_numbers:
+        return {}
+
+    owner, name = repo.split("/", 1)
+    results: Dict[int, List[Dict[str, Any]]] = {}
+
+    for chunk_start in range(0, len(issue_numbers), _CHUNK_SIZE):
+        chunk = issue_numbers[chunk_start : chunk_start + _CHUNK_SIZE]
+        query = _build_batch_query(chunk)
+
+        try:
+            response = gh_graphql(query, {"owner": owner, "name": name})
+        except Exception as exc:
+            logger.warning(
+                "{}  timeline batch fetch failed for chunk starting at issue #{}: {}",
+                repo, chunk[0], exc,
+            )
+            continue
+
+        if response.get("errors") and not response.get("data"):
+            logger.warning(
+                "{}  timeline GraphQL errors for chunk starting at issue #{}: {}",
+                repo, chunk[0], response.get("errors"),
+            )
+            continue
+
+        repo_data = (response.get("data") or {}).get("repository") or {}
+        for i, num in enumerate(chunk):
+            issue_data = repo_data.get(f"issue{i}")
+            if not issue_data:
+                # Issue may have been deleted / transferred — record an empty
+                # list so the caller knows we attempted the fetch.
+                results[num] = []
+                continue
+
+            nodes = (issue_data.get("timelineItems") or {}).get("nodes") or []
+            events: List[Dict[str, Any]] = []
+            for node in nodes:
+                event = _normalize_node(num, node)
+                if event is not None:
+                    events.append(event)
+            results[num] = events
+
+    return results
+
+
+def fetch_and_store_issue_timelines(
+    repo: str,
+    issue_numbers: List[int],
+    github_db,
+    conn=None,
+) -> Dict[int, List[Dict[str, Any]]]:
+    """Fetch timelines for *issue_numbers* and persist each event.
+
+    This is the function ``_poll_repo`` calls when the
+    ``github.fetch_timeline`` flag is on. Returns the same mapping as
+    :func:`fetch_issue_timeline_batch` so callers can log counts.
+    """
+    from .store import upsert_timeline_event
+
+    timelines = fetch_issue_timeline_batch(repo, issue_numbers)
+
+    for issue_number, events in timelines.items():
+        for event in events:
+            try:
+                upsert_timeline_event(repo, event, github_db, conn=conn)
+            except ValueError as exc:
+                logger.warning(
+                    "{}  skipped timeline event for issue #{}: {}",
+                    repo, issue_number, exc,
+                )
+
+    return timelines

--- a/collector/github_poller/fetch_timeline.py
+++ b/collector/github_poller/fetch_timeline.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, List, Optional
 
 from loguru import logger
 
-from .gh_client import gh_graphql
+from .gh_client import BudgetExhausted, gh_graphql
 
 
 # ---------------------------------------------------------------------------
@@ -242,6 +242,11 @@ def fetch_issue_timeline_batch(
 
         try:
             response = gh_graphql(query, {"owner": owner, "name": name})
+        except BudgetExhausted:
+            # Hourly budget is repo-scoped; re-raise so the outer poll cycle
+            # can stop this repo cleanly rather than logging one warning per
+            # remaining chunk while the budget stays pinned.
+            raise
         except Exception as exc:
             logger.warning(
                 "{}  timeline batch fetch failed for chunk starting at issue #{}: {}",

--- a/collector/github_poller/push_counter.py
+++ b/collector/github_poller/push_counter.py
@@ -3,6 +3,11 @@
 Queries PR commits and reviews via ``gh api``, counts commits pushed
 after the first review event timestamp.  Returns 0 if there are no
 reviews.
+
+Epic #17 — Sub-Issue 2/7 (#35): the ``/commits`` round-trip is now
+shared with ``fetch_commits.fetch_pr_commits``. Callers that already
+pulled commits for persistence pass them via the ``commits`` kwarg so
+this function does not double-spend the API budget.
 """
 
 from __future__ import annotations
@@ -16,6 +21,8 @@ from .gh_client import GhCliError, gh_api
 def count_pushes_after_review(
     repo: str,
     pr_number: int,
+    *,
+    commits: Optional[List[Dict[str, Any]]] = None,
 ) -> int:
     """Count commits pushed after the first review on a PR.
 
@@ -25,6 +32,16 @@ def count_pushes_after_review(
         GitHub repository in ``owner/repo`` format.
     pr_number:
         The pull request number.
+    commits:
+        Optional pre-fetched list of commits. Two shapes are accepted:
+
+        * The raw REST shape ``{"commit": {"committer": {"date": ...}}}``
+          that this module historically fetched itself.
+        * The normalized shape produced by
+          :func:`collector.github_poller.fetch_commits.fetch_pr_commits`:
+          ``{"sha": ..., "pushed_at": ISO-8601, ...}``.
+
+        Supplying either form skips the internal ``/commits`` round-trip.
 
     Returns
     -------
@@ -43,8 +60,9 @@ def count_pushes_after_review(
     if first_review_at is None:
         return 0
 
-    # Fetch commits
-    commits = _fetch_commits(owner, name, pr_number)
+    # Fetch commits only if the caller did not pre-supply them.
+    if commits is None:
+        commits = _fetch_commits(owner, name, pr_number)
     if not commits:
         return 0
 
@@ -93,10 +111,22 @@ def _earliest_review_time(reviews: List[Dict[str, Any]]) -> Optional[datetime]:
 
 
 def _parse_commit_date(commit: Dict[str, Any]) -> Optional[datetime]:
-    """Parse the committer date from a commit object."""
-    commit_data = commit.get("commit", {})
-    committer = commit_data.get("committer", {})
-    date_str = committer.get("date")
+    """Parse the committer date from a commit object.
+
+    Accepts both the raw REST shape (``{"commit": {"committer": {"date": ...}}}``)
+    and the normalised shape from ``fetch_commits.fetch_pr_commits``
+    (``{"pushed_at": ISO-8601}``). Returns ``None`` when neither is present
+    or the timestamp is un-parseable.
+    """
+    # Normalised shape (preferred — this is what run.py now hands in).
+    date_str = commit.get("pushed_at")
+
+    if not date_str:
+        # Fall back to the raw REST shape for the historical no-kwarg path.
+        commit_data = commit.get("commit", {})
+        committer = commit_data.get("committer", {})
+        date_str = committer.get("date")
+
     if not date_str:
         return None
     try:

--- a/collector/github_poller/run.py
+++ b/collector/github_poller/run.py
@@ -7,11 +7,20 @@ For each configured repo:
 4. Derive push-after-review counts
 5. Upsert into github.db
 6. Fetch and store edit history (body + comment edits)
-7. Link PRs to sessions (via head_ref matching)
-8. Advance cursor
+7. Fetch and store per-PR commits (Epic #17 E-1, config-flagged)
+8. Fetch and store issue timeline events (Epic #17 E-2, config-flagged)
+9. Link PRs to sessions (via head_ref matching)
+10. Advance cursor
 
 Writes ``health.json`` only after all repos succeed.  Supports
 ``--dry-run`` flag (fetch and parse, skip all DB writes).
+
+The per-repo orchestration is split into named helpers
+(``_apply_item_cap``, ``_attach_comments``, ``_process_issues``,
+``_process_prs``, ``_fetch_commits_step``, ``_fetch_timeline_step``) so new
+collector stages slot in cleanly. The outer ``_poll_repo`` is a
+sequence-of-steps composition; behavior of the pre-existing steps is
+unchanged from the monolithic version.
 
 Usage:
     python -m collector.github_poller.run [--config path/to/config.yaml] [--dry-run]
@@ -25,16 +34,17 @@ import sqlite3
 import sys
 from datetime import date
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from loguru import logger
 
-from am_i_shipping.config_loader import GitHubLimiterConfig, load_config
+from am_i_shipping.config_loader import GitHubConfig, load_config
 from am_i_shipping.db import init_github_db
 from am_i_shipping.health_writer import write_health
 from am_i_shipping.logging_config import setup_logging
 
 from .cursor import advance_cursor, compute_since, read_cursor
+from .fetch_commits import fetch_and_store_pr_commits
 from .fetch_issues import (
     fetch_issue_comments,
     fetch_issue_edit_history,
@@ -42,6 +52,7 @@ from .fetch_issues import (
     fetch_issues,
 )
 from .fetch_prs import fetch_pr_comments, fetch_pr_edit_history, fetch_pr_review_comments, fetch_prs
+from .fetch_timeline import fetch_and_store_issue_timelines
 from .gh_client import BudgetExhausted, calls_made, configure_limiter, graphql_points_used
 from .link_resolver import resolve_link
 from .push_counter import count_pushes_after_review
@@ -118,11 +129,14 @@ def run(
     sessions_db = data_dir / "sessions.db"
 
     logger.info(
-        "polling {} repos: {} | backfill_days={} max_calls_per_hour={}",
+        "polling {} repos: {} | backfill_days={} max_calls_per_hour={} "
+        "fetch_commits={} fetch_timeline={}",
         len(config.github.repos),
         config.github.repos,
         config.github.backfill_days,
         config.github.limiter.max_calls_per_hour,
+        config.github.fetch_commits,
+        config.github.fetch_timeline,
     )
 
     # Apply resource limiters
@@ -145,6 +159,8 @@ def run(
                 backfill_days=config.github.backfill_days,
                 dry_run=dry_run,
                 max_items_per_repo=limiter.max_items_per_repo,
+                fetch_commits_enabled=config.github.fetch_commits,
+                fetch_timeline_enabled=config.github.fetch_timeline,
             )
             total_records += count
             logger.info("OK: {} — {} records", repo, count)
@@ -165,6 +181,403 @@ def run(
     return total_records, all_succeeded
 
 
+# ---------------------------------------------------------------------------
+# Per-repo pipeline — split into named helpers so new stages slot in cleanly.
+# ---------------------------------------------------------------------------
+
+
+def _apply_item_cap(
+    repo: str,
+    issues: List[Dict[str, Any]],
+    prs: List[Dict[str, Any]],
+    max_items_per_repo: int,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Cap the combined issue+PR count to *max_items_per_repo*.
+
+    Issues take priority — PRs consume whatever capacity remains. Returns the
+    two capped lists. Logs only when a cap is actually applied.
+    """
+    total_fetched = len(issues) + len(prs)
+    if total_fetched <= max_items_per_repo:
+        return issues, prs
+
+    if len(issues) >= max_items_per_repo:
+        capped_issues = issues[:max_items_per_repo]
+        capped_prs: List[Dict[str, Any]] = []
+    else:
+        remaining = max_items_per_repo - len(issues)
+        capped_issues = issues
+        capped_prs = prs[:remaining]
+
+    logger.info(
+        "{}  capped to {} issues + {} PRs (max_items_per_repo={})",
+        repo, len(capped_issues), len(capped_prs), max_items_per_repo,
+    )
+    return capped_issues, capped_prs
+
+
+def _attach_comments(
+    repo: str,
+    issues: List[Dict[str, Any]],
+    prs: List[Dict[str, Any]],
+) -> None:
+    """Fetch and attach comments and review comments in place.
+
+    Budget-exhausted errors propagate up (the poll cycle for this repo aborts);
+    all other errors are logged and the offending item gets empty comments.
+    """
+    for issue in issues:
+        try:
+            issue["comments"] = fetch_issue_comments(repo, issue["number"])
+        except BudgetExhausted as exc:
+            logger.error(
+                "{}  budget exhausted fetching comments for issue #{}: {}",
+                repo, issue["number"], exc,
+            )
+            raise
+        except Exception as exc:
+            logger.warning(
+                "{}  comment fetch error (issue #{}): {}",
+                repo, issue["number"], exc,
+            )
+            issue["comments"] = []
+
+    for pr in prs:
+        try:
+            pr["comments"] = fetch_pr_comments(repo, pr["number"])
+        except BudgetExhausted as exc:
+            logger.error(
+                "{}  budget exhausted fetching comments for PR #{}: {}",
+                repo, pr["number"], exc,
+            )
+            raise
+        except Exception as exc:
+            logger.warning(
+                "{}  comment fetch error (PR #{}): {}",
+                repo, pr["number"], exc,
+            )
+            pr["comments"] = []
+
+        try:
+            review_comments = fetch_pr_review_comments(repo, pr["number"])
+            pr["review_comments"] = review_comments
+            pr["review_comment_count"] = len(review_comments)
+        except BudgetExhausted as exc:
+            logger.error(
+                "{}  budget exhausted fetching review comments for PR #{}: {}",
+                repo, pr["number"], exc,
+            )
+            raise
+        except Exception as exc:
+            logger.warning(
+                "{}  review comment fetch error (PR #{}): {}",
+                repo, pr["number"], exc,
+            )
+            pr["review_comments"] = []
+            pr["review_comment_count"] = 0
+
+
+def _process_issues(
+    repo: str,
+    issues: List[Dict[str, Any]],
+    github_db: Path,
+    conn: sqlite3.Connection,
+    is_backfill: bool,
+) -> None:
+    """Upsert issues and fetch + persist edit history.
+
+    In backfill mode we do a single batched GraphQL call for edit history;
+    in delta mode we fetch per-issue only when ``updated_at`` has changed.
+    """
+    if is_backfill:
+        for issue in issues:
+            upsert_issue(repo, issue, github_db, conn=conn)
+
+        issue_numbers = [issue["number"] for issue in issues]
+        if not issue_numbers:
+            return
+
+        try:
+            batch_results = fetch_issue_edit_history_batch(repo, issue_numbers)
+        except Exception as exc:
+            logger.warning("{}  edit history batch fetch error: {}", repo, exc)
+            batch_results = {}
+
+        for issue_number, edits in batch_results.items():
+            for edit in edits.get("body_edits", []):
+                try:
+                    insert_issue_body_edit(
+                        repo,
+                        issue_number,
+                        edit["edited_at"],
+                        edit.get("diff"),
+                        edit.get("editor"),
+                        github_db,
+                        conn=conn,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "{}  insert issue body edit error (issue #{}): {}",
+                        repo, issue_number, exc,
+                    )
+
+            for edit in edits.get("comment_edits", []):
+                try:
+                    insert_issue_comment_edit(
+                        repo,
+                        issue_number,
+                        edit["comment_id"],
+                        edit["edited_at"],
+                        edit.get("diff"),
+                        edit.get("editor"),
+                        github_db,
+                        conn=conn,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "{}  insert issue comment edit error (issue #{}): {}",
+                        repo, issue_number, exc,
+                    )
+        return
+
+    # Delta: one at a time; only re-fetch edits when updated_at changed.
+    for issue in issues:
+        prev_updated_at = _get_stored_updated_at(
+            "issues", repo, "issue_number", issue["number"], github_db,
+            conn=conn,
+        )
+        upsert_issue(repo, issue, github_db, conn=conn)
+
+        current_updated_at = issue.get("updated_at")
+        if not current_updated_at or current_updated_at == prev_updated_at:
+            continue
+
+        try:
+            edits = fetch_issue_edit_history(repo, issue["number"])
+        except Exception as exc:
+            logger.warning(
+                "{}  edit history fetch error (issue #{}): {}",
+                repo, issue["number"], exc,
+            )
+            continue
+
+        for edit in edits.get("body_edits", []):
+            try:
+                insert_issue_body_edit(
+                    repo,
+                    issue["number"],
+                    edit["edited_at"],
+                    edit.get("diff"),
+                    edit.get("editor"),
+                    github_db,
+                    conn=conn,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "{}  insert issue body edit error (issue #{}): {}",
+                    repo, issue["number"], exc,
+                )
+
+        for edit in edits.get("comment_edits", []):
+            try:
+                insert_issue_comment_edit(
+                    repo,
+                    issue["number"],
+                    edit["comment_id"],
+                    edit["edited_at"],
+                    edit.get("diff"),
+                    edit.get("editor"),
+                    github_db,
+                    conn=conn,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "{}  insert issue comment edit error (issue #{}): {}",
+                    repo, issue["number"], exc,
+                )
+
+
+def _process_prs(
+    repo: str,
+    prs: List[Dict[str, Any]],
+    github_db: Path,
+    conn: sqlite3.Connection,
+    is_backfill: bool,
+    *,
+    fetch_commits_enabled: bool,
+) -> None:
+    """Resolve links, derive push counts, upsert PRs, handle edit history.
+
+    When ``fetch_commits_enabled`` is True the per-PR ``/commits`` round-trip
+    is made once (via ``fetch_commits.fetch_and_store_pr_commits``) and the
+    commit list is passed to ``count_pushes_after_review`` so it does not
+    repeat the call.
+    """
+    for pr in prs:
+        # Resolve PR→issue link
+        linked_issue = resolve_link(
+            head_ref=pr.get("head_ref", ""),
+            body=pr.get("body", ""),
+        )
+
+        # Epic #17 E-1: fetch+persist commits once, reuse for push_count.
+        # This is the *only* place in the pipeline that hits /commits per PR.
+        pre_fetched_commits: Optional[List[Dict[str, Any]]] = None
+        if fetch_commits_enabled:
+            pre_fetched_commits = fetch_and_store_pr_commits(
+                repo, pr["number"], github_db, conn=conn,
+            )
+
+        # Derive push count — reuse commits if we already pulled them, else
+        # fall back to push_counter's own /commits fetch (pre-E1 behaviour).
+        if pre_fetched_commits is not None:
+            push_count = count_pushes_after_review(
+                repo, pr["number"], commits=pre_fetched_commits,
+            )
+        else:
+            push_count = count_pushes_after_review(repo, pr["number"])
+        pr["push_count"] = push_count
+
+        if is_backfill:
+            upsert_pr(repo, pr, github_db, conn=conn)
+        else:
+            # Delta: check updated_at before upsert so we only pull edits on
+            # genuinely changed rows.
+            prev_updated_at = _get_stored_updated_at(
+                "pull_requests", repo, "pr_number", pr["number"], github_db,
+                conn=conn,
+            )
+            upsert_pr(repo, pr, github_db, conn=conn)
+
+            current_updated_at = pr.get("updated_at")
+            if current_updated_at and current_updated_at != prev_updated_at:
+                try:
+                    edits = fetch_pr_edit_history(repo, pr["number"])
+                except Exception as exc:
+                    logger.warning(
+                        "{}  edit history fetch error (PR #{}): {}",
+                        repo, pr["number"], exc,
+                    )
+                else:
+                    _persist_pr_edits(repo, pr["number"], edits, github_db, conn)
+
+        # Insert PR→issue link if resolved
+        if linked_issue is not None:
+            upsert_pr_issue_link(repo, pr["number"], linked_issue, github_db, conn=conn)
+
+    # Backfill: fetch PR edit history in bulk after all upserts
+    if is_backfill and prs:
+        for pr in prs:
+            try:
+                edits = fetch_pr_edit_history(repo, pr["number"])
+            except Exception as exc:
+                logger.warning(
+                    "{}  edit history fetch error (PR #{}): {}",
+                    repo, pr["number"], exc,
+                )
+                continue
+            _persist_pr_edits(repo, pr["number"], edits, github_db, conn)
+
+
+def _persist_pr_edits(
+    repo: str,
+    pr_number: int,
+    edits: Dict[str, Any],
+    github_db: Path,
+    conn: sqlite3.Connection,
+) -> None:
+    """Insert PR body + review comment edits. Split out so both the delta and
+    backfill branches of ``_process_prs`` share one body."""
+    for edit in edits.get("body_edits", []):
+        try:
+            insert_pr_body_edit(
+                repo,
+                pr_number,
+                edit["edited_at"],
+                edit.get("diff"),
+                edit.get("editor"),
+                github_db,
+                conn=conn,
+            )
+        except Exception as exc:
+            logger.warning(
+                "{}  insert PR body edit error (PR #{}): {}",
+                repo, pr_number, exc,
+            )
+
+    for edit in edits.get("review_comment_edits", []):
+        try:
+            insert_pr_review_comment_edit(
+                repo,
+                pr_number,
+                edit["comment_id"],
+                edit["edited_at"],
+                edit.get("diff"),
+                edit.get("editor"),
+                github_db,
+                conn=conn,
+            )
+        except Exception as exc:
+            logger.warning(
+                "{}  insert PR review comment edit error (PR #{}): {}",
+                repo, pr_number, exc,
+            )
+
+
+def _fetch_commits_step(
+    repo: str,
+    prs: List[Dict[str, Any]],
+    github_db: Path,
+    conn: sqlite3.Connection,
+) -> None:
+    """Standalone E-1 fetch step — kept for symmetry with the timeline step.
+
+    In the default flow ``_process_prs`` already calls
+    ``fetch_and_store_pr_commits`` inline so push_counter can reuse the result,
+    so this helper is a no-op on that path. It exists so future refactors
+    (e.g. reordering the DAG so commits fetch before PR upsert) have a named
+    seam to hook into.
+    """
+    # Intentionally empty — the real work happens inside ``_process_prs``
+    # when ``fetch_commits_enabled`` is True. Named seam for future DAG
+    # restructuring; leaving commits out of here avoids double-fetching.
+    return
+
+
+def _fetch_timeline_step(
+    repo: str,
+    issues: List[Dict[str, Any]],
+    github_db: Path,
+    conn: sqlite3.Connection,
+) -> None:
+    """Epic #17 E-2: fetch + persist timeline events for the polled issues."""
+    issue_numbers = [issue["number"] for issue in issues]
+    if not issue_numbers:
+        return
+
+    try:
+        timelines = fetch_and_store_issue_timelines(
+            repo, issue_numbers, github_db, conn=conn,
+        )
+    except BudgetExhausted:
+        # Propagate so the outer run() stops this repo cleanly.
+        raise
+    except Exception as exc:
+        logger.warning("{}  timeline fetch error: {}", repo, exc)
+        return
+
+    total_events = sum(len(v) for v in timelines.values())
+    if total_events:
+        logger.info(
+            "{}  persisted {} timeline events across {} issues",
+            repo, total_events, len(timelines),
+        )
+
+
+# ---------------------------------------------------------------------------
+# _poll_repo — composition of the helpers above.
+# ---------------------------------------------------------------------------
+
 def _poll_repo(
     repo: str,
     github_db: Path,
@@ -172,13 +585,26 @@ def _poll_repo(
     backfill_days: int,
     dry_run: bool,
     max_items_per_repo: int = 500,
+    *,
+    fetch_commits_enabled: bool = True,
+    fetch_timeline_enabled: bool = True,
 ) -> int:
-    """Poll a single repo.  Returns the number of records processed."""
+    """Poll a single repo.  Returns the number of records processed.
+
+    The new ``fetch_commits_enabled`` and ``fetch_timeline_enabled`` kwargs
+    (Epic #17 Sub-Issue 2) gate the new E-1 and E-2 collectors. When either
+    flag is False the corresponding step is skipped entirely — the rest of
+    the poll cycle (issues, PRs, push counter, edit history, session linking)
+    runs exactly as it did before this sub-issue.
+    """
     # 1. Read cursor
     cursor_value = None if dry_run else read_cursor(repo, github_db)
     since = compute_since(cursor_value, backfill_days=backfill_days)
 
-    logger.info("{}  mode={} since={}", repo, 'backfill' if cursor_value is None else 'delta', since)
+    logger.info(
+        "{}  mode={} since={}",
+        repo, 'backfill' if cursor_value is None else 'delta', since,
+    )
 
     # 2. Fetch issues and PRs (without comments — fetched after cap to avoid
     #    wasting API calls on items that will be discarded).
@@ -190,262 +616,49 @@ def _poll_repo(
     if dry_run:
         return len(issues) + len(prs)
 
-    # Apply item cap: issues first, PRs get remaining capacity.
-    total_fetched = len(issues) + len(prs)
-    if total_fetched > max_items_per_repo:
-        if len(issues) >= max_items_per_repo:
-            issues = issues[:max_items_per_repo]
-            prs = []
-        else:
-            remaining = max_items_per_repo - len(issues)
-            prs = prs[:remaining]
-        logger.info(
-            "{}  capped to {} issues + {} PRs (max_items_per_repo={})",
-            repo, len(issues), len(prs), max_items_per_repo,
-        )
+    # 3. Apply item cap.
+    issues, prs = _apply_item_cap(repo, issues, prs, max_items_per_repo)
 
-    # Fetch comments only for the capped set.
-    for issue in issues:
-        try:
-            issue["comments"] = fetch_issue_comments(repo, issue["number"])
-        except BudgetExhausted as exc:
-            logger.error("{}  budget exhausted fetching comments for issue #{}: {}", repo, issue["number"], exc)
-            raise
-        except Exception as exc:
-            logger.warning("{}  comment fetch error (issue #{}): {}", repo, issue["number"], exc)
-            issue["comments"] = []
+    # 4. Fetch comments only for the capped set.
+    _attach_comments(repo, issues, prs)
 
-    for pr in prs:
-        try:
-            pr["comments"] = fetch_pr_comments(repo, pr["number"])
-        except BudgetExhausted as exc:
-            logger.error("{}  budget exhausted fetching comments for PR #{}: {}", repo, pr["number"], exc)
-            raise
-        except Exception as exc:
-            logger.warning("{}  comment fetch error (PR #{}): {}", repo, pr["number"], exc)
-            pr["comments"] = []
-
-        try:
-            review_comments = fetch_pr_review_comments(repo, pr["number"])
-            pr["review_comments"] = review_comments
-            pr["review_comment_count"] = len(review_comments)
-        except BudgetExhausted as exc:
-            logger.error("{}  budget exhausted fetching review comments for PR #{}: {}", repo, pr["number"], exc)
-            raise
-        except Exception as exc:
-            logger.warning("{}  review comment fetch error (PR #{}): {}", repo, pr["number"], exc)
-            pr["review_comments"] = []
-            pr["review_comment_count"] = 0
-
-    # Ensure schema exists (also called by run(), but _poll_repo may be
+    # 5. Ensure schema exists (also called by run(), but _poll_repo may be
     # invoked directly in tests), then open a single connection for all writes.
     init_github_db(github_db)
     conn = sqlite3.connect(str(github_db))
     try:
-        # 3–5. Process and upsert issues
         is_backfill = cursor_value is None
 
-        if is_backfill:
-            # Backfill: upsert all issues first, then batch-fetch edit history
-            for issue in issues:
-                upsert_issue(repo, issue, github_db, conn=conn)
+        # 6. Process issues (upsert + edit history).
+        _process_issues(repo, issues, github_db, conn, is_backfill)
 
-            # Batch-fetch edit history for all issues in chunks of 20
-            issue_numbers = [issue["number"] for issue in issues]
-            if issue_numbers:
-                try:
-                    batch_results = fetch_issue_edit_history_batch(repo, issue_numbers)
-                except Exception as exc:
-                    logger.warning("{}  edit history batch fetch error: {}", repo, exc)
-                    batch_results = {}
+        # 7. Process PRs (link resolution, push counts, upsert, edit history,
+        # and — when enabled — E-1 commit persistence).
+        _process_prs(
+            repo, prs, github_db, conn, is_backfill,
+            fetch_commits_enabled=fetch_commits_enabled,
+        )
 
-                for issue_number, edits in batch_results.items():
-                    for edit in edits.get("body_edits", []):
-                        try:
-                            insert_issue_body_edit(
-                                repo,
-                                issue_number,
-                                edit["edited_at"],
-                                edit.get("diff"),
-                                edit.get("editor"),
-                                github_db,
-                                conn=conn,
-                            )
-                        except Exception as exc:
-                            logger.warning("{}  insert issue body edit error (issue #{}): {}", repo, issue_number, exc)
+        # 8. E-1 standalone step (currently a no-op — commits persisted inline
+        # via ``_process_prs`` so push_counter can reuse them).
+        if fetch_commits_enabled:
+            _fetch_commits_step(repo, prs, github_db, conn)
 
-                    for edit in edits.get("comment_edits", []):
-                        try:
-                            insert_issue_comment_edit(
-                                repo,
-                                issue_number,
-                                edit["comment_id"],
-                                edit["edited_at"],
-                                edit.get("diff"),
-                                edit.get("editor"),
-                                github_db,
-                                conn=conn,
-                            )
-                        except Exception as exc:
-                            logger.warning("{}  insert issue comment edit error (issue #{}): {}", repo, issue_number, exc)
-        else:
-            # Delta: upsert each issue and fetch edit history if updated_at changed
-            for issue in issues:
-                prev_updated_at = _get_stored_updated_at(
-                    "issues", repo, "issue_number", issue["number"], github_db,
-                    conn=conn,
-                )
-                upsert_issue(repo, issue, github_db, conn=conn)
-
-                current_updated_at = issue.get("updated_at")
-                if current_updated_at and current_updated_at != prev_updated_at:
-                    try:
-                        edits = fetch_issue_edit_history(repo, issue["number"])
-                    except Exception as exc:
-                        logger.warning("{}  edit history fetch error (issue #{}): {}", repo, issue["number"], exc)
-                        continue
-
-                    for edit in edits.get("body_edits", []):
-                        try:
-                            insert_issue_body_edit(
-                                repo,
-                                issue["number"],
-                                edit["edited_at"],
-                                edit.get("diff"),
-                                edit.get("editor"),
-                                github_db,
-                                conn=conn,
-                            )
-                        except Exception as exc:
-                            logger.warning("{}  insert issue body edit error (issue #{}): {}", repo, issue["number"], exc)
-
-                    for edit in edits.get("comment_edits", []):
-                        try:
-                            insert_issue_comment_edit(
-                                repo,
-                                issue["number"],
-                                edit["comment_id"],
-                                edit["edited_at"],
-                                edit.get("diff"),
-                                edit.get("editor"),
-                                github_db,
-                                conn=conn,
-                            )
-                        except Exception as exc:
-                            logger.warning("{}  insert issue comment edit error (issue #{}): {}", repo, issue["number"], exc)
-
-        # 3–5. Process PRs: resolve links, derive push counts, upsert, edit history
-        for pr in prs:
-            # Resolve PR→issue link
-            linked_issue = resolve_link(
-                head_ref=pr.get("head_ref", ""),
-                body=pr.get("body", ""),
-            )
-
-            # Derive push count
-            push_count = count_pushes_after_review(repo, pr["number"])
-            pr["push_count"] = push_count
-
-            if is_backfill:
-                # Backfill: upsert without updated_at gating
-                upsert_pr(repo, pr, github_db, conn=conn)
-            else:
-                # Delta: check updated_at before upsert
-                prev_updated_at = _get_stored_updated_at(
-                    "pull_requests", repo, "pr_number", pr["number"], github_db,
-                    conn=conn,
-                )
-                upsert_pr(repo, pr, github_db, conn=conn)
-
-                current_updated_at = pr.get("updated_at")
-                if current_updated_at and current_updated_at != prev_updated_at:
-                    try:
-                        edits = fetch_pr_edit_history(repo, pr["number"])
-                    except Exception as exc:
-                        logger.warning("{}  edit history fetch error (PR #{}): {}", repo, pr["number"], exc)
-                    else:
-                        for edit in edits.get("body_edits", []):
-                            try:
-                                insert_pr_body_edit(
-                                    repo,
-                                    pr["number"],
-                                    edit["edited_at"],
-                                    edit.get("diff"),
-                                    edit.get("editor"),
-                                    github_db,
-                                    conn=conn,
-                                )
-                            except Exception as exc:
-                                logger.warning("{}  insert PR body edit error (PR #{}): {}", repo, pr["number"], exc)
-
-                        for edit in edits.get("review_comment_edits", []):
-                            try:
-                                insert_pr_review_comment_edit(
-                                    repo,
-                                    pr["number"],
-                                    edit["comment_id"],
-                                    edit["edited_at"],
-                                    edit.get("diff"),
-                                    edit.get("editor"),
-                                    github_db,
-                                    conn=conn,
-                                )
-                            except Exception as exc:
-                                logger.warning("{}  insert PR review comment edit error (PR #{}): {}", repo, pr["number"], exc)
-
-            # Insert PR→issue link if resolved
-            if linked_issue is not None:
-                upsert_pr_issue_link(repo, pr["number"], linked_issue, github_db, conn=conn)
-
-        # Backfill: fetch PR edit history in bulk after all upserts
-        if is_backfill and prs:
-            for pr in prs:
-                try:
-                    edits = fetch_pr_edit_history(repo, pr["number"])
-                except Exception as exc:
-                    logger.warning("{}  edit history fetch error (PR #{}): {}", repo, pr["number"], exc)
-                    continue
-
-                for edit in edits.get("body_edits", []):
-                    try:
-                        insert_pr_body_edit(
-                            repo,
-                            pr["number"],
-                            edit["edited_at"],
-                            edit.get("diff"),
-                            edit.get("editor"),
-                            github_db,
-                            conn=conn,
-                        )
-                    except Exception as exc:
-                        logger.warning("{}  insert PR body edit error (PR #{}): {}", repo, pr["number"], exc)
-
-                for edit in edits.get("review_comment_edits", []):
-                    try:
-                        insert_pr_review_comment_edit(
-                            repo,
-                            pr["number"],
-                            edit["comment_id"],
-                            edit["edited_at"],
-                            edit.get("diff"),
-                            edit.get("editor"),
-                            github_db,
-                            conn=conn,
-                        )
-                    except Exception as exc:
-                        logger.warning("{}  insert PR review comment edit error (PR #{}): {}", repo, pr["number"], exc)
+        # 9. E-2 timeline events.
+        if fetch_timeline_enabled:
+            _fetch_timeline_step(repo, issues, github_db, conn)
 
         # Commit all writes for this repo
         conn.commit()
     finally:
         conn.close()
 
-    # 6. Link PRs to sessions
+    # 10. Link PRs to sessions
     session_links = link_sessions(repo, github_db, sessions_db)
     if session_links:
         logger.info("{}  linked {} PR-session pairs", repo, session_links)
 
-    # 7. Advance cursor
+    # 11. Advance cursor
     advance_cursor(repo, github_db)
     logger.info("{}  cursor advanced to {}", repo, date.today().isoformat())
 

--- a/collector/github_poller/run.py
+++ b/collector/github_poller/run.py
@@ -17,10 +17,9 @@ Writes ``health.json`` only after all repos succeed.  Supports
 
 The per-repo orchestration is split into named helpers
 (``_apply_item_cap``, ``_attach_comments``, ``_process_issues``,
-``_process_prs``, ``_fetch_commits_step``, ``_fetch_timeline_step``) so new
-collector stages slot in cleanly. The outer ``_poll_repo`` is a
-sequence-of-steps composition; behavior of the pre-existing steps is
-unchanged from the monolithic version.
+``_process_prs``, ``_fetch_timeline_step``) so new collector stages slot in
+cleanly. The outer ``_poll_repo`` is a sequence-of-steps composition;
+behavior of the pre-existing steps is unchanged from the monolithic version.
 
 Usage:
     python -m collector.github_poller.run [--config path/to/config.yaml] [--dry-run]
@@ -537,26 +536,6 @@ def _persist_pr_edits(
             )
 
 
-def _fetch_commits_step(
-    repo: str,
-    prs: List[Dict[str, Any]],
-    github_db: Path,
-    conn: sqlite3.Connection,
-) -> None:
-    """Standalone E-1 fetch step — kept for symmetry with the timeline step.
-
-    In the default flow ``_process_prs`` already calls
-    ``fetch_and_store_pr_commits`` inline so push_counter can reuse the result,
-    so this helper is a no-op on that path. It exists so future refactors
-    (e.g. reordering the DAG so commits fetch before PR upsert) have a named
-    seam to hook into.
-    """
-    # Intentionally empty — the real work happens inside ``_process_prs``
-    # when ``fetch_commits_enabled`` is True. Named seam for future DAG
-    # restructuring; leaving commits out of here avoids double-fetching.
-    return
-
-
 def _fetch_timeline_step(
     repo: str,
     issues: List[Dict[str, Any]],
@@ -646,18 +625,14 @@ def _poll_repo(
         _process_issues(repo, issues, github_db, conn, is_backfill)
 
         # 7. Process PRs (link resolution, push counts, upsert, edit history,
-        # and — when enabled — E-1 commit persistence).
+        # and — when enabled — E-1 commit persistence inline so push_counter
+        # can reuse the commit list).
         _process_prs(
             repo, prs, github_db, conn, is_backfill,
             fetch_commits_enabled=fetch_commits_enabled,
         )
 
-        # 8. E-1 standalone step (currently a no-op — commits persisted inline
-        # via ``_process_prs`` so push_counter can reuse them).
-        if fetch_commits_enabled:
-            _fetch_commits_step(repo, prs, github_db, conn)
-
-        # 9. E-2 timeline events.
+        # 8. E-2 timeline events.
         if fetch_timeline_enabled:
             _fetch_timeline_step(repo, issues, github_db, conn)
 

--- a/collector/github_poller/run.py
+++ b/collector/github_poller/run.py
@@ -53,7 +53,7 @@ from .fetch_issues import (
 )
 from .fetch_prs import fetch_pr_comments, fetch_pr_edit_history, fetch_pr_review_comments, fetch_prs
 from .fetch_timeline import fetch_and_store_issue_timelines
-from .gh_client import BudgetExhausted, calls_made, configure_limiter, graphql_points_used
+from .gh_client import BudgetExhausted, GhCliError, calls_made, configure_limiter, graphql_points_used
 from .link_resolver import resolve_link
 from .push_counter import count_pushes_after_review
 from .session_linker import link_sessions
@@ -422,14 +422,27 @@ def _process_prs(
 
         # Epic #17 E-1: fetch+persist commits once, reuse for push_count.
         # This is the *only* place in the pipeline that hits /commits per PR.
+        # If fetch_commits raises (transient GhCliError), we fall back to the
+        # pre-E1 path of letting push_counter do its own /commits fetch — that
+        # preserves push_count fidelity rather than collapsing to 0 on a flaky
+        # API call (see F-2). BudgetExhausted is not caught so it propagates.
         pre_fetched_commits: Optional[List[Dict[str, Any]]] = None
         if fetch_commits_enabled:
-            pre_fetched_commits = fetch_and_store_pr_commits(
-                repo, pr["number"], github_db, conn=conn,
-            )
+            try:
+                pre_fetched_commits = fetch_and_store_pr_commits(
+                    repo, pr["number"], github_db, conn=conn,
+                )
+            except GhCliError as exc:
+                logger.warning(
+                    "{}  fetch_commits failed (PR #{}): {} — falling back to "
+                    "push_counter self-fetch",
+                    repo, pr["number"], exc,
+                )
+                pre_fetched_commits = None
 
         # Derive push count — reuse commits if we already pulled them, else
         # fall back to push_counter's own /commits fetch (pre-E1 behaviour).
+        # push_count is consumed by upsert_pr below via pr["push_count"].
         if pre_fetched_commits is not None:
             push_count = count_pushes_after_review(
                 repo, pr["number"], commits=pre_fetched_commits,

--- a/collector/github_poller/store.py
+++ b/collector/github_poller/store.py
@@ -295,3 +295,148 @@ def insert_pr_review_comment_edit(
     finally:
         if own_conn:
             conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Epic #17 — Sub-Issue 2/7 (#35): synthesis-table upserts
+# ---------------------------------------------------------------------------
+#
+# ``commits`` and ``timeline_events`` rows are keyed on natural identifiers
+# (``(repo, sha)`` and ``(repo, issue_number, event_id)`` respectively), so
+# ``INSERT OR REPLACE`` is safe and idempotent — re-polling a PR that already
+# has its commits in the table updates the message / pushed_at fields in place
+# without creating duplicates. The same semantics hold for timeline events.
+
+
+def upsert_commit(
+    repo: str,
+    commit: Dict[str, Any],
+    db_path: Union[str, Path],
+    conn: Optional[sqlite3.Connection] = None,
+) -> None:
+    """Insert or update a single commit row.
+
+    Parameters
+    ----------
+    repo:
+        GitHub repository in ``owner/repo`` format.
+    commit:
+        Dict with keys: ``sha`` (required), ``author``, ``authored_at``,
+        ``message``, ``pr_number``, ``pushed_at``. Missing optional keys are
+        stored as NULL.
+    db_path, conn:
+        Same conventions as :func:`upsert_pr` — if *conn* is given the caller
+        owns the lifecycle.
+
+    Raises
+    ------
+    ValueError
+        If *repo* or *commit["sha"]* is missing.
+    """
+    if not repo:
+        raise ValueError("repo is required")
+    sha = commit.get("sha")
+    if not sha:
+        raise ValueError("commit sha is required")
+
+    own_conn = conn is None
+    if own_conn:
+        db_path = Path(db_path)
+        conn = _connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO commits (
+                repo, sha, author, authored_at, message, pr_number, pushed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(repo, sha) DO UPDATE SET
+                author      = excluded.author,
+                authored_at = excluded.authored_at,
+                message     = excluded.message,
+                pr_number   = excluded.pr_number,
+                pushed_at   = excluded.pushed_at
+            """,
+            (
+                repo,
+                sha,
+                commit.get("author"),
+                commit.get("authored_at"),
+                commit.get("message"),
+                commit.get("pr_number"),
+                commit.get("pushed_at"),
+            ),
+        )
+        if own_conn:
+            conn.commit()
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def upsert_timeline_event(
+    repo: str,
+    event: Dict[str, Any],
+    db_path: Union[str, Path],
+    conn: Optional[sqlite3.Connection] = None,
+) -> None:
+    """Insert or update a single timeline event row.
+
+    Parameters
+    ----------
+    repo:
+        GitHub repository in ``owner/repo`` format.
+    event:
+        Dict with keys: ``issue_number`` (required), ``event_id`` (required),
+        ``event_type``, ``actor``, ``created_at``, ``payload_json``. Missing
+        optional keys are stored as NULL; ``payload_json`` is expected to be a
+        JSON string already (the fetcher serializes GraphQL payloads before
+        handing them off).
+    db_path, conn:
+        Same conventions as :func:`upsert_pr`.
+
+    Raises
+    ------
+    ValueError
+        If *repo*, *event["issue_number"]*, or *event["event_id"]* is missing.
+    """
+    if not repo:
+        raise ValueError("repo is required")
+    issue_number = event.get("issue_number")
+    if issue_number is None:
+        raise ValueError("issue_number is required")
+    event_id = event.get("event_id")
+    if event_id is None:
+        raise ValueError("event_id is required")
+
+    own_conn = conn is None
+    if own_conn:
+        db_path = Path(db_path)
+        conn = _connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO timeline_events (
+                repo, issue_number, event_id, event_type,
+                actor, created_at, payload_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(repo, issue_number, event_id) DO UPDATE SET
+                event_type   = excluded.event_type,
+                actor        = excluded.actor,
+                created_at   = excluded.created_at,
+                payload_json = excluded.payload_json
+            """,
+            (
+                repo,
+                issue_number,
+                event_id,
+                event.get("event_type"),
+                event.get("actor"),
+                event.get("created_at"),
+                event.get("payload_json"),
+            ),
+        )
+        if own_conn:
+            conn.commit()
+    finally:
+        if own_conn:
+            conn.close()

--- a/collector/session_parser.py
+++ b/collector/session_parser.py
@@ -51,6 +51,13 @@ class SessionRecord:
     cache_creation_tokens: int
     cache_read_tokens: int
     fast_mode_turns: int
+    # Epic #17 — Sub-Issue 2 (Decision 1): synthesis-layer session anchors.
+    # ``session_started_at`` is the first timestamp observed in the JSONL
+    # (across all entry types), and ``session_ended_at`` is the last. Both
+    # are ISO-8601 strings with tzinfo offset preserved from the source, or
+    # ``None`` when no timestamps were parsed (malformed or ancient session).
+    session_started_at: Optional[str] = None
+    session_ended_at: Optional[str] = None
 
 
 def _git_branch_from_dir(cwd: str) -> Optional[str]:
@@ -245,6 +252,19 @@ def parse_session(filepath: str | Path, threshold: int = 3) -> SessionRecord:
     if len(timestamps) >= 2:
         duration = (timestamps[-1] - timestamps[0]).total_seconds()
 
+    # Session timestamp anchors for Phase-2 synthesis (Epic #17 Decision 1).
+    # We intentionally use ``timestamps`` unsorted — they're appended in file
+    # order, which is already wall-clock ascending. Even if they were not,
+    # taking min/max would be equivalent. Falling back to None when the file
+    # had no timestamped entries keeps the column NULL-able and matches the
+    # schema default set in db.py.
+    if timestamps:
+        session_started_at = timestamps[0].isoformat()
+        session_ended_at = timestamps[-1].isoformat()
+    else:
+        session_started_at = None
+        session_ended_at = None
+
     # Detect reprompts
     reprompt_count, bail_out = detect_reprompts(
         messages, threshold=threshold
@@ -268,6 +288,8 @@ def parse_session(filepath: str | Path, threshold: int = 3) -> SessionRecord:
         cache_creation_tokens=cache_creation_tokens,
         cache_read_tokens=cache_read_tokens,
         fast_mode_turns=fast_mode_turns,
+        session_started_at=session_started_at,
+        session_ended_at=session_ended_at,
     )
 
 

--- a/collector/store.py
+++ b/collector/store.py
@@ -72,8 +72,9 @@ def upsert_session(
                 session_duration_seconds, working_directory,
                 git_branch, raw_content_json,
                 input_tokens, output_tokens, cache_creation_tokens,
-                cache_read_tokens, fast_mode_turns
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                cache_read_tokens, fast_mode_turns,
+                session_started_at, session_ended_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(session_uuid) DO UPDATE SET
                 turn_count = excluded.turn_count,
                 tool_call_count = excluded.tool_call_count,
@@ -88,7 +89,9 @@ def upsert_session(
                 output_tokens = excluded.output_tokens,
                 cache_creation_tokens = excluded.cache_creation_tokens,
                 cache_read_tokens = excluded.cache_read_tokens,
-                fast_mode_turns = excluded.fast_mode_turns
+                fast_mode_turns = excluded.fast_mode_turns,
+                session_started_at = excluded.session_started_at,
+                session_ended_at = excluded.session_ended_at
             """,
             (
                 record.session_uuid,
@@ -106,6 +109,8 @@ def upsert_session(
                 record.cache_creation_tokens,
                 record.cache_read_tokens,
                 record.fast_mode_turns,
+                record.session_started_at,
+                record.session_ended_at,
             ),
         )
         conn.commit()

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -58,6 +58,23 @@ github:
     # no other tooling competes for the same quota.
     max_calls_per_hour: 2500
 
+  # -----------------------------------------------------------------
+  # Epic #17 — Phase-2 synthesis collectors (E-1 + E-2)
+  # -----------------------------------------------------------------
+  # Both default ON. Set to false to roll back to Phase-1 behaviour —
+  # the rest of the poll cycle is unaffected.
+  #
+  #   fetch_commits  — per-PR commit data (E-1). Required for the
+  #                    workflow-unit graph builder (#36) and downstream
+  #                    synthesis. Shares the per-PR /commits call with
+  #                    push_counter, so enabling costs no extra API
+  #                    quota vs. Phase-1.
+  #   fetch_timeline — issue timeline events (E-2). Assigned, labeled,
+  #                    unlabeled, closed, reopened, cross-referenced,
+  #                    referenced. GraphQL aliased batches of 20.
+  # fetch_commits: true
+  # fetch_timeline: true
+
 # -------------------------------------------------------------------
 # App-switch logger (Collector 3) — DISABLED
 # Uncomment to re-enable. Code remains in collector/appswitch/.

--- a/tests/test_backfill_session_timestamps.py
+++ b/tests/test_backfill_session_timestamps.py
@@ -1,0 +1,248 @@
+"""Tests for am_i_shipping/scripts/backfill_session_timestamps.py.
+
+Epic #17 Sub-Issue 2 (#35). Verifies the one-shot backfill populates the
+two timestamp columns for rows that pre-date the schema addition, without
+touching any other column.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from am_i_shipping.db import init_sessions_db
+from am_i_shipping.scripts.backfill_session_timestamps import (
+    _build_session_index,
+    _extract_timestamps,
+    backfill,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _write_jsonl(path: Path, session_uuid: str, timestamps: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = []
+    for i, ts in enumerate(timestamps):
+        lines.append(json.dumps({
+            "sessionId": session_uuid,
+            "type": "user" if i % 2 == 0 else "assistant",
+            "timestamp": ts,
+            "message": {"role": "user", "content": "x"},
+        }))
+    path.write_text("\n".join(lines) + "\n")
+
+
+def _insert_bare_session(db: Path, session_uuid: str) -> None:
+    """Insert a session row with NULL timestamp columns."""
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute(
+            """
+            INSERT INTO sessions (
+                session_uuid, turn_count, tool_call_count, tool_failure_count,
+                reprompt_count, bail_out, session_duration_seconds,
+                working_directory, git_branch, raw_content_json,
+                input_tokens, output_tokens, cache_creation_tokens,
+                cache_read_tokens, fast_mode_turns
+            ) VALUES (?, 1, 0, 0, 0, 0, 0.0, NULL, NULL, '[]', 0, 0, 0, 0, 0)
+            """,
+            (session_uuid,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSessionIndex:
+    def test_indexes_session_files(self, tmp_path):
+        projects = tmp_path / "projects"
+        _write_jsonl(
+            projects / "proj-1" / "sess-a.jsonl",
+            "aaaa-1111",
+            ["2024-01-15T10:00:00Z", "2024-01-15T10:30:00Z"],
+        )
+        _write_jsonl(
+            projects / "proj-2" / "sess-b.jsonl",
+            "bbbb-2222",
+            ["2024-02-15T10:00:00Z"],
+        )
+        # Subagent file — should be excluded.
+        _write_jsonl(
+            projects / "proj-1" / "subagents" / "sub.jsonl",
+            "cccc-3333",
+            ["2024-03-15T10:00:00Z"],
+        )
+
+        index = _build_session_index(projects)
+        assert "aaaa-1111" in index
+        assert "bbbb-2222" in index
+        assert "cccc-3333" not in index
+        assert index["aaaa-1111"].name == "sess-a.jsonl"
+
+    def test_missing_projects_path_returns_empty(self, tmp_path):
+        assert _build_session_index(tmp_path / "nope") == {}
+
+
+class TestExtractTimestamps:
+    def test_first_and_last(self, tmp_path):
+        f = tmp_path / "sess.jsonl"
+        _write_jsonl(
+            f, "uid",
+            ["2024-01-15T10:00:00Z", "2024-01-15T10:05:00Z", "2024-01-15T10:30:00Z"],
+        )
+        stamps = _extract_timestamps(f)
+        assert stamps is not None
+        first, last = stamps
+        assert first.startswith("2024-01-15T10:00")
+        assert last.startswith("2024-01-15T10:30")
+
+    def test_no_timestamps_returns_none(self, tmp_path):
+        f = tmp_path / "sess.jsonl"
+        f.write_text(json.dumps({"sessionId": "x"}) + "\n")
+        assert _extract_timestamps(f) is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end backfill
+# ---------------------------------------------------------------------------
+
+
+class TestBackfill:
+    def test_populates_timestamps_without_touching_other_columns(self, tmp_path):
+        projects = tmp_path / "projects"
+        _write_jsonl(
+            projects / "p" / "sess.jsonl",
+            "uuid-aaaa",
+            ["2024-05-01T00:00:00Z", "2024-05-01T01:00:00Z"],
+        )
+
+        db = tmp_path / "sessions.db"
+        init_sessions_db(db)
+        _insert_bare_session(db, "uuid-aaaa")
+
+        # Capture the "other" column values before running the backfill.
+        conn = sqlite3.connect(str(db))
+        before = conn.execute(
+            "SELECT turn_count, raw_content_json, input_tokens "
+            "FROM sessions WHERE session_uuid = 'uuid-aaaa'"
+        ).fetchone()
+        conn.close()
+
+        updated, skipped, errored = backfill(db, projects)
+        assert updated == 1
+        assert skipped == 0
+        assert errored == 0
+
+        conn = sqlite3.connect(str(db))
+        row = conn.execute(
+            "SELECT session_started_at, session_ended_at, "
+            "turn_count, raw_content_json, input_tokens "
+            "FROM sessions WHERE session_uuid = 'uuid-aaaa'"
+        ).fetchone()
+        conn.close()
+
+        assert row[0].startswith("2024-05-01T00:00")
+        assert row[1].startswith("2024-05-01T01:00")
+        # Every other column unchanged.
+        assert (row[2], row[3], row[4]) == before
+
+    def test_already_populated_rows_are_skipped(self, tmp_path):
+        projects = tmp_path / "projects"
+        _write_jsonl(
+            projects / "p" / "sess.jsonl",
+            "uuid-aaaa",
+            ["2024-05-01T00:00:00Z", "2024-05-01T01:00:00Z"],
+        )
+
+        db = tmp_path / "sessions.db"
+        init_sessions_db(db)
+
+        # Insert a row that already has timestamps.
+        conn = sqlite3.connect(str(db))
+        conn.execute(
+            """
+            INSERT INTO sessions (
+                session_uuid, turn_count, tool_call_count, tool_failure_count,
+                reprompt_count, bail_out, session_duration_seconds,
+                working_directory, git_branch, raw_content_json,
+                input_tokens, output_tokens, cache_creation_tokens,
+                cache_read_tokens, fast_mode_turns,
+                session_started_at, session_ended_at
+            ) VALUES (?, 1, 0, 0, 0, 0, 0.0, NULL, NULL, '[]', 0, 0, 0, 0, 0,
+                      ?, ?)
+            """,
+            ("uuid-aaaa", "pre-existing", "pre-existing"),
+        )
+        conn.commit()
+        conn.close()
+
+        updated, skipped, errored = backfill(db, projects)
+        assert updated == 0
+        assert skipped == 0
+        assert errored == 0
+
+    def test_missing_jsonl_skipped_not_errored(self, tmp_path):
+        projects = tmp_path / "projects"
+        projects.mkdir(parents=True)
+
+        db = tmp_path / "sessions.db"
+        init_sessions_db(db)
+        _insert_bare_session(db, "orphan-uuid")
+
+        updated, skipped, errored = backfill(db, projects)
+        assert updated == 0
+        assert skipped == 1
+        assert errored == 0
+
+    def test_dry_run_does_not_write(self, tmp_path):
+        projects = tmp_path / "projects"
+        _write_jsonl(
+            projects / "p" / "sess.jsonl",
+            "uuid-aaaa",
+            ["2024-05-01T00:00:00Z", "2024-05-01T01:00:00Z"],
+        )
+
+        db = tmp_path / "sessions.db"
+        init_sessions_db(db)
+        _insert_bare_session(db, "uuid-aaaa")
+
+        updated, skipped, errored = backfill(db, projects, dry_run=True)
+        assert updated == 1
+
+        conn = sqlite3.connect(str(db))
+        row = conn.execute(
+            "SELECT session_started_at, session_ended_at "
+            "FROM sessions WHERE session_uuid = 'uuid-aaaa'"
+        ).fetchone()
+        conn.close()
+        # Still NULL — dry-run did not write.
+        assert row == (None, None)
+
+    def test_limit_caps_rows(self, tmp_path):
+        projects = tmp_path / "projects"
+        db = tmp_path / "sessions.db"
+        init_sessions_db(db)
+
+        for i in range(5):
+            uid = f"uuid-{i}"
+            _write_jsonl(
+                projects / "p" / f"{uid}.jsonl",
+                uid,
+                ["2024-05-01T00:00:00Z", "2024-05-01T01:00:00Z"],
+            )
+            _insert_bare_session(db, uid)
+
+        updated, skipped, errored = backfill(db, projects, limit=2)
+        assert updated == 2

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -238,3 +238,35 @@ class TestSynthesisConfig:
         cfg = load_config(cfg_path)
         assert cfg.synthesis.output_dir == "weekly-retros"
         assert cfg.synthesis.model == "claude-sonnet-4-5"
+
+
+class TestEpic17FetchFlags:
+    """Epic #17 Sub-Issue 2 (#35): E-1 / E-2 config flags."""
+
+    def test_fetch_flags_default_true(self, tmp_path):
+        cfg_path = _write_config(tmp_path, {
+            "session": {"projects_path": "/path"},
+            "github": {"repos": ["a/b"]},
+        })
+        cfg = load_config(cfg_path)
+        assert cfg.github.fetch_commits is True
+        assert cfg.github.fetch_timeline is True
+
+    def test_fetch_commits_false_disables_e1(self, tmp_path):
+        cfg_path = _write_config(tmp_path, {
+            "session": {"projects_path": "/path"},
+            "github": {"repos": ["a/b"], "fetch_commits": False},
+        })
+        cfg = load_config(cfg_path)
+        assert cfg.github.fetch_commits is False
+        # fetch_timeline still defaults on.
+        assert cfg.github.fetch_timeline is True
+
+    def test_fetch_timeline_false_disables_e2(self, tmp_path):
+        cfg_path = _write_config(tmp_path, {
+            "session": {"projects_path": "/path"},
+            "github": {"repos": ["a/b"], "fetch_timeline": False},
+        })
+        cfg = load_config(cfg_path)
+        assert cfg.github.fetch_commits is True
+        assert cfg.github.fetch_timeline is False

--- a/tests/test_fetch_commits.py
+++ b/tests/test_fetch_commits.py
@@ -1,0 +1,203 @@
+"""Tests for collector/github_poller/fetch_commits.py (Epic #17, E-1).
+
+Uses fixture data and mocked ``gh_api`` — no live network calls.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from am_i_shipping.db import init_github_db
+from collector.github_poller.fetch_commits import (
+    _normalize_commit,
+    fetch_and_store_pr_commits,
+    fetch_pr_commits,
+)
+from collector.github_poller.gh_client import GhCliError
+
+
+# ---------------------------------------------------------------------------
+# Fixture data — the raw REST shape that gh api returns for /pulls/{n}/commits.
+# ---------------------------------------------------------------------------
+
+REST_COMMITS_FIXTURE = [
+    {
+        "sha": "aaaa1111",
+        "commit": {
+            "message": "initial commit",
+            "author": {
+                "name": "Alice Author",
+                "date": "2024-01-19T10:00:00Z",
+            },
+            "committer": {
+                "name": "Alice Author",
+                "date": "2024-01-19T10:00:00Z",
+            },
+        },
+        "author": {"login": "alice"},
+    },
+    {
+        "sha": "bbbb2222",
+        "commit": {
+            "message": "address review feedback",
+            "author": {
+                "name": "Bob Bytes",
+                "date": "2024-01-20T14:00:00Z",
+            },
+            "committer": {
+                "name": "Bob Bytes",
+                "date": "2024-01-20T14:00:00Z",
+            },
+        },
+        "author": {"login": "bob"},
+    },
+    # A detached-author commit: no top-level "author" key with login.
+    {
+        "sha": "cccc3333",
+        "commit": {
+            "message": "cherry-pick",
+            "author": {
+                "name": "Charlie Cherry",
+                "date": "2024-01-21T09:00:00Z",
+            },
+            "committer": {
+                "name": "GitHub",
+                "date": "2024-01-21T09:00:00Z",
+            },
+        },
+        "author": None,
+    },
+]
+
+
+class TestNormalizeCommit:
+    def test_normalize_prefers_login(self):
+        normalized = _normalize_commit(REST_COMMITS_FIXTURE[0], pr_number=1)
+        assert normalized["sha"] == "aaaa1111"
+        assert normalized["author"] == "alice"
+        assert normalized["authored_at"] == "2024-01-19T10:00:00Z"
+        assert normalized["message"] == "initial commit"
+        assert normalized["pr_number"] == 1
+        assert normalized["pushed_at"] == "2024-01-19T10:00:00Z"
+
+    def test_normalize_falls_back_to_commit_author_name(self):
+        """When the top-level author.login is missing, use commit.author.name."""
+        normalized = _normalize_commit(REST_COMMITS_FIXTURE[2], pr_number=7)
+        assert normalized["author"] == "Charlie Cherry"
+
+
+class TestFetchPrCommits:
+    @patch("collector.github_poller.fetch_commits.gh_api")
+    def test_returns_normalized_list(self, mock_api):
+        mock_api.return_value = REST_COMMITS_FIXTURE
+        result = fetch_pr_commits("owner/repo", 42)
+
+        assert len(result) == 3
+        # Verify the correct endpoint was called with pagination
+        args, kwargs = mock_api.call_args
+        assert args[0] == "/repos/owner/repo/pulls/42/commits"
+        assert kwargs.get("paginate") is True
+        # Every row carries the pr_number
+        assert all(c["pr_number"] == 42 for c in result)
+        # SHAs preserved
+        assert [c["sha"] for c in result] == ["aaaa1111", "bbbb2222", "cccc3333"]
+
+    @patch("collector.github_poller.fetch_commits.gh_api")
+    def test_api_error_returns_empty(self, mock_api):
+        mock_api.side_effect = GhCliError(["gh", "api"], 1, "boom")
+        assert fetch_pr_commits("owner/repo", 1) == []
+
+    @patch("collector.github_poller.fetch_commits.gh_api")
+    def test_non_list_response_returns_empty(self, mock_api):
+        mock_api.return_value = {"unexpected": "object"}
+        assert fetch_pr_commits("owner/repo", 1) == []
+
+    @patch("collector.github_poller.fetch_commits.gh_api")
+    def test_skips_rows_without_sha(self, mock_api):
+        mock_api.return_value = [
+            {"commit": {"author": {"date": "2024-01-01T00:00:00Z"}}},  # no sha
+            REST_COMMITS_FIXTURE[0],
+        ]
+        result = fetch_pr_commits("owner/repo", 1)
+        assert len(result) == 1
+        assert result[0]["sha"] == "aaaa1111"
+
+
+class TestFetchAndStorePrCommits:
+    @patch("collector.github_poller.fetch_commits.gh_api")
+    def test_persists_each_commit(self, mock_api, tmp_path):
+        mock_api.return_value = REST_COMMITS_FIXTURE
+        db = tmp_path / "github.db"
+        init_github_db(db)
+
+        returned = fetch_and_store_pr_commits("owner/repo", 42, db)
+        assert len(returned) == 3
+
+        conn = sqlite3.connect(str(db))
+        try:
+            rows = conn.execute(
+                "SELECT sha, pr_number, author FROM commits "
+                "WHERE repo = 'owner/repo' ORDER BY sha"
+            ).fetchall()
+        finally:
+            conn.close()
+
+        assert rows == [
+            ("aaaa1111", 42, "alice"),
+            ("bbbb2222", 42, "bob"),
+            ("cccc3333", 42, "Charlie Cherry"),
+        ]
+
+    @patch("collector.github_poller.fetch_commits.gh_api")
+    def test_idempotent_double_store(self, mock_api, tmp_path):
+        """Running twice produces the same row count — ON CONFLICT DO UPDATE."""
+        mock_api.return_value = REST_COMMITS_FIXTURE
+        db = tmp_path / "github.db"
+        init_github_db(db)
+
+        fetch_and_store_pr_commits("owner/repo", 42, db)
+        fetch_and_store_pr_commits("owner/repo", 42, db)
+
+        conn = sqlite3.connect(str(db))
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM commits WHERE repo = 'owner/repo'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert count == 3
+
+    def test_skips_fetch_when_commits_supplied(self, tmp_path):
+        """If the caller already has the commits, no gh_api call is made."""
+        db = tmp_path / "github.db"
+        init_github_db(db)
+
+        pre_fetched = [
+            {
+                "sha": "ffff0000",
+                "author": "external",
+                "authored_at": "2024-02-01T00:00:00Z",
+                "message": "pre-fetched",
+                "pr_number": 99,
+                "pushed_at": "2024-02-01T00:00:00Z",
+            },
+        ]
+
+        with patch("collector.github_poller.fetch_commits.gh_api") as mock_api:
+            returned = fetch_and_store_pr_commits(
+                "owner/repo", 99, db, commits=pre_fetched,
+            )
+            assert mock_api.call_count == 0
+
+        assert returned == pre_fetched
+        conn = sqlite3.connect(str(db))
+        try:
+            row = conn.execute(
+                "SELECT sha, pr_number FROM commits WHERE repo = 'owner/repo'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row == ("ffff0000", 99)

--- a/tests/test_fetch_commits.py
+++ b/tests/test_fetch_commits.py
@@ -106,9 +106,13 @@ class TestFetchPrCommits:
         assert [c["sha"] for c in result] == ["aaaa1111", "bbbb2222", "cccc3333"]
 
     @patch("collector.github_poller.fetch_commits.gh_api")
-    def test_api_error_returns_empty(self, mock_api):
+    def test_api_error_propagates(self, mock_api):
+        """Post-F-2: GhCliError is now surfaced to the caller so
+        push_counter can fall back instead of silently collapsing push_count
+        to 0 on a transient /commits failure."""
         mock_api.side_effect = GhCliError(["gh", "api"], 1, "boom")
-        assert fetch_pr_commits("owner/repo", 1) == []
+        with pytest.raises(GhCliError):
+            fetch_pr_commits("owner/repo", 1)
 
     @patch("collector.github_poller.fetch_commits.gh_api")
     def test_non_list_response_returns_empty(self, mock_api):

--- a/tests/test_fetch_timeline.py
+++ b/tests/test_fetch_timeline.py
@@ -20,6 +20,7 @@ from collector.github_poller.fetch_timeline import (
     fetch_and_store_issue_timelines,
     fetch_issue_timeline_batch,
 )
+from collector.github_poller.gh_client import BudgetExhausted
 
 
 # ---------------------------------------------------------------------------
@@ -197,6 +198,28 @@ class TestFetchIssueTimelineBatch:
         }
         result = fetch_issue_timeline_batch("owner/repo", [1, 2])
         assert result == {1: [], 2: []}
+
+    @patch("collector.github_poller.fetch_timeline.gh_graphql")
+    def test_budget_exhausted_propagates(self, mock_gql):
+        """Invariant: BudgetExhausted MUST escape fetch_issue_timeline_batch so
+        the outer poll cycle can stop cleanly. A generic except-Exception would
+        silently continue iterating chunks while the budget stays pinned — this
+        negative-assertion test guards against that regression (see F-1)."""
+        mock_gql.side_effect = BudgetExhausted(100, 100, 600.0)
+        with pytest.raises(BudgetExhausted):
+            fetch_issue_timeline_batch("owner/repo", [1, 2, 3])
+        # Exactly one chunk attempted — we did NOT continue past the budget cap.
+        assert mock_gql.call_count == 1
+
+    @patch("collector.github_poller.fetch_timeline.gh_graphql")
+    def test_budget_exhausted_propagates_through_store(self, mock_gql, tmp_path):
+        """fetch_and_store_issue_timelines must also re-raise BudgetExhausted
+        so _fetch_timeline_step's handler in run.py observes it."""
+        mock_gql.side_effect = BudgetExhausted(100, 100, 600.0)
+        db = tmp_path / "github.db"
+        init_github_db(db)
+        with pytest.raises(BudgetExhausted):
+            fetch_and_store_issue_timelines("owner/repo", [1], db)
 
 
 class TestFetchAndStoreIssueTimelines:

--- a/tests/test_fetch_timeline.py
+++ b/tests/test_fetch_timeline.py
@@ -1,0 +1,245 @@
+"""Tests for collector/github_poller/fetch_timeline.py (Epic #17, E-2).
+
+Uses mocked ``gh_graphql`` — no live network calls.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+from am_i_shipping.db import init_github_db
+from collector.github_poller.fetch_timeline import (
+    TIMELINE_EVENT_TYPES,
+    _build_batch_query,
+    _event_id_from_node,
+    _normalize_node,
+    fetch_and_store_issue_timelines,
+    fetch_issue_timeline_batch,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders — GraphQL response shapes as returned by gh_graphql.
+# ---------------------------------------------------------------------------
+
+
+def _gql_response_for_chunk(chunk: list[int], events_by_number: dict[int, list[dict]]):
+    """Build a mock GraphQL response that covers one chunk of aliased queries."""
+    repo_block = {}
+    for i, num in enumerate(chunk):
+        nodes = events_by_number.get(num, [])
+        repo_block[f"issue{i}"] = {
+            "number": num,
+            "timelineItems": {"nodes": nodes},
+        }
+    return {
+        "data": {
+            "rateLimit": {"cost": 1, "remaining": 4999},
+            "repository": repo_block,
+        }
+    }
+
+
+_ASSIGNED_NODE = {
+    "__typename": "AssignedEvent",
+    "id": "AE_111",
+    "createdAt": "2024-01-15T10:00:00Z",
+    "actor": {"login": "alice"},
+    "assignee": {"login": "bob"},
+}
+
+_LABELED_NODE = {
+    "__typename": "LabeledEvent",
+    "id": "LE_222",
+    "createdAt": "2024-01-15T11:00:00Z",
+    "actor": {"login": "carol"},
+    "label": {"name": "bug"},
+}
+
+_CROSS_REF_NODE = {
+    "__typename": "CrossReferencedEvent",
+    "id": "CRE_333",
+    "createdAt": "2024-01-16T09:00:00Z",
+    "actor": {"login": "dave"},
+    "source": {"number": 42, "repository": {"nameWithOwner": "owner/repo"}},
+}
+
+
+class TestNodeNormalization:
+    def test_event_id_stable_across_calls(self):
+        a = _event_id_from_node({"id": "LE_222"})
+        b = _event_id_from_node({"id": "LE_222"})
+        assert a == b
+        assert isinstance(a, int)
+        assert a > 0
+
+    def test_event_id_differs_across_relay_ids(self):
+        assert _event_id_from_node({"id": "AE_111"}) != _event_id_from_node({"id": "AE_112"})
+
+    def test_event_id_missing(self):
+        assert _event_id_from_node({}) is None
+
+    def test_normalize_assigned(self):
+        row = _normalize_node(7, _ASSIGNED_NODE)
+        assert row is not None
+        assert row["issue_number"] == 7
+        assert row["event_type"] == "assigned"
+        assert row["actor"] == "alice"
+        assert row["created_at"] == "2024-01-15T10:00:00Z"
+        payload = json.loads(row["payload_json"])
+        assert payload["__typename"] == "AssignedEvent"
+        assert payload["assignee"]["login"] == "bob"
+
+    def test_normalize_labeled(self):
+        row = _normalize_node(7, _LABELED_NODE)
+        assert row["event_type"] == "labeled"
+        assert row["actor"] == "carol"
+
+    def test_normalize_cross_referenced(self):
+        row = _normalize_node(7, _CROSS_REF_NODE)
+        assert row["event_type"] == "cross-referenced"
+        payload = json.loads(row["payload_json"])
+        assert payload["source"]["number"] == 42
+
+    def test_normalize_unknown_type_returns_none(self):
+        assert _normalize_node(7, {"__typename": "SomeOtherEvent", "id": "X"}) is None
+
+
+class TestBuildBatchQuery:
+    def test_query_includes_all_event_types(self):
+        q = _build_batch_query([1, 2, 3])
+        for ev in TIMELINE_EVENT_TYPES:
+            assert ev in q
+
+    def test_query_uses_aliases(self):
+        q = _build_batch_query([10, 20, 30])
+        assert "issue0: issue(number: 10)" in q
+        assert "issue1: issue(number: 20)" in q
+        assert "issue2: issue(number: 30)" in q
+
+
+class TestFetchIssueTimelineBatch:
+    @patch("collector.github_poller.fetch_timeline.gh_graphql")
+    def test_empty_input_returns_empty(self, mock_gql):
+        result = fetch_issue_timeline_batch("owner/repo", [])
+        assert result == {}
+        assert mock_gql.call_count == 0
+
+    @patch("collector.github_poller.fetch_timeline.gh_graphql")
+    def test_single_chunk_normalizes_events(self, mock_gql):
+        mock_gql.return_value = _gql_response_for_chunk(
+            [1, 2],
+            {1: [_ASSIGNED_NODE, _LABELED_NODE], 2: []},
+        )
+        result = fetch_issue_timeline_batch("owner/repo", [1, 2])
+        assert mock_gql.call_count == 1
+        assert set(result.keys()) == {1, 2}
+        assert [e["event_type"] for e in result[1]] == ["assigned", "labeled"]
+        assert result[2] == []
+
+    @patch("collector.github_poller.fetch_timeline.gh_graphql")
+    def test_chunks_greater_than_twenty(self, mock_gql):
+        """25 issues should trigger two GraphQL calls (20 + 5)."""
+        issue_numbers = list(range(1, 26))
+
+        calls: list[int] = []
+
+        def _side_effect(query, variables):
+            calls.append(1)
+            # First call: issues 1..20 (aliases issue0..issue19).
+            # Second call: issues 21..25 (aliases issue0..issue4).
+            if len(calls) == 1:
+                return _gql_response_for_chunk(list(range(1, 21)), {})
+            return _gql_response_for_chunk(list(range(21, 26)), {})
+
+        mock_gql.side_effect = _side_effect
+
+        result = fetch_issue_timeline_batch("owner/repo", issue_numbers)
+        assert mock_gql.call_count == 2
+        assert set(result.keys()) == set(issue_numbers)
+
+    @patch("collector.github_poller.fetch_timeline.gh_graphql")
+    def test_graphql_error_skips_chunk(self, mock_gql):
+        """A chunk that raises is logged and skipped; other chunks still land."""
+        issue_numbers = list(range(1, 26))
+
+        calls: list[int] = []
+
+        def _side_effect(query, variables):
+            calls.append(1)
+            if len(calls) == 1:
+                raise RuntimeError("first chunk explodes")
+            return _gql_response_for_chunk(list(range(21, 26)), {})
+
+        mock_gql.side_effect = _side_effect
+
+        result = fetch_issue_timeline_batch("owner/repo", issue_numbers)
+        # Missing issues from chunk 1, present from chunk 2.
+        assert all(n not in result for n in range(1, 21))
+        assert all(n in result for n in range(21, 26))
+
+    @patch("collector.github_poller.fetch_timeline.gh_graphql")
+    def test_deleted_issue_gets_empty_list(self, mock_gql):
+        """When GraphQL returns null for an alias (transferred/deleted), we
+        record an empty event list rather than omitting the issue."""
+        mock_gql.return_value = {
+            "data": {
+                "rateLimit": {"cost": 1, "remaining": 4999},
+                "repository": {
+                    "issue0": None,
+                    "issue1": {"number": 2, "timelineItems": {"nodes": []}},
+                },
+            }
+        }
+        result = fetch_issue_timeline_batch("owner/repo", [1, 2])
+        assert result == {1: [], 2: []}
+
+
+class TestFetchAndStoreIssueTimelines:
+    @patch("collector.github_poller.fetch_timeline.gh_graphql")
+    def test_persists_events(self, mock_gql, tmp_path):
+        mock_gql.return_value = _gql_response_for_chunk(
+            [1], {1: [_ASSIGNED_NODE, _LABELED_NODE, _CROSS_REF_NODE]},
+        )
+        db = tmp_path / "github.db"
+        init_github_db(db)
+
+        fetch_and_store_issue_timelines("owner/repo", [1], db)
+
+        conn = sqlite3.connect(str(db))
+        try:
+            rows = conn.execute(
+                "SELECT event_type, actor FROM timeline_events "
+                "WHERE repo = 'owner/repo' AND issue_number = 1 "
+                "ORDER BY event_type"
+            ).fetchall()
+        finally:
+            conn.close()
+        assert set(rows) == {
+            ("assigned", "alice"),
+            ("cross-referenced", "dave"),
+            ("labeled", "carol"),
+        }
+
+    @patch("collector.github_poller.fetch_timeline.gh_graphql")
+    def test_idempotent(self, mock_gql, tmp_path):
+        mock_gql.return_value = _gql_response_for_chunk([1], {1: [_ASSIGNED_NODE]})
+        db = tmp_path / "github.db"
+        init_github_db(db)
+
+        fetch_and_store_issue_timelines("owner/repo", [1], db)
+        fetch_and_store_issue_timelines("owner/repo", [1], db)
+
+        conn = sqlite3.connect(str(db))
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM timeline_events "
+                "WHERE repo = 'owner/repo' AND issue_number = 1"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert count == 1

--- a/tests/test_github_poller_run.py
+++ b/tests/test_github_poller_run.py
@@ -342,3 +342,63 @@ class TestEpic17FetchIntegration:
         # Neither new fetcher was invoked.
         assert mock_fetch_commits.call_count == 0
         assert mock_fetch_timeline.call_count == 0
+
+    @patch("collector.github_poller.run.link_sessions", return_value=0)
+    @patch("collector.github_poller.run.count_pushes_after_review", return_value=7)
+    @patch("collector.github_poller.run.fetch_pr_edit_history", return_value={})
+    @patch("collector.github_poller.run.fetch_issue_edit_history_batch", return_value={})
+    @patch("collector.github_poller.run.fetch_pr_review_comments", return_value=[])
+    @patch("collector.github_poller.run.fetch_issue_comments", return_value=[])
+    @patch("collector.github_poller.run.fetch_prs")
+    @patch("collector.github_poller.run.fetch_issues")
+    @patch("collector.github_poller.run.fetch_and_store_issue_timelines", return_value={})
+    @patch("collector.github_poller.run.fetch_and_store_pr_commits")
+    def test_fetch_commits_error_falls_back_to_push_counter_self_fetch(
+        self,
+        mock_fetch_commits,
+        mock_fetch_timeline,
+        mock_issues,
+        mock_prs,
+        mock_issue_comments,
+        mock_pr_review_comments,
+        mock_edit_batch,
+        mock_pr_edit,
+        mock_push,
+        mock_link,
+        tmp_path,
+    ):
+        """F-2 invariant: when fetch_and_store_pr_commits raises GhCliError,
+        count_pushes_after_review is invoked WITHOUT the `commits` kwarg, so
+        push_counter can perform its own /commits fetch. The push_count must
+        NOT collapse to 0 on a transient fetch_commits failure."""
+        from collector.github_poller.gh_client import GhCliError
+
+        mock_issues.return_value = []
+        mock_prs.return_value = [
+            {"number": 10, "title": "P", "head_ref": "fix/1",
+             "body": "Closes #1", "review_comments": [],
+             "review_comment_count": 0, "created_at": None,
+             "merged_at": None},
+        ]
+        # fetch_commits blows up with a transient error.
+        mock_fetch_commits.side_effect = GhCliError(["gh"], 1, "boom")
+
+        _poll_repo(
+            "owner/repo",
+            tmp_path / "github.db",
+            tmp_path / "sessions.db",
+            backfill_days=30,
+            dry_run=False,
+            fetch_commits_enabled=True,
+            fetch_timeline_enabled=False,
+        )
+
+        # count_pushes_after_review must have been called without the kwarg
+        # so push_counter re-fetches /commits itself and returns its own count
+        # (7 per the mock) — NOT 0.
+        assert mock_push.call_count == 1
+        call_kwargs = mock_push.call_args.kwargs
+        assert "commits" not in call_kwargs, (
+            "Fallback path must NOT pass commits=[] — that would collapse "
+            "push_count to 0. See F-2."
+        )

--- a/tests/test_github_poller_run.py
+++ b/tests/test_github_poller_run.py
@@ -84,6 +84,8 @@ class TestDryRun:
 
 
 class TestPollRepo:
+    @patch("collector.github_poller.run.fetch_and_store_issue_timelines", return_value={})
+    @patch("collector.github_poller.run.fetch_and_store_pr_commits", return_value=[])
     @patch("collector.github_poller.run.link_sessions")
     @patch("collector.github_poller.run.count_pushes_after_review")
     @patch("collector.github_poller.run.fetch_pr_edit_history", return_value={})
@@ -95,6 +97,7 @@ class TestPollRepo:
     def test_full_poll_produces_rows(
         self, mock_issues, mock_prs, mock_issue_comments, mock_pr_comments,
         mock_edit_batch, mock_pr_edit, mock_push, mock_link,
+        mock_fetch_commits, mock_fetch_timeline,
         tmp_path
     ):
         mock_issues.return_value = [
@@ -133,6 +136,8 @@ class TestPollRepo:
         assert len(links) == 1  # fix/1-bug resolves to issue #1
         assert len(cursor) == 1  # cursor advanced
 
+    @patch("collector.github_poller.run.fetch_and_store_issue_timelines", return_value={})
+    @patch("collector.github_poller.run.fetch_and_store_pr_commits", return_value=[])
     @patch("collector.github_poller.run.link_sessions")
     @patch("collector.github_poller.run.count_pushes_after_review")
     @patch("collector.github_poller.run.fetch_pr_edit_history", return_value={})
@@ -145,6 +150,7 @@ class TestPollRepo:
     def test_rerun_produces_same_row_count(
         self, mock_issues, mock_prs, mock_issue_comments, mock_pr_comments,
         mock_edit_batch, mock_issue_edit, mock_pr_edit, mock_push, mock_link,
+        mock_fetch_commits, mock_fetch_timeline,
         tmp_path
     ):
         """Re-running poll with same data produces identical row count."""
@@ -180,12 +186,15 @@ class TestPollRepo:
 
 
 class TestHealthJson:
+    @patch("collector.github_poller.run.fetch_and_store_issue_timelines", return_value={})
+    @patch("collector.github_poller.run.fetch_and_store_pr_commits", return_value=[])
     @patch("collector.github_poller.run.link_sessions")
     @patch("collector.github_poller.run.count_pushes_after_review")
     @patch("collector.github_poller.run.fetch_prs")
     @patch("collector.github_poller.run.fetch_issues")
     def test_health_written_on_success(
         self, mock_issues, mock_prs, mock_push, mock_link,
+        mock_fetch_commits, mock_fetch_timeline,
         config_file, tmp_path
     ):
         mock_issues.return_value = []
@@ -201,12 +210,15 @@ class TestHealthJson:
         assert "github_poller" in data
         assert "last_success" in data["github_poller"]
 
+    @patch("collector.github_poller.run.fetch_and_store_issue_timelines", return_value={})
+    @patch("collector.github_poller.run.fetch_and_store_pr_commits", return_value=[])
     @patch("collector.github_poller.run.link_sessions")
     @patch("collector.github_poller.run.count_pushes_after_review")
     @patch("collector.github_poller.run.fetch_prs")
     @patch("collector.github_poller.run.fetch_issues")
     def test_health_not_written_on_failure(
         self, mock_issues, mock_prs, mock_push, mock_link,
+        mock_fetch_commits, mock_fetch_timeline,
         config_file, tmp_path
     ):
         mock_issues.side_effect = Exception("API down")
@@ -215,3 +227,118 @@ class TestHealthJson:
 
         health = tmp_path / "data" / "health.json"
         assert not health.exists()
+
+
+class TestEpic17FetchIntegration:
+    """Epic #17 Sub-Issue 2 (#35): wiring for fetch_commits / fetch_timeline.
+
+    Asserts that ``_poll_repo`` calls the new E-1/E-2 helpers when the
+    flags are on, and skips them when the flags are off — without changing
+    behaviour of the pre-existing issue/PR path.
+    """
+
+    @patch("collector.github_poller.run.link_sessions", return_value=0)
+    @patch("collector.github_poller.run.count_pushes_after_review", return_value=0)
+    @patch("collector.github_poller.run.fetch_pr_edit_history", return_value={})
+    @patch("collector.github_poller.run.fetch_issue_edit_history_batch", return_value={})
+    @patch("collector.github_poller.run.fetch_pr_review_comments", return_value=[])
+    @patch("collector.github_poller.run.fetch_issue_comments", return_value=[])
+    @patch("collector.github_poller.run.fetch_prs")
+    @patch("collector.github_poller.run.fetch_issues")
+    @patch("collector.github_poller.run.fetch_and_store_issue_timelines")
+    @patch("collector.github_poller.run.fetch_and_store_pr_commits")
+    def test_fetchers_called_by_default(
+        self,
+        mock_fetch_commits,
+        mock_fetch_timeline,
+        mock_issues,
+        mock_prs,
+        mock_issue_comments,
+        mock_pr_review_comments,
+        mock_edit_batch,
+        mock_pr_edit,
+        mock_push,
+        mock_link,
+        tmp_path,
+    ):
+        mock_issues.return_value = [
+            {"number": 1, "title": "I", "state": "OPEN", "body": "",
+             "comments": [], "type_label": None, "created_at": None,
+             "closed_at": None},
+        ]
+        mock_prs.return_value = [
+            {"number": 10, "title": "P", "head_ref": "fix/1",
+             "body": "Closes #1", "review_comments": [],
+             "review_comment_count": 0, "created_at": None,
+             "merged_at": None},
+        ]
+        mock_fetch_commits.return_value = []
+        mock_fetch_timeline.return_value = {}
+
+        _poll_repo(
+            "owner/repo",
+            tmp_path / "github.db",
+            tmp_path / "sessions.db",
+            backfill_days=30,
+            dry_run=False,
+            fetch_commits_enabled=True,
+            fetch_timeline_enabled=True,
+        )
+
+        # fetch_and_store_pr_commits was called once per PR.
+        assert mock_fetch_commits.call_count == 1
+        # fetch_and_store_issue_timelines was called with the list of issue numbers.
+        assert mock_fetch_timeline.call_count == 1
+        call_args = mock_fetch_timeline.call_args
+        assert call_args.args[0] == "owner/repo"
+        assert call_args.args[1] == [1]
+
+    @patch("collector.github_poller.run.link_sessions", return_value=0)
+    @patch("collector.github_poller.run.count_pushes_after_review", return_value=0)
+    @patch("collector.github_poller.run.fetch_pr_edit_history", return_value={})
+    @patch("collector.github_poller.run.fetch_issue_edit_history_batch", return_value={})
+    @patch("collector.github_poller.run.fetch_pr_review_comments", return_value=[])
+    @patch("collector.github_poller.run.fetch_issue_comments", return_value=[])
+    @patch("collector.github_poller.run.fetch_prs")
+    @patch("collector.github_poller.run.fetch_issues")
+    @patch("collector.github_poller.run.fetch_and_store_issue_timelines")
+    @patch("collector.github_poller.run.fetch_and_store_pr_commits")
+    def test_fetchers_skipped_when_flags_off(
+        self,
+        mock_fetch_commits,
+        mock_fetch_timeline,
+        mock_issues,
+        mock_prs,
+        mock_issue_comments,
+        mock_pr_review_comments,
+        mock_edit_batch,
+        mock_pr_edit,
+        mock_push,
+        mock_link,
+        tmp_path,
+    ):
+        mock_issues.return_value = [
+            {"number": 1, "title": "I", "state": "OPEN", "body": "",
+             "comments": [], "type_label": None, "created_at": None,
+             "closed_at": None},
+        ]
+        mock_prs.return_value = [
+            {"number": 10, "title": "P", "head_ref": "fix/1",
+             "body": "Closes #1", "review_comments": [],
+             "review_comment_count": 0, "created_at": None,
+             "merged_at": None},
+        ]
+
+        _poll_repo(
+            "owner/repo",
+            tmp_path / "github.db",
+            tmp_path / "sessions.db",
+            backfill_days=30,
+            dry_run=False,
+            fetch_commits_enabled=False,
+            fetch_timeline_enabled=False,
+        )
+
+        # Neither new fetcher was invoked.
+        assert mock_fetch_commits.call_count == 0
+        assert mock_fetch_timeline.call_count == 0

--- a/tests/test_integration_gate.py
+++ b/tests/test_integration_gate.py
@@ -77,8 +77,17 @@ class TestIntegrationGate:
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
 
-    # Known tables for each database — avoids dynamic SQL construction
-    GITHUB_TABLES = ("issues", "pull_requests", "pushes", "issue_pr_links")
+    # Known tables for each database — avoids dynamic SQL construction.
+    # Epic #17 Sub-Issue 2 (#35) adds ``commits`` and ``timeline_events``;
+    # both are populated by the new E-1 / E-2 collectors enabled by default.
+    GITHUB_TABLES = (
+        "issues",
+        "pull_requests",
+        "pushes",
+        "issue_pr_links",
+        "commits",
+        "timeline_events",
+    )
 
     def test_databases_have_data(self) -> None:
         """After a run, implemented collector DBs contain rows."""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -218,3 +218,30 @@ class TestGitBranchFallback:
         session_file.write_text("\n".join(lines) + "\n")
         record = parse_session(session_file)
         assert record.git_branch is None
+
+
+class TestSessionTimestamps:
+    """Epic #17 Sub-Issue 2 (#35): session_started_at and session_ended_at."""
+
+    def test_extracts_first_and_last_timestamp(self):
+        record = parse_session(SAMPLE)
+        # First timestamp in the fixture is 2026-01-15T10:00:00.000Z on a
+        # queue-operation entry; last is 2026-01-15T10:00:35.000Z.
+        assert record.session_started_at is not None
+        assert record.session_started_at.startswith("2026-01-15T10:00:00")
+        assert record.session_ended_at is not None
+        assert record.session_ended_at.startswith("2026-01-15T10:00:35")
+
+    def test_no_timestamps_returns_none(self, tmp_path):
+        """A session file with zero parseable timestamps yields None/None."""
+        session_file = tmp_path / "no-ts.jsonl"
+        session_file.write_text(
+            json.dumps({
+                "type": "user",
+                "message": {"role": "user", "content": "hello"},
+                "sessionId": "ts-none",
+            }) + "\n"
+        )
+        record = parse_session(session_file)
+        assert record.session_started_at is None
+        assert record.session_ended_at is None

--- a/tests/test_push_counter.py
+++ b/tests/test_push_counter.py
@@ -86,3 +86,25 @@ class TestPushCounter:
         """If API calls fail, returns 0 rather than raising."""
         mock_api.side_effect = GhCliError(["gh", "api"], 1, "timeout")
         assert count_pushes_after_review("owner/repo", 1) == 0
+
+    @patch("collector.github_poller.push_counter.gh_api")
+    def test_pre_fetched_commits_skip_second_roundtrip(self, mock_api):
+        """Epic #17 E-1: when callers pass pre-fetched commits, push_counter
+        does NOT hit /commits again — it reuses what fetch_commits already
+        pulled."""
+        reviews = [{"submitted_at": "2024-01-20T12:00:00Z"}]
+        pre_fetched = [
+            # Normalised shape from fetch_commits.fetch_pr_commits.
+            {"sha": "a", "pushed_at": "2024-01-19T10:00:00Z"},  # before review
+            {"sha": "b", "pushed_at": "2024-01-20T14:00:00Z"},  # after
+            {"sha": "c", "pushed_at": "2024-01-21T09:00:00Z"},  # after
+        ]
+        # Only /reviews is fetched — not /commits.
+        mock_api.return_value = reviews
+
+        count = count_pushes_after_review(
+            "owner/repo", 1, commits=pre_fetched,
+        )
+        assert count == 2
+        # Exactly one gh_api call (for reviews).
+        assert mock_api.call_count == 1

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -128,3 +128,54 @@ class TestProcessSession:
         from datetime import datetime
 
         datetime.fromisoformat(ts)
+
+
+class TestSessionTimestampsColumns:
+    """Epic #17 Sub-Issue 2 (#35): the two session timestamp columns roundtrip."""
+
+    def test_stored_and_read_back(self, tmp_path):
+        db_path = tmp_path / "sessions.db"
+        record = _make_record(
+            session_uuid="ts-uuid",
+            session_started_at="2024-05-01T00:00:00+00:00",
+            session_ended_at="2024-05-01T01:00:00+00:00",
+        )
+        upsert_session(record, db_path=db_path, data_dir=tmp_path)
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT session_started_at, session_ended_at "
+            "FROM sessions WHERE session_uuid = 'ts-uuid'"
+        ).fetchone()
+        conn.close()
+        assert row == (
+            "2024-05-01T00:00:00+00:00",
+            "2024-05-01T01:00:00+00:00",
+        )
+
+    def test_second_upsert_overwrites_timestamps(self, tmp_path):
+        db_path = tmp_path / "sessions.db"
+        r1 = _make_record(
+            session_uuid="ts-uuid",
+            session_started_at="2024-05-01T00:00:00+00:00",
+            session_ended_at="2024-05-01T01:00:00+00:00",
+        )
+        upsert_session(r1, db_path=db_path, data_dir=tmp_path)
+
+        r2 = _make_record(
+            session_uuid="ts-uuid",
+            session_started_at="2024-06-01T00:00:00+00:00",
+            session_ended_at="2024-06-01T02:00:00+00:00",
+        )
+        upsert_session(r2, db_path=db_path, data_dir=tmp_path)
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT session_started_at, session_ended_at "
+            "FROM sessions WHERE session_uuid = 'ts-uuid'"
+        ).fetchone()
+        conn.close()
+        assert row == (
+            "2024-06-01T00:00:00+00:00",
+            "2024-06-01T02:00:00+00:00",
+        )


### PR DESCRIPTION
Closes #35. Part of epic #17.

## Changes
- Mechanical extraction of `_poll_repo` into named helpers (pure refactor)
- `fetch_commits.py`: per-PR commit fetch wired behind `github.fetch_commits` flag
- `fetch_timeline.py`: GraphQL timeline events wired behind `github.fetch_timeline` flag
- `store.py`: `upsert_commit` and `upsert_timeline_event` added
- `push_counter.py`: accepts pre-fetched commits to avoid double `/commits` round-trip
- `session_parser.py` + `collector/store.py`: populate `session_started_at`/`session_ended_at` on new inserts
- `scripts/backfill_session_timestamps.py`: one-shot backfill for historical session timestamps
- Tests: `test_fetch_commits.py`, `test_fetch_timeline.py`, `test_backfill_session_timestamps.py`, integration-gate updated

## Acceptance criteria
- [x] run.py refactor is pure extraction — existing tests green
- [x] fetch_commits persists commits per-PR; no repo-wide enumeration
- [x] fetch_timeline populates timeline_events for listed event types
- [x] GITHUB_TABLES includes commits and timeline_events
- [x] Config flags default true; disabling leaves Phase 1 behavior unchanged
- [x] Backfill script populates session_started_at/session_ended_at

## Test results
279 passed, 15 skipped (integration gate skipped — requires AMIS_INTEGRATION=1)