### PR TITLE
feat(#37): G-2 unit identifier + G-3 timeline renderer + per-unit metrics

### DIFF
--- a/synthesis/metrics.py
+++ b/synthesis/metrics.py
@@ -1,0 +1,218 @@
+"""Per-unit metric calculators (Epic #17 — Sub-Issue 4 / Issue #37).
+
+Each function is pure — it takes already-fetched rows and returns a
+number — so the unit identifier (``synthesis/unit_identifier.py``) can
+wire them up after a single scan over the github/sessions tables.
+
+Metric semantics follow the epic ADR:
+
+* ``elapsed_days``     — wall-clock span from the first event observed in
+  the unit to the last event, across *all* nodes (sessions, issues, PRs).
+  Units with a single timestamp return ``0.0``.
+* ``dark_time_pct``    — sessions-only gap ratio,
+  ``1 - sum(session_ended_at - session_started_at) / (max(ended) - min(started))``.
+  Single-session units return ``0.0`` (ADR Decision 3).
+* ``total_reprompts``  — sum of ``sessions.reprompt_count`` across the
+  unit's sessions. Missing / NULL values count as ``0``.
+* ``review_cycles``    — per-PR review activity across the unit. Uses
+  ``len(review_comments_json)`` when present, falling back to
+  ``push_count`` when the review comments payload is empty. Missing PR
+  rows count as 0.
+
+Design
+------
+Functions accept *either* a sqlite3 connection (so the caller can pass a
+github or sessions DB handle) *or* already-materialised row iterables.
+Keeping both surfaces lets the unit identifier build one SQL query per
+DB while ``test_metrics.py`` can exercise the logic with plain tuples.
+
+No network, no LLM. All functions are offline by design.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime
+from typing import Iterable, Optional
+
+
+# ---------------------------------------------------------------------------
+# Timestamp helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_ts(value: Optional[str]) -> Optional[datetime]:
+    """Parse an ISO-8601 string into a naive UTC ``datetime``.
+
+    The collectors store timestamps in ``YYYY-MM-DDTHH:MM:SSZ`` form. We
+    accept any ``fromisoformat``-compatible variant and drop the ``Z``
+    suffix, because ``datetime.fromisoformat`` on Python 3.10 cannot
+    parse it. Returns ``None`` for falsy / unparseable input so callers
+    can skip missing values uniformly.
+    """
+    if not value:
+        return None
+    s = value.strip()
+    if s.endswith("Z"):
+        s = s[:-1]
+    try:
+        return datetime.fromisoformat(s)
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# elapsed_days
+# ---------------------------------------------------------------------------
+
+
+def elapsed_days(timestamps: Iterable[Optional[str]]) -> float:
+    """Return span from earliest to latest timestamp in *timestamps*, in days.
+
+    Callers collect every timestamp associated with the unit's nodes —
+    session start/end, issue created/closed/updated, PR
+    created/merged/updated, commit authored/pushed — and pass them in a
+    single iterable. ``None`` / empty strings are ignored. If fewer than
+    two valid timestamps remain, the result is ``0.0``.
+    """
+    parsed = [t for t in (_parse_ts(v) for v in timestamps) if t is not None]
+    if len(parsed) < 2:
+        return 0.0
+    delta = max(parsed) - min(parsed)
+    return delta.total_seconds() / 86400.0
+
+
+# ---------------------------------------------------------------------------
+# dark_time_pct
+# ---------------------------------------------------------------------------
+
+
+def dark_time_pct(
+    session_intervals: Iterable[tuple[Optional[str], Optional[str]]],
+) -> float:
+    """Return sessions-only gap ratio across *session_intervals*.
+
+    Each entry is a ``(session_started_at, session_ended_at)`` pair. The
+    metric answers: "during the span from the first session's start to
+    the last session's end, what fraction of time had no active
+    session?". Formally::
+
+        1 - sum(ended - started) / (max(ended) - min(started))
+
+    Sessions missing a start or end are dropped (can't be part of an
+    interval). Single-session units return ``0.0`` even if the
+    denominator would collapse to zero — this is Decision 3 in the epic
+    ADR: "dark time has no meaning for a single session".
+    """
+    parsed: list[tuple[datetime, datetime]] = []
+    for started, ended in session_intervals:
+        s = _parse_ts(started)
+        e = _parse_ts(ended)
+        if s is None or e is None:
+            continue
+        if e < s:
+            # Defensive: reject malformed rows rather than producing
+            # negative durations that would break the ratio.
+            continue
+        parsed.append((s, e))
+    if len(parsed) < 2:
+        return 0.0
+    active = sum((e - s).total_seconds() for s, e in parsed)
+    span = (max(e for _, e in parsed) - min(s for s, _ in parsed)).total_seconds()
+    if span <= 0:
+        return 0.0
+    ratio = 1.0 - (active / span)
+    # Clamp to [0, 1] — overlapping sessions could in theory produce a
+    # negative ratio; abandonment with no gap span doesn't happen here
+    # because ``span <= 0`` is handled above.
+    if ratio < 0.0:
+        return 0.0
+    if ratio > 1.0:
+        return 1.0
+    return ratio
+
+
+# ---------------------------------------------------------------------------
+# total_reprompts
+# ---------------------------------------------------------------------------
+
+
+def total_reprompts(
+    session_ids: Iterable[str],
+    sessions_conn: sqlite3.Connection,
+) -> int:
+    """Return sum of ``sessions.reprompt_count`` for the given *session_ids*.
+
+    Missing rows and NULL counts are treated as ``0`` — the metric is a
+    *running total* and should not fail just because a session row was
+    pruned or never got a reprompt tally.
+    """
+    ids = [sid for sid in session_ids if sid]
+    if not ids:
+        return 0
+    placeholders = ",".join("?" * len(ids))
+    cur = sessions_conn.execute(
+        f"SELECT COALESCE(SUM(reprompt_count), 0) FROM sessions "
+        f"WHERE session_uuid IN ({placeholders})",
+        ids,
+    )
+    row = cur.fetchone()
+    return int(row[0] or 0)
+
+
+# ---------------------------------------------------------------------------
+# review_cycles
+# ---------------------------------------------------------------------------
+
+
+def _count_review_comments(payload: Optional[str]) -> int:
+    """Return len of the JSON array in *payload*, 0 on any failure."""
+    if not payload:
+        return 0
+    try:
+        parsed = json.loads(payload)
+    except (ValueError, TypeError):
+        return 0
+    if isinstance(parsed, list):
+        return len(parsed)
+    return 0
+
+
+def review_cycles(
+    pr_refs: Iterable[tuple[str, int]],
+    github_conn: sqlite3.Connection,
+) -> int:
+    """Return total review activity across the unit's PRs.
+
+    *pr_refs* is an iterable of ``(repo, pr_number)`` tuples. For each
+    PR, we prefer the length of ``review_comments_json`` (the raw
+    payload count); if that's empty we fall back to ``push_count`` as a
+    coarse proxy for "how many times the author iterated". Missing rows
+    contribute ``0``.
+
+    The two signals are additive within a PR's row but mutually
+    exclusive in practice — ``review_comments_json`` is populated only
+    for PRs with review activity, and ``push_count`` captures the
+    "author-iteration-without-review" case. The fallback avoids double-
+    counting when reviews happened (the richer signal wins).
+    """
+    pairs = list(pr_refs)
+    if not pairs:
+        return 0
+    total = 0
+    for repo, pr_number in pairs:
+        cur = github_conn.execute(
+            "SELECT review_comments_json, push_count FROM pull_requests "
+            "WHERE repo = ? AND pr_number = ?",
+            (repo, pr_number),
+        )
+        row = cur.fetchone()
+        if row is None:
+            continue
+        review_comments_json, push_count = row
+        n = _count_review_comments(review_comments_json)
+        if n == 0:
+            n = int(push_count or 0)
+        total += n
+    return total

--- a/synthesis/metrics.py
+++ b/synthesis/metrics.py
@@ -42,14 +42,24 @@ from typing import Iterable, Optional
 # ---------------------------------------------------------------------------
 
 
-def _parse_ts(value: Optional[str]) -> Optional[datetime]:
+def parse_ts(value: Optional[str]) -> Optional[datetime]:
     """Parse an ISO-8601 string into a naive UTC ``datetime``.
 
     The collectors store timestamps in ``YYYY-MM-DDTHH:MM:SSZ`` form. We
     accept any ``fromisoformat``-compatible variant and drop the ``Z``
     suffix, because ``datetime.fromisoformat`` on Python 3.10 cannot
-    parse it. Returns ``None`` for falsy / unparseable input so callers
-    can skip missing values uniformly.
+    parse it. We also tolerate offset-suffixed inputs such as
+    ``+00:00`` / ``+HH:MM`` (occasionally emitted by some GitHub REST
+    endpoints) by stripping the tzinfo after parsing — the rest of this
+    module assumes *naive UTC*, so mixing aware/naive datetimes in
+    subtraction would raise ``TypeError``.
+
+    Returns ``None`` for falsy / unparseable input so callers can skip
+    missing values uniformly.
+
+    Public (``parse_ts``) because ``synthesis.unit_identifier`` needs the
+    same parsing rules for its status-derivation logic. Keeping a single
+    implementation avoids drift between the two modules.
     """
     if not value:
         return None
@@ -57,9 +67,21 @@ def _parse_ts(value: Optional[str]) -> Optional[datetime]:
     if s.endswith("Z"):
         s = s[:-1]
     try:
-        return datetime.fromisoformat(s)
+        dt = datetime.fromisoformat(s)
     except ValueError:
         return None
+    # Drop tzinfo if present so callers can subtract against naive
+    # ``datetime`` values (e.g. ``datetime.utcnow()``) without raising.
+    if dt.tzinfo is not None:
+        dt = dt.replace(tzinfo=None)
+    return dt
+
+
+# Backwards-compatible private alias — internal callers within this
+# module continue to use ``_parse_ts`` so the original module-local
+# style is preserved even as the function gains a public name for
+# cross-module use.
+_parse_ts = parse_ts
 
 
 # ---------------------------------------------------------------------------

--- a/synthesis/unit_identifier.py
+++ b/synthesis/unit_identifier.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 
 import hashlib
 import sqlite3
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional, Union
 
@@ -155,8 +155,12 @@ def _pick_root(
     return best[1], best[2]
 
 
-def _parse_repo_number(node_ref: Optional[str]) -> Optional[tuple[str, int]]:
-    """Return ``(repo, number)`` for ``"owner/repo#N"`` refs, else None."""
+def parse_repo_number(node_ref: Optional[str]) -> Optional[tuple[str, int]]:
+    """Return ``(repo, number)`` for ``"owner/repo#N"`` refs, else None.
+
+    Public helper — ``synthesis.unit_timeline`` imports this to avoid a
+    duplicated copy.
+    """
     if not node_ref or "#" not in node_ref:
         return None
     repo, _, num = node_ref.rpartition("#")
@@ -164,6 +168,10 @@ def _parse_repo_number(node_ref: Optional[str]) -> Optional[tuple[str, int]]:
         return repo, int(num)
     except ValueError:
         return None
+
+
+# Private alias kept so intra-module call sites below do not churn.
+_parse_repo_number = parse_repo_number
 
 
 # ---------------------------------------------------------------------------
@@ -339,7 +347,10 @@ def identify_units(
     existing rows are preserved unchanged (append-only).
     """
     if now is None:
-        now = datetime.utcnow()
+        # ``datetime.utcnow()`` is deprecated on 3.12+. Build a naive-UTC
+        # datetime explicitly so the rest of this module's naive-vs-naive
+        # arithmetic keeps working.
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
 
     gh_path = Path(github_db_path)
     sess_path = Path(sessions_db_path)

--- a/synthesis/unit_identifier.py
+++ b/synthesis/unit_identifier.py
@@ -268,7 +268,7 @@ def _summarise_unit(
         for created, merged, updated in pr_rows:
             if merged:
                 continue
-            latest = metrics._parse_ts(updated) or metrics._parse_ts(created)
+            latest = metrics.parse_ts(updated) or metrics.parse_ts(created)
             if latest is None:
                 continue
             if now - latest <= timedelta(days=abandonment_days):
@@ -284,7 +284,7 @@ def _summarise_unit(
         # as "abandoned" — they just completed).
         last_activity: Optional[datetime] = None
         for ts in all_timestamps:
-            parsed = metrics._parse_ts(ts)
+            parsed = metrics.parse_ts(ts)
             if parsed is None:
                 continue
             if last_activity is None or parsed > last_activity:

--- a/synthesis/unit_identifier.py
+++ b/synthesis/unit_identifier.py
@@ -1,0 +1,419 @@
+"""G-2 unit identifier (Epic #17 — Issue #37).
+
+Walks ``graph_edges`` for a given ``week_start``, finds connected
+components via a hand-rolled union-find (no networkx — same minimalism
+convention as ``graph_builder``), materialises one row per component in
+the append-only ``units`` table, and fills in the per-unit metrics
+defined in ``synthesis.metrics``.
+
+Key invariants
+--------------
+* **Deterministic unit IDs.** ``unit_id = sha256("|".join(sorted(node_ids)))[:16]``.
+  Re-running over the same graph produces identical IDs.
+* **Append-only.** Writes use ``INSERT OR IGNORE`` keyed on
+  ``(week_start, unit_id)``. Re-running for the same ``week_start`` is a
+  no-op — historical rows are preserved even if the underlying graph
+  rotated.
+* **Singleton friendly.** Nodes with no incident edges produce
+  single-node units. Each still gets a deterministic ID, metrics, and
+  status derived from its lone node.
+* **Root pick is stable.** Priority ``issue > pr > commit > session``.
+  Ties broken by sorting ``node_id`` — never depends on insertion order.
+
+Status derivation
+-----------------
+A unit's ``status`` is a rough per-unit summary derived entirely from
+the fixture/live data we already have:
+
+* ``"open"``      — any issue/PR in the unit is currently open.
+* ``"closed"``    — every issue/PR is closed (for PRs: ``merged_at`` set
+  OR state == closed; no explicit ``state`` column — closed-unmerged PRs
+  fall out of here because ``merged_at`` is NULL and the issue/PR date
+  test fires the abandonment rule).
+* ``"abandoned"`` — last activity older than 14 days AND no open items.
+  ``cross_unit.py`` (Sub-Issue 6) refines this.
+
+These values are coarse and deliberately conservative. Downstream
+consumers treat them as hints; the true source of truth remains the
+per-event data in ``issues``/``pull_requests``/``sessions``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional, Union
+
+from synthesis import metrics
+
+
+# Priority order for picking a unit's "root" node. Lower index = higher
+# priority. ``session`` is last on purpose: sessions are the Claude-side
+# artefact and tell us nothing about the WHY of the work, which is
+# what a root label is supposed to summarise.
+_ROOT_PRIORITY = {"issue": 0, "pr": 1, "commit": 2, "session": 3}
+
+# Days of inactivity past which we mark a unit ``abandoned`` in the
+# absence of any open item. Epic ADR default; cross_unit.py may refine.
+_ABANDONMENT_DAYS_DEFAULT = 14
+
+
+# ---------------------------------------------------------------------------
+# Union-find
+# ---------------------------------------------------------------------------
+
+
+class _UnionFind:
+    """Minimal union-find. ``parent[x] == x`` is the root.
+
+    Path compression + union-by-size; both standard. No rank tracking —
+    size is enough for the handful of nodes we ever see in one week.
+    """
+
+    def __init__(self) -> None:
+        self._parent: dict[str, str] = {}
+        self._size: dict[str, int] = {}
+
+    def add(self, x: str) -> None:
+        if x not in self._parent:
+            self._parent[x] = x
+            self._size[x] = 1
+
+    def find(self, x: str) -> str:
+        # Iterative path compression to keep the stack bounded for
+        # pathological chains, not that we expect any.
+        root = x
+        while self._parent[root] != root:
+            root = self._parent[root]
+        # Compress.
+        cur = x
+        while self._parent[cur] != root:
+            self._parent[cur], cur = root, self._parent[cur]
+        return root
+
+    def union(self, a: str, b: str) -> None:
+        self.add(a)
+        self.add(b)
+        ra, rb = self.find(a), self.find(b)
+        if ra == rb:
+            return
+        # Attach the smaller tree under the larger.
+        if self._size[ra] < self._size[rb]:
+            ra, rb = rb, ra
+        self._parent[rb] = ra
+        self._size[ra] += self._size[rb]
+
+    def components(self) -> list[list[str]]:
+        """Return components as a list of sorted node-id lists.
+
+        The outer list is sorted by each component's smallest node_id so
+        iteration order is deterministic.
+        """
+        groups: dict[str, list[str]] = {}
+        for node in self._parent:
+            groups.setdefault(self.find(node), []).append(node)
+        return sorted(
+            (sorted(group) for group in groups.values()),
+            key=lambda g: g[0],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _unit_id_from_nodes(node_ids: list[str]) -> str:
+    """Deterministic 16-char unit ID from the component's node IDs.
+
+    ``sha256("|".join(sorted(node_ids)))[:16]``. The pipe separator
+    prevents collisions between ``"abc"+"def"`` and ``"ab"+"cdef"`` if a
+    future node naming scheme ever allowed concatenation ambiguity.
+    """
+    key = "|".join(sorted(node_ids))
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+
+
+def _pick_root(
+    nodes_in_unit: list[tuple[str, str, Optional[str]]],
+) -> tuple[str, str]:
+    """Return ``(root_node_type, root_node_id)`` for this unit.
+
+    *nodes_in_unit* is a list of ``(node_id, node_type, node_ref)``
+    tuples. We pick by priority first, then break ties by sorting
+    ``node_id`` so the pick is independent of row insertion order.
+    """
+    best = None
+    for node_id, node_type, _ref in nodes_in_unit:
+        prio = _ROOT_PRIORITY.get(node_type or "", 99)
+        key = (prio, node_id)
+        if best is None or key < best[0]:
+            best = (key, node_type or "", node_id)
+    assert best is not None  # guaranteed by caller: components never empty
+    return best[1], best[2]
+
+
+def _parse_repo_number(node_ref: Optional[str]) -> Optional[tuple[str, int]]:
+    """Return ``(repo, number)`` for ``"owner/repo#N"`` refs, else None."""
+    if not node_ref or "#" not in node_ref:
+        return None
+    repo, _, num = node_ref.rpartition("#")
+    try:
+        return repo, int(num)
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Status + metric aggregation for one unit
+# ---------------------------------------------------------------------------
+
+
+def _summarise_unit(
+    unit_nodes: list[tuple[str, str, Optional[str]]],
+    github_conn: sqlite3.Connection,
+    sessions_conn: sqlite3.Connection,
+    abandonment_days: int,
+    now: datetime,
+) -> dict:
+    """Collect metric + status inputs for one unit into one dict.
+
+    Returning a dict rather than a 7-tuple keeps the caller's row
+    assembly readable (``row[5]`` vs ``row["dark_time_pct"]``).
+    """
+    # --- gather per-type membership -----------------------------------
+    session_uuids: list[str] = []
+    issue_refs: list[tuple[str, int]] = []  # (repo, issue_number)
+    pr_refs: list[tuple[str, int]] = []     # (repo, pr_number)
+
+    for _nid, ntype, nref in unit_nodes:
+        if ntype == "session" and nref:
+            session_uuids.append(nref)
+        elif ntype == "issue":
+            parsed = _parse_repo_number(nref)
+            if parsed:
+                issue_refs.append(parsed)
+        elif ntype == "pr":
+            parsed = _parse_repo_number(nref)
+            if parsed:
+                pr_refs.append(parsed)
+
+    # --- pull source rows --------------------------------------------
+    session_rows: list[tuple[Optional[str], Optional[str], int]] = []
+    # (session_started_at, session_ended_at, reprompt_count)
+    if session_uuids:
+        placeholders = ",".join("?" * len(session_uuids))
+        cur = sessions_conn.execute(
+            f"SELECT session_started_at, session_ended_at, reprompt_count "
+            f"FROM sessions WHERE session_uuid IN ({placeholders})",
+            session_uuids,
+        )
+        session_rows = list(cur.fetchall())
+
+    issue_rows: list[tuple[str, Optional[str], Optional[str], Optional[str]]] = []
+    # (state, created_at, closed_at, updated_at)
+    for repo, num in issue_refs:
+        cur = github_conn.execute(
+            "SELECT state, created_at, closed_at, updated_at "
+            "FROM issues WHERE repo = ? AND issue_number = ?",
+            (repo, num),
+        )
+        row = cur.fetchone()
+        if row is not None:
+            issue_rows.append(row)
+
+    pr_rows: list[tuple[Optional[str], Optional[str], Optional[str]]] = []
+    # (created_at, merged_at, updated_at)
+    for repo, num in pr_refs:
+        cur = github_conn.execute(
+            "SELECT created_at, merged_at, updated_at "
+            "FROM pull_requests WHERE repo = ? AND pr_number = ?",
+            (repo, num),
+        )
+        row = cur.fetchone()
+        if row is not None:
+            pr_rows.append(row)
+
+    # --- metrics ------------------------------------------------------
+    all_timestamps: list[Optional[str]] = []
+    for started, ended, _rc in session_rows:
+        all_timestamps.append(started)
+        all_timestamps.append(ended)
+    for state, created, closed, updated in issue_rows:
+        all_timestamps.extend((created, closed, updated))
+    for created, merged, updated in pr_rows:
+        all_timestamps.extend((created, merged, updated))
+
+    elapsed = metrics.elapsed_days(all_timestamps)
+    dark = metrics.dark_time_pct(
+        [(s, e) for s, e, _ in session_rows]
+    )
+    reprompts = metrics.total_reprompts(session_uuids, sessions_conn)
+    cycles = metrics.review_cycles(pr_refs, github_conn)
+
+    # --- status -------------------------------------------------------
+    has_open = False
+    for state, *_ in issue_rows:
+        if (state or "").lower() == "open":
+            has_open = True
+            break
+    if not has_open:
+        # A PR without merged_at that is referenced here is either
+        # closed-unmerged or still open. We can't tell from the
+        # pull_requests table (no ``state`` column in the schema), so we
+        # treat missing ``merged_at`` as "open-ish" only when updated_at
+        # is recent; otherwise it's stale/abandoned.
+        for created, merged, updated in pr_rows:
+            if merged:
+                continue
+            latest = metrics._parse_ts(updated) or metrics._parse_ts(created)
+            if latest is None:
+                continue
+            if now - latest <= timedelta(days=abandonment_days):
+                has_open = True
+                break
+
+    status = "closed"
+    if has_open:
+        status = "open"
+    else:
+        # Abandonment check: last activity older than N days AND unit
+        # has any non-session content (singleton sessions don't qualify
+        # as "abandoned" — they just completed).
+        last_activity: Optional[datetime] = None
+        for ts in all_timestamps:
+            parsed = metrics._parse_ts(ts)
+            if parsed is None:
+                continue
+            if last_activity is None or parsed > last_activity:
+                last_activity = parsed
+        has_tracked_work = bool(issue_rows or pr_rows)
+        if (
+            has_tracked_work
+            and last_activity is not None
+            and now - last_activity > timedelta(days=abandonment_days)
+        ):
+            status = "abandoned"
+
+    return {
+        "elapsed_days": elapsed,
+        "dark_time_pct": dark,
+        "total_reprompts": reprompts,
+        "review_cycles": cycles,
+        "status": status,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def identify_units(
+    github_db_path: Union[str, Path],
+    sessions_db_path: Union[str, Path],
+    week_start: str,
+    *,
+    abandonment_days: int = _ABANDONMENT_DAYS_DEFAULT,
+    now: Optional[datetime] = None,
+) -> int:
+    """Populate ``units`` for *week_start*. Returns rows inserted.
+
+    *now* is an injection point for tests that need to pin the
+    abandonment cutoff. Defaults to ``datetime.utcnow()``.
+
+    Parameters
+    ----------
+    github_db_path, sessions_db_path:
+        Paths to the collector DBs. May be the same file (the fixture
+        packs both schemas into one SQLite).
+    week_start:
+        YYYY-MM-DD anchor. Only ``graph_nodes``/``graph_edges`` rows
+        with a matching ``week_start`` are considered.
+
+    Side effects
+    ------------
+    Writes to ``units`` via ``INSERT OR IGNORE``. Safe to re-run:
+    existing rows are preserved unchanged (append-only).
+    """
+    if now is None:
+        now = datetime.utcnow()
+
+    gh_path = Path(github_db_path)
+    sess_path = Path(sessions_db_path)
+    gh = sqlite3.connect(str(gh_path))
+    sess = gh if sess_path == gh_path else sqlite3.connect(str(sess_path))
+
+    try:
+        # --- read graph_nodes + graph_edges for this week -------------
+        node_rows = gh.execute(
+            "SELECT node_id, node_type, node_ref FROM graph_nodes "
+            "WHERE week_start = ? ORDER BY node_id",
+            (week_start,),
+        ).fetchall()
+        edge_rows = gh.execute(
+            "SELECT src_node_id, dst_node_id FROM graph_edges "
+            "WHERE week_start = ? ORDER BY src_node_id, dst_node_id",
+            (week_start,),
+        ).fetchall()
+
+        if not node_rows:
+            return 0
+
+        # --- build components -----------------------------------------
+        uf = _UnionFind()
+        for node_id, _type, _ref in node_rows:
+            uf.add(node_id)
+        node_set = {nid for nid, *_ in node_rows}
+        for src, dst in edge_rows:
+            # Guard against edges that reference nodes outside this
+            # week's partition. The graph builder shouldn't produce
+            # these, but tolerating them keeps the identifier robust to
+            # hand-edited debugging DBs.
+            if src in node_set and dst in node_set:
+                uf.union(src, dst)
+
+        node_info = {nid: (nt, nr) for nid, nt, nr in node_rows}
+        components = uf.components()
+
+        # --- write one row per component -----------------------------
+        inserted = 0
+        for comp in components:
+            unit_id = _unit_id_from_nodes(comp)
+            nodes_in_unit = [(nid, *node_info[nid]) for nid in comp]
+            root_type, root_id = _pick_root(nodes_in_unit)
+            summary = _summarise_unit(
+                nodes_in_unit,
+                github_conn=gh,
+                sessions_conn=sess,
+                abandonment_days=abandonment_days,
+                now=now,
+            )
+            cur = gh.execute(
+                "INSERT OR IGNORE INTO units "
+                "(week_start, unit_id, root_node_type, root_node_id, "
+                " elapsed_days, dark_time_pct, total_reprompts, "
+                " review_cycles, status) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    week_start,
+                    unit_id,
+                    root_type,
+                    root_id,
+                    summary["elapsed_days"],
+                    summary["dark_time_pct"],
+                    summary["total_reprompts"],
+                    summary["review_cycles"],
+                    summary["status"],
+                ),
+            )
+            if cur.rowcount:
+                inserted += 1
+        gh.commit()
+        return inserted
+    finally:
+        if sess is not gh:
+            sess.close()
+        gh.close()

--- a/synthesis/unit_timeline.py
+++ b/synthesis/unit_timeline.py
@@ -38,20 +38,14 @@ from __future__ import annotations
 import sqlite3
 from typing import Iterable, Optional
 
+from synthesis.unit_identifier import parse_repo_number as _parse_repo_number
+
 
 # ---------------------------------------------------------------------------
-# Node-ref parsing (mirrors unit_identifier)
+# Node-ref parsing is shared with ``unit_identifier`` via the imported
+# ``parse_repo_number`` (aliased to ``_parse_repo_number`` to match the
+# private-by-convention style used below).
 # ---------------------------------------------------------------------------
-
-
-def _parse_repo_number(node_ref: Optional[str]) -> Optional[tuple[str, int]]:
-    if not node_ref or "#" not in node_ref:
-        return None
-    repo, _, num = node_ref.rpartition("#")
-    try:
-        return repo, int(num)
-    except ValueError:
-        return None
 
 
 # ---------------------------------------------------------------------------

--- a/synthesis/unit_timeline.py
+++ b/synthesis/unit_timeline.py
@@ -1,0 +1,232 @@
+"""G-3 unit timeline renderer (Epic #17 — Issue #37).
+
+Pure function: given a unit's membership (derived by walking
+``graph_edges`` from the unit's ``root_node_id`` or by looking up the
+unit's component from the identifier), return a chronological list of
+events — session start/end, issue opened/closed, PR opened/merged,
+commits — suitable for LLM prompt assembly in Sub-Issue 5.
+
+Shape
+-----
+Each event is a dict::
+
+    {
+        "timestamp": "2025-01-06T09:00:00Z",   # ISO-8601 string
+        "type": "session_start",                # see TYPES below
+        "node_id": "n-u1-sess-a",               # the node this event is about
+        "description": "Session 00000000...101 started",
+    }
+
+TYPES
+-----
+``session_start`` / ``session_end``
+    From ``sessions.session_started_at`` / ``session_ended_at``.
+``issue_opened`` / ``issue_closed``
+    From ``issues.created_at`` / ``issues.closed_at``.
+``pr_opened`` / ``pr_merged``
+    From ``pull_requests.created_at`` / ``pull_requests.merged_at``.
+``commit_authored``
+    From ``commits.authored_at``.
+
+Ordering is by ``(timestamp, node_id, type)`` so ties are stable across
+runs. Events with no timestamp are dropped — the renderer is a
+timeline, not an inventory.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Iterable, Optional
+
+
+# ---------------------------------------------------------------------------
+# Node-ref parsing (mirrors unit_identifier)
+# ---------------------------------------------------------------------------
+
+
+def _parse_repo_number(node_ref: Optional[str]) -> Optional[tuple[str, int]]:
+    if not node_ref or "#" not in node_ref:
+        return None
+    repo, _, num = node_ref.rpartition("#")
+    try:
+        return repo, int(num)
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Per-type event collectors
+# ---------------------------------------------------------------------------
+
+
+def _session_events(
+    node_id: str,
+    uuid: str,
+    sessions_conn: sqlite3.Connection,
+) -> list[dict]:
+    cur = sessions_conn.execute(
+        "SELECT session_started_at, session_ended_at "
+        "FROM sessions WHERE session_uuid = ?",
+        (uuid,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return []
+    started, ended = row
+    events: list[dict] = []
+    if started:
+        events.append({
+            "timestamp": started,
+            "type": "session_start",
+            "node_id": node_id,
+            "description": f"Session {uuid} started",
+        })
+    if ended:
+        events.append({
+            "timestamp": ended,
+            "type": "session_end",
+            "node_id": node_id,
+            "description": f"Session {uuid} ended",
+        })
+    return events
+
+
+def _issue_events(
+    node_id: str,
+    repo: str,
+    number: int,
+    github_conn: sqlite3.Connection,
+) -> list[dict]:
+    cur = github_conn.execute(
+        "SELECT title, created_at, closed_at FROM issues "
+        "WHERE repo = ? AND issue_number = ?",
+        (repo, number),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return []
+    title, created, closed = row
+    events: list[dict] = []
+    if created:
+        events.append({
+            "timestamp": created,
+            "type": "issue_opened",
+            "node_id": node_id,
+            "description": f"Issue {repo}#{number} opened: {title or ''}".strip(),
+        })
+    if closed:
+        events.append({
+            "timestamp": closed,
+            "type": "issue_closed",
+            "node_id": node_id,
+            "description": f"Issue {repo}#{number} closed",
+        })
+    return events
+
+
+def _pr_events(
+    node_id: str,
+    repo: str,
+    number: int,
+    github_conn: sqlite3.Connection,
+) -> list[dict]:
+    cur = github_conn.execute(
+        "SELECT title, created_at, merged_at FROM pull_requests "
+        "WHERE repo = ? AND pr_number = ?",
+        (repo, number),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return []
+    title, created, merged = row
+    events: list[dict] = []
+    if created:
+        events.append({
+            "timestamp": created,
+            "type": "pr_opened",
+            "node_id": node_id,
+            "description": f"PR {repo}#{number} opened: {title or ''}".strip(),
+        })
+    if merged:
+        events.append({
+            "timestamp": merged,
+            "type": "pr_merged",
+            "node_id": node_id,
+            "description": f"PR {repo}#{number} merged",
+        })
+    return events
+
+
+def _commit_events(
+    node_id: str,
+    sha: str,
+    github_conn: sqlite3.Connection,
+) -> list[dict]:
+    cur = github_conn.execute(
+        "SELECT authored_at, message FROM commits WHERE sha = ?",
+        (sha,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return []
+    authored, message = row
+    if not authored:
+        return []
+    # Truncate commit messages aggressively — the timeline is meant for
+    # LLM consumption, and squash-merge commits can carry kilobytes of
+    # body text (see ``commits.message`` note in db.py).
+    summary = (message or "").splitlines()[0] if message else ""
+    return [{
+        "timestamp": authored,
+        "type": "commit_authored",
+        "node_id": node_id,
+        "description": f"Commit {sha[:8]}: {summary}".strip().rstrip(":"),
+    }]
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def render_timeline(
+    unit_nodes: Iterable[tuple[str, str, Optional[str]]],
+    github_conn: sqlite3.Connection,
+    sessions_conn: sqlite3.Connection,
+) -> list[dict]:
+    """Return chronological events for the nodes in *unit_nodes*.
+
+    *unit_nodes* is an iterable of ``(node_id, node_type, node_ref)``
+    tuples — same shape as the rows produced by
+    ``unit_identifier._summarise_unit``. Callers typically resolve the
+    nodes for a specific ``unit_id`` first (e.g. by re-running
+    union-find over the graph for that week_start) and then pass the
+    component in here.
+
+    Returned dicts are sorted by ``(timestamp, node_id, type)`` so the
+    output is deterministic — same inputs → byte-identical output,
+    suitable for snapshot testing.
+    """
+    events: list[dict] = []
+    for node_id, node_type, node_ref in unit_nodes:
+        if node_type == "session" and node_ref:
+            events.extend(_session_events(node_id, node_ref, sessions_conn))
+        elif node_type == "issue":
+            parsed = _parse_repo_number(node_ref)
+            if parsed:
+                repo, num = parsed
+                events.extend(_issue_events(node_id, repo, num, github_conn))
+        elif node_type == "pr":
+            parsed = _parse_repo_number(node_ref)
+            if parsed:
+                repo, num = parsed
+                events.extend(_pr_events(node_id, repo, num, github_conn))
+        elif node_type == "commit" and node_ref:
+            # ``node_ref`` for commits is ``"repo@sha"``; extract the
+            # sha after the last ``@``.
+            _, _, sha = node_ref.rpartition("@")
+            if sha:
+                events.extend(_commit_events(node_id, sha, github_conn))
+
+    events.sort(key=lambda e: (e["timestamp"], e["node_id"], e["type"]))
+    return events

--- a/tests/fixtures/synthesis/expected_units.json
+++ b/tests/fixtures/synthesis/expected_units.json
@@ -1,0 +1,40 @@
+{
+  "_readme": "Snapshot of the expected output of synthesis.unit_identifier.identify_units when run against tests/fixtures/synthesis/golden.sqlite with week_start='2025-01-06' and now=2025-01-13T00:00:00. See tests/test_unit_identifier.py. 'now' is pinned so abandonment status is deterministic (within 14 days of unit 1/3 activity, far past unit 2).",
+  "week_start": "2025-01-06",
+  "now": "2025-01-13T00:00:00",
+  "units": [
+    {
+      "unit_id": "0e5eb65932c9f5f7",
+      "nodes": ["n-u3-sess"],
+      "root_node_type": "session",
+      "root_node_id": "n-u3-sess",
+      "elapsed_days": 0.013888888888888888,
+      "dark_time_pct": 0.0,
+      "total_reprompts": 0,
+      "review_cycles": 0,
+      "status": "closed"
+    },
+    {
+      "unit_id": "52c2800675966c48",
+      "nodes": ["n-u2-issue", "n-u2-pr"],
+      "root_node_type": "issue",
+      "root_node_id": "n-u2-issue",
+      "elapsed_days": 1.9583333333333333,
+      "dark_time_pct": 0.0,
+      "total_reprompts": 0,
+      "review_cycles": 0,
+      "status": "open"
+    },
+    {
+      "unit_id": "9dcb15f9dbf5b54c",
+      "nodes": ["n-u1-issue", "n-u1-pr-a", "n-u1-pr-b", "n-u1-sess-a", "n-u1-sess-b"],
+      "root_node_type": "issue",
+      "root_node_id": "n-u1-issue",
+      "elapsed_days": 2.2534722222222223,
+      "dark_time_pct": 0.9532710280373832,
+      "total_reprompts": 1,
+      "review_cycles": 2,
+      "status": "closed"
+    }
+  ]
+}

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,196 @@
+"""Unit tests for ``synthesis/metrics.py`` (Epic #17 — Issue #37).
+
+Each metric is tested with hand-crafted inputs so failures point at the
+calculation, not at fixture wiring. The fixture-wired end-to-end
+assertions live in ``tests/test_unit_identifier.py``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from synthesis import metrics
+
+
+# ---------------------------------------------------------------------------
+# elapsed_days
+# ---------------------------------------------------------------------------
+
+
+class TestElapsedDays:
+    def test_two_timestamps_one_day_apart(self):
+        assert metrics.elapsed_days([
+            "2025-01-06T09:00:00Z",
+            "2025-01-07T09:00:00Z",
+        ]) == pytest.approx(1.0)
+
+    def test_with_none_values_ignored(self):
+        assert metrics.elapsed_days([
+            None,
+            "2025-01-06T09:00:00Z",
+            "",
+            "2025-01-06T21:00:00Z",
+            None,
+        ]) == pytest.approx(0.5)
+
+    def test_single_timestamp_returns_zero(self):
+        assert metrics.elapsed_days(["2025-01-06T09:00:00Z"]) == 0.0
+
+    def test_empty_returns_zero(self):
+        assert metrics.elapsed_days([]) == 0.0
+
+    def test_all_none_returns_zero(self):
+        assert metrics.elapsed_days([None, None, ""]) == 0.0
+
+    def test_malformed_skipped(self):
+        # "not-a-date" is dropped; valid pair still produces a span.
+        assert metrics.elapsed_days([
+            "not-a-date",
+            "2025-01-06T00:00:00Z",
+            "2025-01-08T00:00:00Z",
+        ]) == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# dark_time_pct
+# ---------------------------------------------------------------------------
+
+
+class TestDarkTimePct:
+    def test_two_disjoint_sessions(self):
+        # Two 1-hour sessions within a 10-hour window → 8h dark / 10h
+        intervals = [
+            ("2025-01-06T00:00:00Z", "2025-01-06T01:00:00Z"),
+            ("2025-01-06T09:00:00Z", "2025-01-06T10:00:00Z"),
+        ]
+        assert metrics.dark_time_pct(intervals) == pytest.approx(0.8)
+
+    def test_single_session_returns_zero(self):
+        """ADR Decision 3: dark_time has no meaning for a single session."""
+        assert metrics.dark_time_pct([
+            ("2025-01-06T09:00:00Z", "2025-01-06T10:00:00Z"),
+        ]) == 0.0
+
+    def test_empty_returns_zero(self):
+        assert metrics.dark_time_pct([]) == 0.0
+
+    def test_missing_timestamps_skipped(self):
+        intervals = [
+            (None, "2025-01-06T01:00:00Z"),
+            ("2025-01-06T02:00:00Z", None),
+            ("2025-01-06T09:00:00Z", "2025-01-06T10:00:00Z"),
+        ]
+        # After dropping the broken two, one valid interval → 0.0
+        assert metrics.dark_time_pct(intervals) == 0.0
+
+    def test_overlapping_sessions_clamped(self):
+        # Two overlapping 1h sessions cover only 1.5h of real time;
+        # active = 2h, span = 1.5h, ratio = 1 - 4/3 = negative → clamp 0
+        intervals = [
+            ("2025-01-06T00:00:00Z", "2025-01-06T01:00:00Z"),
+            ("2025-01-06T00:30:00Z", "2025-01-06T01:30:00Z"),
+        ]
+        assert metrics.dark_time_pct(intervals) == 0.0
+
+    def test_malformed_order_skipped(self):
+        # end before start should be rejected.
+        intervals = [
+            ("2025-01-06T02:00:00Z", "2025-01-06T01:00:00Z"),
+            ("2025-01-06T09:00:00Z", "2025-01-06T10:00:00Z"),
+        ]
+        # One valid after filtering → 0.0
+        assert metrics.dark_time_pct(intervals) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# total_reprompts
+# ---------------------------------------------------------------------------
+
+
+class TestTotalReprompts:
+    @pytest.fixture
+    def sessions_conn(self):
+        conn = sqlite3.connect(":memory:")
+        conn.execute(
+            "CREATE TABLE sessions (session_uuid TEXT PRIMARY KEY, reprompt_count INTEGER)"
+        )
+        conn.executemany(
+            "INSERT INTO sessions VALUES (?, ?)",
+            [("a", 2), ("b", 5), ("c", None), ("d", 0)],
+        )
+        conn.commit()
+        yield conn
+        conn.close()
+
+    def test_sum_across_rows(self, sessions_conn):
+        assert metrics.total_reprompts(["a", "b"], sessions_conn) == 7
+
+    def test_null_coerced_to_zero(self, sessions_conn):
+        assert metrics.total_reprompts(["a", "c"], sessions_conn) == 2
+
+    def test_missing_rows_ignored(self, sessions_conn):
+        assert metrics.total_reprompts(["a", "does-not-exist"], sessions_conn) == 2
+
+    def test_empty_returns_zero(self, sessions_conn):
+        assert metrics.total_reprompts([], sessions_conn) == 0
+
+
+# ---------------------------------------------------------------------------
+# review_cycles
+# ---------------------------------------------------------------------------
+
+
+class TestReviewCycles:
+    @pytest.fixture
+    def github_conn(self):
+        conn = sqlite3.connect(":memory:")
+        conn.execute(
+            "CREATE TABLE pull_requests ("
+            "repo TEXT, pr_number INTEGER, "
+            "review_comments_json TEXT, push_count INTEGER, "
+            "PRIMARY KEY (repo, pr_number))"
+        )
+        conn.executemany(
+            "INSERT INTO pull_requests VALUES (?, ?, ?, ?)",
+            [
+                ("r", 1, '[{"id": 1}, {"id": 2}, {"id": 3}]', 0),
+                ("r", 2, "[]", 4),
+                ("r", 3, None, 2),
+                ("r", 4, "malformed[", 1),
+                ("r", 5, "[]", 0),
+            ],
+        )
+        conn.commit()
+        yield conn
+        conn.close()
+
+    def test_review_comments_preferred(self, github_conn):
+        assert metrics.review_cycles([("r", 1)], github_conn) == 3
+
+    def test_fallback_to_push_count(self, github_conn):
+        # empty array → fall back to push_count=4
+        assert metrics.review_cycles([("r", 2)], github_conn) == 4
+
+    def test_null_review_comments_falls_back(self, github_conn):
+        assert metrics.review_cycles([("r", 3)], github_conn) == 2
+
+    def test_malformed_json_falls_back(self, github_conn):
+        assert metrics.review_cycles([("r", 4)], github_conn) == 1
+
+    def test_both_empty_returns_zero(self, github_conn):
+        assert metrics.review_cycles([("r", 5)], github_conn) == 0
+
+    def test_multiple_prs_sum(self, github_conn):
+        assert metrics.review_cycles(
+            [("r", 1), ("r", 2)], github_conn
+        ) == 3 + 4
+
+    def test_missing_pr_ignored(self, github_conn):
+        assert metrics.review_cycles(
+            [("r", 1), ("r", 999)], github_conn
+        ) == 3
+
+    def test_empty_returns_zero(self, github_conn):
+        assert metrics.review_cycles([], github_conn) == 0

--- a/tests/test_unit_identifier.py
+++ b/tests/test_unit_identifier.py
@@ -1,0 +1,284 @@
+"""Tests for ``synthesis/unit_identifier.py`` (Epic #17 — Issue #37).
+
+Uses the committed golden fixture
+(``tests/fixtures/synthesis/golden.sqlite``). The fixture ships with
+pre-populated ``units`` rows that represent the *ground truth topology*
+(three connected components); these tests truncate that pre-fill and
+re-derive the same three components via ``identify_units``.
+
+All assertions pin ``now=datetime(2025, 1, 13)`` — one week after
+unit 1's last activity, ~26 days after unit 2's — so the
+status-abandonment logic is deterministic across CI runs.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from synthesis.unit_identifier import identify_units, _UnionFind, _unit_id_from_nodes
+
+
+FIXTURE_SRC = Path(__file__).parent / "fixtures" / "synthesis" / "golden.sqlite"
+EXPECTED_PATH = Path(__file__).parent / "fixtures" / "synthesis" / "expected_units.json"
+
+# Pinned "now" matching ``expected_units.json``. 2025-01-13 is 5 days
+# after unit 1's last event, 33 days after unit 2's last event.
+PINNED_NOW = datetime(2025, 1, 13, 0, 0, 0)
+WEEK_START = "2025-01-06"
+
+
+def _fresh_fixture(tmp_path: Path) -> Path:
+    """Return a writable copy of the golden fixture with ``units`` cleared.
+
+    The fixture's committed ``units`` rows are ground-truth documentation
+    (three components, known topology). For tests that exercise the
+    identifier we truncate them so re-population is visible.
+    """
+    dst = tmp_path / "golden.sqlite"
+    shutil.copy(FIXTURE_SRC, dst)
+    conn = sqlite3.connect(str(dst))
+    try:
+        conn.execute("DELETE FROM units")
+        conn.commit()
+    finally:
+        conn.close()
+    return dst
+
+
+# ---------------------------------------------------------------------------
+# Union-find sanity
+# ---------------------------------------------------------------------------
+
+
+class TestUnionFind:
+    def test_singletons_stay_separate(self):
+        uf = _UnionFind()
+        uf.add("a")
+        uf.add("b")
+        uf.add("c")
+        assert uf.components() == [["a"], ["b"], ["c"]]
+
+    def test_chain_merges(self):
+        uf = _UnionFind()
+        uf.union("a", "b")
+        uf.union("b", "c")
+        assert uf.components() == [["a", "b", "c"]]
+
+    def test_two_components(self):
+        uf = _UnionFind()
+        uf.union("a", "b")
+        uf.union("c", "d")
+        assert uf.components() == [["a", "b"], ["c", "d"]]
+
+    def test_idempotent_union(self):
+        uf = _UnionFind()
+        uf.union("a", "b")
+        uf.union("a", "b")  # second call is a no-op
+        assert uf.components() == [["a", "b"]]
+
+
+class TestUnitIdGeneration:
+    def test_id_is_deterministic(self):
+        a = _unit_id_from_nodes(["a", "b", "c"])
+        b = _unit_id_from_nodes(["c", "b", "a"])  # order independent
+        assert a == b
+        assert len(a) == 16
+
+    def test_id_differs_by_membership(self):
+        assert _unit_id_from_nodes(["a", "b"]) != _unit_id_from_nodes(["a", "c"])
+
+
+# ---------------------------------------------------------------------------
+# Fixture-level assertions
+# ---------------------------------------------------------------------------
+
+
+class TestIdentifyUnitsFixture:
+    def test_three_units_produced(self, tmp_path):
+        db = _fresh_fixture(tmp_path)
+        inserted = identify_units(
+            db, db, WEEK_START, now=PINNED_NOW,
+        )
+        assert inserted == 3
+
+        conn = sqlite3.connect(str(db))
+        try:
+            rows = conn.execute(
+                "SELECT unit_id, root_node_type, root_node_id, status "
+                "FROM units WHERE week_start = ? "
+                "ORDER BY unit_id",
+                (WEEK_START,),
+            ).fetchall()
+        finally:
+            conn.close()
+        assert len(rows) == 3
+
+    def test_expected_unit_ids_and_membership(self, tmp_path):
+        """Unit IDs and their node membership match the committed snapshot."""
+        db = _fresh_fixture(tmp_path)
+        identify_units(db, db, WEEK_START, now=PINNED_NOW)
+
+        expected = json.loads(EXPECTED_PATH.read_text())
+        expected_ids = sorted(u["unit_id"] for u in expected["units"])
+
+        conn = sqlite3.connect(str(db))
+        try:
+            actual_ids = sorted(r[0] for r in conn.execute(
+                "SELECT unit_id FROM units WHERE week_start = ?",
+                (WEEK_START,),
+            ).fetchall())
+        finally:
+            conn.close()
+        assert actual_ids == expected_ids
+
+    def test_metric_values_match_snapshot(self, tmp_path):
+        db = _fresh_fixture(tmp_path)
+        identify_units(db, db, WEEK_START, now=PINNED_NOW)
+        expected = {
+            u["unit_id"]: u
+            for u in json.loads(EXPECTED_PATH.read_text())["units"]
+        }
+
+        conn = sqlite3.connect(str(db))
+        try:
+            rows = conn.execute(
+                "SELECT unit_id, root_node_type, root_node_id, "
+                "elapsed_days, dark_time_pct, total_reprompts, "
+                "review_cycles, status "
+                "FROM units WHERE week_start = ?",
+                (WEEK_START,),
+            ).fetchall()
+        finally:
+            conn.close()
+
+        for unit_id, rtype, rid, elapsed, dark, reprompts, cycles, status in rows:
+            exp = expected[unit_id]
+            assert rtype == exp["root_node_type"], unit_id
+            assert rid == exp["root_node_id"], unit_id
+            assert elapsed == pytest.approx(exp["elapsed_days"]), unit_id
+            assert dark == pytest.approx(exp["dark_time_pct"]), unit_id
+            assert reprompts == exp["total_reprompts"], unit_id
+            assert cycles == exp["review_cycles"], unit_id
+            assert status == exp["status"], unit_id
+
+    def test_unit_ids_deterministic_across_runs(self, tmp_path):
+        """Two fresh runs produce identical unit IDs in the same order."""
+        first = _fresh_fixture(tmp_path)
+        identify_units(first, first, WEEK_START, now=PINNED_NOW)
+
+        second_dir = tmp_path / "run2"
+        second_dir.mkdir()
+        second = _fresh_fixture(second_dir)
+        identify_units(second, second, WEEK_START, now=PINNED_NOW)
+
+        def _ids(path: Path) -> list[str]:
+            conn = sqlite3.connect(str(path))
+            try:
+                return [r[0] for r in conn.execute(
+                    "SELECT unit_id FROM units WHERE week_start = ? ORDER BY unit_id",
+                    (WEEK_START,),
+                ).fetchall()]
+            finally:
+                conn.close()
+
+        assert _ids(first) == _ids(second)
+
+    def test_rerun_is_no_op(self, tmp_path):
+        """Second identify_units for the same week_start inserts 0 rows."""
+        db = _fresh_fixture(tmp_path)
+        first_inserted = identify_units(db, db, WEEK_START, now=PINNED_NOW)
+        second_inserted = identify_units(db, db, WEEK_START, now=PINNED_NOW)
+        assert first_inserted == 3
+        assert second_inserted == 0
+
+        # Row count didn't change.
+        conn = sqlite3.connect(str(db))
+        try:
+            n = conn.execute(
+                "SELECT COUNT(*) FROM units WHERE week_start = ?",
+                (WEEK_START,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert n == 3
+
+    def test_rerun_preserves_existing_rows(self, tmp_path):
+        """Pre-existing units for the same (week, unit_id) are preserved.
+
+        We seed a row with a bogus metric value; after identify_units
+        runs, that value MUST still be there — append-only semantics.
+        """
+        db = _fresh_fixture(tmp_path)
+        conn = sqlite3.connect(str(db))
+        try:
+            # Pre-seed the singleton unit with sentinel values.
+            conn.execute(
+                "INSERT INTO units VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (WEEK_START, "0e5eb65932c9f5f7", "session", "n-u3-sess",
+                 999.0, 0.5, 42, 7, "sentinel"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        identify_units(db, db, WEEK_START, now=PINNED_NOW)
+
+        conn = sqlite3.connect(str(db))
+        try:
+            row = conn.execute(
+                "SELECT elapsed_days, status FROM units "
+                "WHERE week_start = ? AND unit_id = ?",
+                (WEEK_START, "0e5eb65932c9f5f7"),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == 999.0  # sentinel preserved
+        assert row[1] == "sentinel"  # sentinel preserved
+
+    def test_singleton_handling(self, tmp_path):
+        """The singleton session becomes its own unit with dark_time=0."""
+        db = _fresh_fixture(tmp_path)
+        identify_units(db, db, WEEK_START, now=PINNED_NOW)
+
+        conn = sqlite3.connect(str(db))
+        try:
+            row = conn.execute(
+                "SELECT root_node_type, root_node_id, dark_time_pct "
+                "FROM units WHERE week_start = ? AND unit_id = ?",
+                (WEEK_START, "0e5eb65932c9f5f7"),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row == ("session", "n-u3-sess", 0.0)
+
+    def test_empty_graph_returns_zero(self, tmp_path):
+        """No graph_nodes rows for the week → nothing written."""
+        db = _fresh_fixture(tmp_path)
+        conn = sqlite3.connect(str(db))
+        try:
+            conn.execute("DELETE FROM graph_nodes WHERE week_start = ?", (WEEK_START,))
+            conn.execute("DELETE FROM graph_edges WHERE week_start = ?", (WEEK_START,))
+            conn.commit()
+        finally:
+            conn.close()
+        inserted = identify_units(db, db, WEEK_START, now=PINNED_NOW)
+        assert inserted == 0
+
+    def test_separate_db_paths(self, tmp_path):
+        """identify_units accepts distinct github/sessions paths.
+
+        Sanity check — the same fixture copied twice should produce
+        identical units regardless of whether both paths point at the
+        same file or two identical files.
+        """
+        gh = _fresh_fixture(tmp_path)
+        sess = tmp_path / "sessions_copy.sqlite"
+        shutil.copy(gh, sess)
+        inserted = identify_units(gh, sess, WEEK_START, now=PINNED_NOW)
+        assert inserted == 3

--- a/tests/test_unit_identifier.py
+++ b/tests/test_unit_identifier.py
@@ -227,7 +227,13 @@ class TestIdentifyUnitsFixture:
         finally:
             conn.close()
 
-        identify_units(db, db, WEEK_START, now=PINNED_NOW)
+        # After the pre-seed for the singleton (unit_id=0e5eb65932c9f5f7),
+        # identify_units should insert only the other two components —
+        # the seeded row is preserved via INSERT OR IGNORE. Pinning the
+        # return value here closes the gap where a silent overwrite +
+        # re-insert would still make the row-value assertions below pass.
+        inserted = identify_units(db, db, WEEK_START, now=PINNED_NOW)
+        assert inserted == 2
 
         conn = sqlite3.connect(str(db))
         try:

--- a/tests/test_unit_timeline.py
+++ b/tests/test_unit_timeline.py
@@ -1,0 +1,182 @@
+"""Tests for ``synthesis/unit_timeline.py`` (Epic #17 — Issue #37).
+
+Snapshot-style assertions against the golden fixture. The renderer is a
+pure function — same inputs produce byte-identical events — so these
+tests pin both ordering and descriptions.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+from pathlib import Path
+
+from synthesis.unit_timeline import render_timeline
+
+
+FIXTURE_SRC = Path(__file__).parent / "fixtures" / "synthesis" / "golden.sqlite"
+
+
+def _fresh_fixture(tmp_path: Path) -> Path:
+    dst = tmp_path / "golden.sqlite"
+    shutil.copy(FIXTURE_SRC, dst)
+    return dst
+
+
+# ---------------------------------------------------------------------------
+# Unit 1 — multi-session / multi-PR
+# ---------------------------------------------------------------------------
+
+
+def _unit_1_nodes():
+    """Match the fixture's Unit 1 component."""
+    return [
+        ("n-u1-issue", "issue", "example/repo#201"),
+        ("n-u1-pr-a", "pr", "example/repo#301"),
+        ("n-u1-pr-b", "pr", "example/repo#302"),
+        ("n-u1-sess-a", "session", "00000000-0000-0000-0000-000000000101"),
+        ("n-u1-sess-b", "session", "00000000-0000-0000-0000-000000000102"),
+    ]
+
+
+class TestRenderTimelineUnit1:
+    def test_event_count(self, tmp_path):
+        db = _fresh_fixture(tmp_path)
+        conn = sqlite3.connect(str(db))
+        try:
+            events = render_timeline(_unit_1_nodes(), conn, conn)
+        finally:
+            conn.close()
+        # 1 issue_opened + 1 issue_closed + 2 pr_opened + 2 pr_merged
+        # + 2 session_start + 2 session_end = 10
+        assert len(events) == 10
+
+    def test_chronological_order(self, tmp_path):
+        db = _fresh_fixture(tmp_path)
+        conn = sqlite3.connect(str(db))
+        try:
+            events = render_timeline(_unit_1_nodes(), conn, conn)
+        finally:
+            conn.close()
+        timestamps = [e["timestamp"] for e in events]
+        assert timestamps == sorted(timestamps)
+
+    def test_snapshot(self, tmp_path):
+        db = _fresh_fixture(tmp_path)
+        conn = sqlite3.connect(str(db))
+        try:
+            events = render_timeline(_unit_1_nodes(), conn, conn)
+        finally:
+            conn.close()
+
+        # First event: issue opened at 2025-01-06T08:55:00Z
+        assert events[0] == {
+            "timestamp": "2025-01-06T08:55:00Z",
+            "type": "issue_opened",
+            "node_id": "n-u1-issue",
+            "description": "Issue example/repo#201 opened: Unit 1 multi-session issue",
+        }
+        # Last event: issue closed at 2025-01-08T15:00:00Z
+        assert events[-1] == {
+            "timestamp": "2025-01-08T15:00:00Z",
+            "type": "issue_closed",
+            "node_id": "n-u1-issue",
+            "description": "Issue example/repo#201 closed",
+        }
+
+    def test_session_and_pr_events_present(self, tmp_path):
+        db = _fresh_fixture(tmp_path)
+        conn = sqlite3.connect(str(db))
+        try:
+            events = render_timeline(_unit_1_nodes(), conn, conn)
+        finally:
+            conn.close()
+        types = [e["type"] for e in events]
+        assert types.count("session_start") == 2
+        assert types.count("session_end") == 2
+        assert types.count("pr_opened") == 2
+        assert types.count("pr_merged") == 2
+
+
+# ---------------------------------------------------------------------------
+# Unit 2 — abandoned (open issue + closed-unmerged PR, no sessions)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderTimelineUnit2:
+    def _unit_2_nodes(self):
+        return [
+            ("n-u2-issue", "issue", "example/repo#202"),
+            ("n-u2-pr", "pr", "example/repo#303"),
+        ]
+
+    def test_no_merge_event_for_unmerged_pr(self, tmp_path):
+        db = _fresh_fixture(tmp_path)
+        conn = sqlite3.connect(str(db))
+        try:
+            events = render_timeline(self._unit_2_nodes(), conn, conn)
+        finally:
+            conn.close()
+        types = {e["type"] for e in events}
+        # Unit 2's PR 303 never merged, issue 202 still open.
+        assert "pr_merged" not in types
+        assert "issue_closed" not in types
+        assert "issue_opened" in types
+        assert "pr_opened" in types
+
+
+# ---------------------------------------------------------------------------
+# Unit 3 — singleton session
+# ---------------------------------------------------------------------------
+
+
+class TestRenderTimelineUnit3:
+    def test_only_session_events(self, tmp_path):
+        db = _fresh_fixture(tmp_path)
+        conn = sqlite3.connect(str(db))
+        try:
+            events = render_timeline(
+                [("n-u3-sess", "session", "00000000-0000-0000-0000-000000000303")],
+                conn,
+                conn,
+            )
+        finally:
+            conn.close()
+        assert [e["type"] for e in events] == ["session_start", "session_end"]
+        assert events[0]["timestamp"] == "2025-01-07T16:00:00Z"
+        assert events[1]["timestamp"] == "2025-01-07T16:20:00Z"
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_two_calls_identical(self, tmp_path):
+        db = _fresh_fixture(tmp_path)
+        conn = sqlite3.connect(str(db))
+        try:
+            a = render_timeline(_unit_1_nodes(), conn, conn)
+            b = render_timeline(_unit_1_nodes(), conn, conn)
+        finally:
+            conn.close()
+        assert a == b
+
+    def test_input_order_does_not_matter(self, tmp_path):
+        db = _fresh_fixture(tmp_path)
+        conn = sqlite3.connect(str(db))
+        try:
+            a = render_timeline(_unit_1_nodes(), conn, conn)
+            b = render_timeline(list(reversed(_unit_1_nodes())), conn, conn)
+        finally:
+            conn.close()
+        assert a == b
+
+    def test_empty_nodes_returns_empty(self, tmp_path):
+        db = _fresh_fixture(tmp_path)
+        conn = sqlite3.connect(str(db))
+        try:
+            assert render_timeline([], conn, conn) == []
+        finally:
+            conn.close()


### PR DESCRIPTION
Closes #37. Part of epic #17.

## Changes
- `synthesis/unit_identifier.py`: union-find unit identification, persistent units table (append-only)
- `synthesis/metrics.py`: elapsed_days, dark_time_pct (sessions-only), total_reprompts, review_cycles
- `synthesis/unit_timeline.py`: pure chronological event renderer per unit
- Tests: fixture-based assertions for 3-unit topology, metric values, snapshot

## Acceptance criteria
- [x] Golden fixture produces exactly 3 units with expected node membership
- [x] Metric values match snapshotted expectations
- [x] Unit IDs deterministic across runs
- [x] Re-running for same week_start is a no-op (append-only)
- [x] Singleton handling tested
- [x] Timeline snapshot test passes