### PR TITLE
feat(#39): S-2 weekly synthesis + S-3 output writer + am-synthesize entry point

### DIFF
--- a/am_i_shipping/config_loader.py
+++ b/am_i_shipping/config_loader.py
@@ -109,6 +109,22 @@ class Config:
             p = self._config_dir / p
         return p
 
+    @property
+    def synthesis_output_path(self) -> Path:
+        """Return the resolved synthesis output directory as an absolute Path.
+
+        Mirrors :py:meth:`data_path` for ``synthesis.output_dir``: relative
+        paths resolve against the directory that contained ``config.yaml``,
+        NOT against ``data_dir``. The old CLI anchored against
+        ``data_dir.parent``, which only happened to coincide with the
+        config dir for the default ``data_dir = "data"`` layout and broke
+        silently for any other layout.
+        """
+        p = Path(self.synthesis.output_dir)
+        if not p.is_absolute():
+            p = self._config_dir / p
+        return p
+
 
 def load_config(config_path: str | Path | None = None) -> Config:
     """Load config.yaml from *config_path* (default: config.yaml in repo root).

--- a/concept.md
+++ b/concept.md
@@ -97,7 +97,7 @@ Do NOT produce scores or rankings. Instead:
 1. Identify at most 2 anomalies against the developer's own baseline.
 2. For each anomaly, offer three possible explanations — one environmental,
    one behavioral, one tool-related.
-3. Ask one clarifying question per anomaly the developer can answer from memory.
+3. Ask at most 2 clarifying questions total (across all anomalies) the developer can answer from memory.
 4. Do not recommend anything yet.
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,11 @@ am-health-check = "am_i_shipping.health_check:main"
 am-session-parser = "collector.session_parser:main"
 am-github-poller = "collector.github_poller.run:main"
 am-appswitch-export = "collector.appswitch.export:main"
+am-synthesize = "synthesis.cli:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["am_i_shipping*", "collector*"]
+include = ["am_i_shipping*", "collector*", "synthesis*"]

--- a/synthesis/cli.py
+++ b/synthesis/cli.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
+from dataclasses import replace
 from pathlib import Path
 from typing import Optional, Sequence
 
@@ -62,11 +63,16 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     Exit codes
     ----------
-    * ``0`` — retrospective written (or the file already existed and
-      we skipped atomically — that is idempotent success).
-    * ``0`` — dry-run prompt written.
-    * ``1`` — no units found for the requested week.
+    * ``0`` — retrospective written, dry-run prompt written, the file
+      already existed (idempotent success), or no units were found for
+      the requested week. All of these are non-error conditions.
     * ``2`` — unexpected error (traceback logged).
+
+    The "no units for the week" and "file already exists" cases both
+    collapse to exit 0 because re-running ``am-synthesize --week
+    <same-week>`` is expected to be a cheap no-op per ADR Decision 2
+    (idempotency). A human driver will notice the stderr message
+    ``No retrospective written (...)`` when the run produced nothing.
     """
     logging.basicConfig(
         level=logging.INFO,
@@ -83,16 +89,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     github_db = data_dir / "github.db"
     sessions_db = data_dir / "sessions.db"
 
-    # The output_dir in SynthesisConfig is relative to the config file;
-    # resolve it the same way so `retrospectives/` lands next to config.
+    # Resolve the synthesis output dir the same way — via the Config's
+    # own property, which anchors relative paths against the config
+    # file's directory (NOT against ``data_dir.parent``, which only
+    # coincided with the config dir for the default ``data_dir="data"``
+    # layout). See Config.synthesis_output_path.
     synthesis_cfg = config.synthesis
-    output_dir = Path(synthesis_cfg.output_dir)
-    if not output_dir.is_absolute():
-        output_dir = data_dir.parent / output_dir
+    output_dir = config.synthesis_output_path
     # Mutate via a fresh dataclass copy so we don't silently rewrite
     # the caller's config object — replace only the resolved path.
-    from dataclasses import replace
-
     resolved_cfg = replace(synthesis_cfg, output_dir=str(output_dir))
 
     try:

--- a/synthesis/cli.py
+++ b/synthesis/cli.py
@@ -1,0 +1,128 @@
+"""``am-synthesize`` CLI entry point (Epic #17 — Issue #39).
+
+Thin wrapper around :func:`synthesis.weekly.run_synthesis`. The CLI's
+job is to parse flags and resolve DB paths from ``config.yaml``; the
+synthesis pipeline itself lives in ``synthesis.weekly``.
+
+Usage::
+
+    am-synthesize --week 2026-04-12
+    am-synthesize --week 2026-04-12 --dry-run
+    AMIS_SYNTHESIS_LIVE=1 ANTHROPIC_API_KEY=sk-... am-synthesize --week 2026-04-12
+
+When ``AMIS_SYNTHESIS_LIVE`` is unset, the run uses the offline
+:class:`synthesis.fake_client.FakeAnthropicClient` and does not require
+an API key.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import Optional, Sequence
+
+from am_i_shipping.config_loader import load_config
+from synthesis.weekly import run_synthesis
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="am-synthesize",
+        description=(
+            "Run the weekly synthesis engine for a given week_start. "
+            "Writes retrospectives/<week>.md. Use --dry-run to emit the "
+            "assembled prompt without calling the API."
+        ),
+    )
+    parser.add_argument(
+        "--week",
+        required=True,
+        help="Week start date (YYYY-MM-DD). Must match units.week_start.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Write the assembled prompt to retrospectives/.dry-run/ "
+            "instead of calling the API."
+        ),
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to config.yaml (default: config.yaml in repo root).",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Entry point. Returns a shell-suitable exit code.
+
+    Exit codes
+    ----------
+    * ``0`` — retrospective written (or the file already existed and
+      we skipped atomically — that is idempotent success).
+    * ``0`` — dry-run prompt written.
+    * ``1`` — no units found for the requested week.
+    * ``2`` — unexpected error (traceback logged).
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    config = load_config(args.config)
+    # Resolve DB paths against the config's data directory. ``data_path``
+    # on the Config returns an absolute Path relative to the config file
+    # so the CLI works regardless of the caller's cwd.
+    data_dir: Path = config.data_path
+    github_db = data_dir / "github.db"
+    sessions_db = data_dir / "sessions.db"
+
+    # The output_dir in SynthesisConfig is relative to the config file;
+    # resolve it the same way so `retrospectives/` lands next to config.
+    synthesis_cfg = config.synthesis
+    output_dir = Path(synthesis_cfg.output_dir)
+    if not output_dir.is_absolute():
+        output_dir = data_dir.parent / output_dir
+    # Mutate via a fresh dataclass copy so we don't silently rewrite
+    # the caller's config object — replace only the resolved path.
+    from dataclasses import replace
+
+    resolved_cfg = replace(synthesis_cfg, output_dir=str(output_dir))
+
+    try:
+        result = run_synthesis(
+            resolved_cfg,
+            github_db,
+            sessions_db,
+            args.week,
+            dry_run=args.dry_run,
+        )
+    except Exception:  # noqa: BLE001 — CLI is the top of the stack
+        logging.exception("Synthesis failed")
+        return 2
+
+    if result is None and not args.dry_run:
+        # Two cases reach here: (a) no units for the week, (b) the
+        # retrospective already existed and we skipped. Both are
+        # non-errors — idempotent success for case (b), and no-op for
+        # case (a). We log INFO in both cases inside the pipeline so
+        # the CLI simply surfaces a zero exit.
+        print(
+            "No retrospective written (no units for week, or file already exists)",
+            file=sys.stderr,
+        )
+        return 0
+
+    if result is not None:
+        print(str(result))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — CLI plumbing
+    sys.exit(main())

--- a/synthesis/fake_client.py
+++ b/synthesis/fake_client.py
@@ -29,7 +29,7 @@ experiment loop generates recommendations).
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, List
 
 
@@ -74,11 +74,10 @@ class FakeMessage:
     model: str = "fake-claude"
     role: str = "assistant"
     stop_reason: str = "end_turn"
-    usage: FakeUsage = None  # type: ignore[assignment]
-
-    def __post_init__(self) -> None:
-        if self.usage is None:
-            self.usage = FakeUsage()
+    # ``default_factory`` gives each FakeMessage its own fresh FakeUsage
+    # instance — safer than a class-level default if callers ever mutate
+    # ``.usage`` fields (token counters) in place.
+    usage: FakeUsage = field(default_factory=FakeUsage)
 
 
 # ---------------------------------------------------------------------------

--- a/synthesis/fake_client.py
+++ b/synthesis/fake_client.py
@@ -1,0 +1,188 @@
+"""Deterministic offline Anthropic client (Epic #17 — Issue #39).
+
+Mimics just enough of the ``anthropic`` SDK's ``messages.create`` surface
+for :mod:`synthesis.weekly` to exercise the full synthesis pipeline
+without a network call or an API key.
+
+Why in-tree instead of monkeypatching the real SDK
+---------------------------------------------------
+The weekly runner picks between the live SDK and this fake based on the
+``AMIS_SYNTHESIS_LIVE`` env var. Co-locating the fake next to the
+production call site means:
+
+* The fake's return shape is type-compatible with
+  :class:`anthropic.types.Message` at the narrow surface
+  :mod:`synthesis.weekly` consumes (``.content[0].text``) — so swapping
+  ``AMIS_SYNTHESIS_LIVE=1`` on flips to the real SDK without any
+  branching in callers beyond the client selection itself.
+* The deterministic payload is the anchor for the golden snapshot test
+  in ``tests/fixtures/synthesis/expected_retrospective.md``: re-running
+  against ``AMIS_SYNTHESIS_LIVE`` unset must produce byte-identical
+  output.
+
+The Markdown returned below conforms to the epic template:
+Velocity Trend / Unit Summary Table / Outlier Units / Abandoned Units
+/ Dark Time / Clarifying Questions. Exactly two clarifying questions,
+no Recommendations section (ADR: synthesis asks questions; the
+experiment loop generates recommendations).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, List
+
+
+# ---------------------------------------------------------------------------
+# SDK-shaped response objects
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeTextBlock:
+    """Minimal stand-in for ``anthropic.types.TextBlock``."""
+
+    text: str
+    type: str = "text"
+
+
+@dataclass
+class FakeUsage:
+    """Minimal stand-in for ``anthropic.types.Usage``.
+
+    The live SDK returns rich token accounting here. Tests currently
+    only need the fields to exist so call sites that log usage do not
+    ``AttributeError``. All counters are zero in offline mode.
+    """
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+
+
+@dataclass
+class FakeMessage:
+    """Minimal stand-in for ``anthropic.types.Message``.
+
+    The ``model``, ``role`` and ``stop_reason`` values mirror what the
+    live SDK would return for a simple synthesis call, so offline output
+    renders realistically in logs.
+    """
+
+    content: List[FakeTextBlock]
+    model: str = "fake-claude"
+    role: str = "assistant"
+    stop_reason: str = "end_turn"
+    usage: FakeUsage = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.usage is None:
+            self.usage = FakeUsage()
+
+
+# ---------------------------------------------------------------------------
+# The canned retrospective Markdown
+# ---------------------------------------------------------------------------
+#
+# This Markdown is the anchor for the golden snapshot
+# (``tests/fixtures/synthesis/expected_retrospective.md``). Any change to
+# this constant is a breaking change to that snapshot — update both in
+# the same commit or the snapshot test will fail.
+#
+# Content invariants enforced by tests / the epic ADR:
+#   * Headings present: Velocity Trend, Unit Summary Table,
+#     Outlier Units, Abandoned Units, Dark Time, Clarifying Questions.
+#   * Exactly two lines matching ``^\d+\.`` under Clarifying Questions
+#     (the "≤2 total" constraint — two is the ceiling, not two per unit).
+#   * No "Recommendations" heading anywhere.
+
+
+_FAKE_RETROSPECTIVE_MD = """# Weekly Retrospective
+
+## Velocity Trend
+
+No historical baseline available yet; this is the first synthesised
+week. Record this week's per-unit elapsed_days and total_reprompts as
+the anchor for next week's delta.
+
+## Unit Summary Table
+
+| unit_id | root_node | elapsed_days | dark_time_pct | total_reprompts | review_cycles | status |
+|---------|-----------|--------------|---------------|-----------------|---------------|--------|
+| (populated from units table for the given week_start) | | | | | | |
+
+## Outlier Units
+
+Outlier units this week are those whose metric value exceeds
+``median + 2sigma`` across the week's population. Empty list means no
+unit breached the threshold — not that the pass did not run.
+
+## Abandoned Units
+
+Units with no graph_nodes event within the last 14 days and no open
+issue/PR are flagged as abandoned. The abandonment flag is a hint for
+triage, not a prescription.
+
+## Dark Time
+
+Dark time is the fraction of the unit's wall-clock span during which
+no session was active. Single-session units report 0.0 by definition
+(see ADR Decision 3).
+
+## Clarifying Questions
+
+1. Of the flagged outlier units, which one surprises you most, and what
+   precondition do you think was missing when the work started?
+2. For the abandoned units, is the plan still valid but deprioritised,
+   or did the motivation evaporate once scoping revealed the true cost?
+"""
+
+
+# ---------------------------------------------------------------------------
+# Public SDK-shaped facade
+# ---------------------------------------------------------------------------
+
+
+class FakeMessages:
+    """Stand-in for ``anthropic.Anthropic().messages``.
+
+    Only ``create`` is implemented — the synthesis runner never touches
+    anything else. Unknown keyword arguments are accepted and ignored so
+    future SDK additions (e.g. ``metadata``) do not break offline mode.
+    """
+
+    def create(
+        self,
+        *,
+        model: str,
+        max_tokens: int,
+        system: Any,
+        messages: list,
+        **kwargs: Any,
+    ) -> FakeMessage:
+        # Signature is keyword-only to match the real SDK and to make
+        # incompatible call sites fail loudly at call time rather than
+        # silently ignoring a dropped argument.
+        _ = (model, max_tokens, system, messages, kwargs)
+        return FakeMessage(content=[FakeTextBlock(text=_FAKE_RETROSPECTIVE_MD)])
+
+
+class FakeAnthropicClient:
+    """Stand-in for ``anthropic.Anthropic``.
+
+    Construct with no args. The ``messages`` attribute mirrors the real
+    client's namespace so call sites do not need a type switch.
+    """
+
+    def __init__(self) -> None:
+        self.messages = FakeMessages()
+
+
+__all__ = [
+    "FakeAnthropicClient",
+    "FakeMessages",
+    "FakeMessage",
+    "FakeTextBlock",
+    "FakeUsage",
+]

--- a/synthesis/output_writer.py
+++ b/synthesis/output_writer.py
@@ -1,0 +1,113 @@
+"""S-3 retrospective output writer (Epic #17 — Issue #39).
+
+Writes the rendered weekly retrospective Markdown to
+``retrospectives/<week_start>.md`` with two invariants from the epic ADR:
+
+* **Decision 2 — Idempotency by refuse-to-overwrite.** If the output
+  file already exists, the writer logs INFO and returns ``None`` without
+  touching disk. Re-running ``am-synthesize --week <same-week>`` is a
+  no-op — the prior file (which may contain the user's hand-written
+  answers under the Clarifying Questions section) is never stomped.
+* **Atomic write.** Bytes land in ``<path>.tmp`` first, then a single
+  ``os.rename`` promotes them into place. Readers never see a partial
+  file even if the writer is killed mid-``write()``.
+
+The writer is intentionally pure I/O: prompt assembly + LLM call live in
+:mod:`synthesis.weekly`. Keeping the two concerns apart lets
+``--dry-run`` exercise the prompt path without going near the output
+file at all.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Optional, Union
+
+
+logger = logging.getLogger(__name__)
+
+
+def write_retrospective(
+    content: str,
+    output_dir: Union[str, Path],
+    week_start: str,
+) -> Optional[Path]:
+    """Atomically write *content* to ``<output_dir>/<week_start>.md``.
+
+    Parameters
+    ----------
+    content:
+        The rendered Markdown. Written as UTF-8. No trailing newline is
+        added — the caller owns the final byte.
+    output_dir:
+        Directory to write into. Created (with parents) if missing.
+    week_start:
+        ``YYYY-MM-DD`` anchor. Used verbatim as the filename stem.
+
+    Returns
+    -------
+    ``Path`` to the file written, or ``None`` if the file already existed
+    and the call was a refuse-to-overwrite no-op.
+
+    Idempotency
+    -----------
+    When the output path exists the function logs INFO and returns
+    ``None`` without reading the existing file, writing the tmp file, or
+    touching ``output_dir`` in any way. This matches ADR Decision 2:
+    the synthesis call is downstream of this check in
+    :func:`synthesis.weekly.run_synthesis`, so "file exists" also skips
+    the API call.
+
+    Atomicity
+    ---------
+    The write goes to ``<path>.tmp`` and is then renamed to ``<path>``.
+    On POSIX ``os.rename`` is atomic within the same filesystem, so
+    readers observe either the old state (nothing) or the new state
+    (complete file) — never a half-written file. If something goes
+    wrong between the tmp write and the rename, the tmp file is
+    unlinked so a later run is not confused by stray ``.tmp`` droppings.
+    """
+    out_dir = Path(output_dir)
+    output_path = out_dir / f"{week_start}.md"
+
+    # --- Decision 2: refuse to overwrite -------------------------------
+    if output_path.exists():
+        logger.info(
+            "Retrospective already exists at %s; skipping write (idempotent)",
+            output_path,
+        )
+        return None
+
+    # --- ensure the output directory exists ----------------------------
+    # We do this AFTER the exists check so a pre-existing file under an
+    # already-existing directory is the cheap path (no mkdir syscall).
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # --- atomic write via .tmp + rename --------------------------------
+    tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")
+    try:
+        # ``open`` in text mode with an explicit UTF-8 encoding avoids
+        # the platform-default encoding mismatch that bites us on
+        # Windows CI runners (cp1252 by default).
+        with open(tmp_path, "w", encoding="utf-8", newline="") as f:
+            f.write(content)
+        os.replace(tmp_path, output_path)
+    except Exception:
+        # Best-effort cleanup — we do not want to leave ``.tmp``
+        # droppings that could confuse a later run into thinking it
+        # crashed. Swallow cleanup failures so the original exception
+        # is what propagates.
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except OSError:
+            pass
+        raise
+
+    logger.info("Wrote retrospective to %s", output_path)
+    return output_path
+
+
+__all__ = ["write_retrospective"]

--- a/synthesis/output_writer.py
+++ b/synthesis/output_writer.py
@@ -97,13 +97,18 @@ def write_retrospective(
     except Exception:
         # Best-effort cleanup — we do not want to leave ``.tmp``
         # droppings that could confuse a later run into thinking it
-        # crashed. Swallow cleanup failures so the original exception
-        # is what propagates.
+        # crashed. Log (don't raise) cleanup failures so the original
+        # exception is what propagates, but a later operator can see
+        # that the tmp file may still be sitting on disk.
         try:
             if tmp_path.exists():
                 tmp_path.unlink()
-        except OSError:
-            pass
+        except OSError as cleanup_err:
+            logger.warning(
+                "Failed to clean up tmp file %s after write failure: %s",
+                tmp_path,
+                cleanup_err,
+            )
         raise
 
     logger.info("Wrote retrospective to %s", output_path)

--- a/synthesis/weekly.py
+++ b/synthesis/weekly.py
@@ -1,0 +1,608 @@
+"""S-2 weekly synthesis runner (Epic #17 — Issue #39).
+
+Assembles the weekly retrospective prompt from the synthesis tables
+(``units`` with cross-unit flags, ``graph_nodes`` / ``graph_edges`` for
+component resolution, ``sessions.raw_content_json`` for transcripts),
+calls the Anthropic API (or the offline :class:`FakeAnthropicClient`
+stand-in when ``AMIS_SYNTHESIS_LIVE`` is unset), and hands the
+rendered Markdown to :func:`synthesis.output_writer.write_retrospective`.
+
+Architecture decisions anchored here
+------------------------------------
+* **Decision 2 (idempotency).** The output writer refuses to overwrite
+  an existing retrospective; :func:`run_synthesis` calls the API only
+  *after* that guard so re-running the same ``--week`` is cheap.
+* **Decision 4 (water-fill transcripts).** See
+  :func:`water_fill_truncate` — sessions share a 512 KB transcript
+  budget proportionally. Small sessions are never truncated; large
+  sessions take the equal-share haircut. The algorithm is the unit of
+  test (``tests/test_weekly.py::test_water_fill_*``).
+
+What lives where
+----------------
+* ``run_synthesis`` — end-to-end pipeline.
+* ``water_fill_truncate`` — pure-function transcript budgeter (tested
+  independently; no DB access).
+* ``_assemble_prompt`` — Markdown prompt assembly (static cacheable
+  context + per-unit dynamic block).
+* ``_get_client`` — picks between live SDK and
+  :class:`synthesis.fake_client.FakeAnthropicClient` based on
+  ``AMIS_SYNTHESIS_LIVE``.
+
+Prompt caching
+--------------
+When the live SDK is active, the static context block (template,
+thresholds, column descriptions) is sent with ``cache_control`` so
+subsequent weekly runs pay a cache-hit price on it. The dynamic
+per-unit block is never cached — it changes every week.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from pathlib import Path
+from typing import List, Optional, Tuple, Union
+
+from am_i_shipping.config_loader import SynthesisConfig
+from synthesis.fake_client import FakeAnthropicClient
+from synthesis.output_writer import write_retrospective
+from synthesis.unit_timeline import render_timeline
+
+
+logger = logging.getLogger(__name__)
+
+
+# Total transcript budget across all sessions in a single synthesis run,
+# in bytes. ADR Decision 4. 512 KB fits comfortably within Claude's
+# 200K-token context window at ~3-4 bytes per token while leaving
+# plenty of room for the static template + per-unit stats blocks.
+TRANSCRIPT_BUDGET_BYTES = 512 * 1024  # 524288
+
+# Upper bound on output tokens for the weekly synthesis call. The real
+# response is a few hundred tokens of Markdown; the ceiling exists so a
+# runaway generation does not burn tokens indefinitely.
+_MAX_OUTPUT_TOKENS = 4096
+
+
+# ---------------------------------------------------------------------------
+# Water-fill transcript truncation (ADR Decision 4)
+# ---------------------------------------------------------------------------
+
+
+def water_fill_truncate(
+    contents: List[str],
+    budget: int,
+) -> List[str]:
+    """Apportion *budget* bytes across *contents* via equal-share water-fill.
+
+    The algorithm (per the ADR):
+
+    1. Sort the inputs ascending by current byte-length.
+    2. Walk from smallest to largest. Each entry's ``share`` is
+       ``remaining_budget / remaining_count``.
+    3. If the entry fits within its share, include it whole and shrink
+       the remaining budget + count (the saved bytes cascade to larger
+       entries).
+    4. Otherwise truncate to exactly ``share`` bytes.
+
+    This gives equal truncation burden to equally-large sessions while
+    letting small sessions pass through untouched, which is what we want
+    when the transcript budget is smaller than the total session
+    content.
+
+    Parameters
+    ----------
+    contents:
+        List of UTF-8 strings. Treated as opaque bytes for budgeting
+        (``len(s.encode('utf-8'))`` would be more accurate but the ADR
+        specifies ``len(content)`` and callers already truncate at
+        character boundaries so the simpler form matches the spec).
+    budget:
+        Total byte allowance. Must be non-negative. ``0`` returns a list
+        of empty strings with the same cardinality as *contents*.
+
+    Returns
+    -------
+    List of truncated strings in the SAME ORDER as the input. Internal
+    sorting is by a side index so the returned list aligns positionally
+    with *contents* — tests rely on that when asserting per-session
+    results.
+
+    Example
+    -------
+    ``budget=10, contents=["aaaaa", "bbbbbbbbbbbbbbb"]`` → ``["aaaaa",
+    "bbbbb"]``. The small session's 5-byte saving does not move budget
+    to the large one because the large one exceeded its share anyway;
+    the net effect is the small one passed through, the large one took
+    a 5-byte haircut.
+
+    ``budget=12, contents=["aaaaa", "bbbbbbbbbbbbbbb"]`` → ``["aaaaa",
+    "bbbbbbb"]``. First pass gives each session share=6. The 5-byte
+    session consumes 5, leaving 7 for the large session. Large session
+    truncates to 7.
+
+    ``budget=10, contents=["aaaaaaaa", "bbbbbbbbb"]`` → ``["aaaaa",
+    "bbbbb"]``. Neither session fits its initial share=5; both
+    truncate to 5.
+    """
+    if budget < 0:
+        raise ValueError(f"budget must be non-negative, got {budget}")
+    if not contents:
+        return []
+
+    # Pair up (index, content) so we can sort by size without losing
+    # the positional alignment the caller expects.
+    indexed: List[Tuple[int, str]] = list(enumerate(contents))
+    # Sort ascending by byte length. Ties broken by index for
+    # determinism — two equally-sized sessions should truncate
+    # identically, but the tie-break rule ensures the walk order is
+    # reproducible across Python versions.
+    indexed.sort(key=lambda p: (len(p[1]), p[0]))
+
+    result: List[Optional[str]] = [None] * len(contents)
+    remaining_budget = budget
+    remaining_count = len(indexed)
+
+    for original_idx, content in indexed:
+        if remaining_count <= 0:
+            # Defensive — should not hit with the loop bounds above.
+            result[original_idx] = ""
+            continue
+        # Integer-division share so the budget never goes negative.
+        # Any remainder is absorbed by the last entry, which is the
+        # largest and therefore the most capable of taking the bonus.
+        share = remaining_budget // remaining_count
+        if len(content) <= share:
+            result[original_idx] = content
+            remaining_budget -= len(content)
+        else:
+            # Truncate to exactly ``share`` bytes. Character-boundary
+            # only — we do not attempt to land on a valid UTF-8
+            # boundary here because the ADR spec is ``content[:share]``
+            # and the caller feeds already-decoded text.
+            result[original_idx] = content[:share]
+            remaining_budget -= share
+        remaining_count -= 1
+
+    # None of the slots should remain unassigned at this point.
+    return [r if r is not None else "" for r in result]
+
+
+# ---------------------------------------------------------------------------
+# Unit / session loading
+# ---------------------------------------------------------------------------
+
+
+def _load_units(
+    github_conn: sqlite3.Connection,
+    week_start: str,
+) -> List[dict]:
+    """Return one dict per ``units`` row for *week_start*.
+
+    Includes ``outlier_flags`` (JSON string or NULL) and
+    ``abandonment_flag`` (0/1 or NULL) from the cross-unit pass.
+    """
+    rows = github_conn.execute(
+        "SELECT unit_id, root_node_type, root_node_id, "
+        "       elapsed_days, dark_time_pct, total_reprompts, "
+        "       review_cycles, status, outlier_flags, abandonment_flag "
+        "FROM units WHERE week_start = ? "
+        "ORDER BY unit_id",
+        (week_start,),
+    ).fetchall()
+    return [
+        {
+            "unit_id": r[0],
+            "root_node_type": r[1],
+            "root_node_id": r[2],
+            "elapsed_days": r[3],
+            "dark_time_pct": r[4],
+            "total_reprompts": r[5],
+            "review_cycles": r[6],
+            "status": r[7],
+            "outlier_flags": r[8],
+            "abandonment_flag": r[9],
+        }
+        for r in rows
+    ]
+
+
+def _unit_nodes(
+    github_conn: sqlite3.Connection,
+    week_start: str,
+    root_node_id: str,
+) -> List[Tuple[str, str, Optional[str]]]:
+    """Walk ``graph_edges`` to collect the component containing *root_node_id*.
+
+    Returns ``[(node_id, node_type, node_ref), ...]`` — the shape the
+    :func:`synthesis.unit_timeline.render_timeline` and the session-
+    lookup helpers below consume.
+    """
+    # Pull all nodes + edges for the week in one pass; the per-unit
+    # filtering is pure Python BFS so we do not hammer SQLite with N+1
+    # queries the way a naive recursive-SQL version would.
+    nodes = {
+        nid: (nt, nr)
+        for nid, nt, nr in github_conn.execute(
+            "SELECT node_id, node_type, node_ref FROM graph_nodes "
+            "WHERE week_start = ?",
+            (week_start,),
+        ).fetchall()
+    }
+    adj: dict[str, set[str]] = {}
+    for src, dst in github_conn.execute(
+        "SELECT src_node_id, dst_node_id FROM graph_edges "
+        "WHERE week_start = ?",
+        (week_start,),
+    ).fetchall():
+        adj.setdefault(src, set()).add(dst)
+        adj.setdefault(dst, set()).add(src)
+
+    if not root_node_id or root_node_id not in nodes:
+        return []
+
+    seen = {root_node_id}
+    stack = [root_node_id]
+    while stack:
+        cur = stack.pop()
+        for nxt in adj.get(cur, ()):
+            if nxt not in seen and nxt in nodes:
+                seen.add(nxt)
+                stack.append(nxt)
+
+    return sorted(
+        (
+            (nid, nodes[nid][0] or "", nodes[nid][1])
+            for nid in seen
+        ),
+        key=lambda x: x[0],
+    )
+
+
+def _load_session_transcripts(
+    sessions_conn: sqlite3.Connection,
+    session_uuids: List[str],
+) -> List[Tuple[str, str]]:
+    """Return ``[(session_uuid, raw_content_json), ...]`` for the given UUIDs.
+
+    Rows with NULL raw_content_json contribute an empty string — the
+    water-fill algorithm treats them as zero-length entries that always
+    pass through their share untouched.
+    """
+    if not session_uuids:
+        return []
+    placeholders = ",".join("?" * len(session_uuids))
+    rows = sessions_conn.execute(
+        f"SELECT session_uuid, raw_content_json FROM sessions "
+        f"WHERE session_uuid IN ({placeholders})",
+        session_uuids,
+    ).fetchall()
+    by_uuid = {r[0]: (r[1] or "") for r in rows}
+    # Preserve the caller's order so the prompt is deterministic.
+    return [(uid, by_uuid.get(uid, "")) for uid in session_uuids]
+
+
+# ---------------------------------------------------------------------------
+# Prompt assembly
+# ---------------------------------------------------------------------------
+
+
+# Static context — same every week. Sent as a cacheable block when the
+# live SDK is active so re-runs pay a cache-read price on the ~1-2 KB of
+# boilerplate below.
+_STATIC_SYSTEM_PROMPT = """You are the weekly synthesis engine for the am-i-shipping workflow monitor.
+
+Purpose
+-------
+Produce a Markdown retrospective that helps the developer identify which
+preconditions (Phase 0, steps 1-5 of the idealized workflow) failed
+during the past week. The unit of improvement is the user's behavior,
+not Claude's — frame every observation in those terms.
+
+Required Markdown sections (exact headings, in order)
+-----------------------------------------------------
+1. `## Velocity Trend`            — change in throughput vs. the user's
+   own prior baseline. Omit population benchmarks.
+2. `## Unit Summary Table`        — one row per unit from the week's
+   `units` table.
+3. `## Outlier Units`             — units flagged by the cross-unit pass
+   (`outlier_flags` non-empty). For each, note which metric(s) breached.
+4. `## Abandoned Units`           — units with `abandonment_flag = 1`.
+   Do not prescribe follow-up; surface the signal.
+5. `## Dark Time`                 — fraction of each unit's wall-clock
+   span during which no session was active. Highlight the top-2.
+6. `## Clarifying Questions`      — at most TWO total, numbered `1.`
+   and `2.`. Each question should be answerable from the user's memory
+   of the week — no research required.
+
+Constraints
+-----------
+* At most TWO clarifying questions across the entire document.
+  The limit is TOTAL, not per unit.
+* No `## Recommendations` section. The experiment loop (a separate
+  call, not this one) generates recommendations. Synthesis only asks.
+* No population benchmarks ("you used Claude X% more than average");
+  personal baseline only.
+
+Metric column legend
+--------------------
+* `elapsed_days`      — wall-clock span from first to last event.
+* `dark_time_pct`     — 1 - (sum(session active) / span).
+* `total_reprompts`   — sum of `sessions.reprompt_count` in the unit.
+* `review_cycles`     — len(review_comments_json) or push_count fallback.
+* `outlier_flags`     — JSON list of metric names > median + 2sigma.
+* `abandonment_flag`  — 1 if no event within 14 days.
+
+Thresholds
+----------
+* Outlier cutoff:    median + 2.0 * stdev (population stdev).
+* Abandonment cutoff: 14 days without a graph_nodes event.
+"""
+
+
+def _format_unit_block(unit: dict, transcript: str) -> str:
+    """Render one unit's dynamic block for the prompt.
+
+    Includes the metrics, flags, and (potentially truncated) transcript.
+    Keeps the Markdown readable by an LLM — table-less, heading-heavy.
+    """
+    flags = unit.get("outlier_flags") or "[]"
+    abandoned = unit.get("abandonment_flag")
+    abandoned_str = "yes" if abandoned == 1 else ("no" if abandoned == 0 else "n/a")
+    lines = [
+        f"### unit {unit['unit_id']}",
+        f"- root_node: {unit['root_node_type']}:{unit['root_node_id']}",
+        f"- elapsed_days: {unit['elapsed_days']}",
+        f"- dark_time_pct: {unit['dark_time_pct']}",
+        f"- total_reprompts: {unit['total_reprompts']}",
+        f"- review_cycles: {unit['review_cycles']}",
+        f"- status: {unit['status']}",
+        f"- outlier_flags: {flags}",
+        f"- abandonment_flag: {abandoned_str}",
+        "",
+        "#### transcript",
+        "```",
+        transcript,
+        "```",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _assemble_prompt(
+    units: List[dict],
+    unit_transcripts: dict,
+    unit_timelines: dict,
+    week_start: str,
+) -> Tuple[str, List[dict]]:
+    """Return (system_prompt, user_messages) for the synthesis call.
+
+    *system_prompt* is the static cacheable block. *user_messages* is
+    the list of ``{"role": "user", "content": ...}`` dicts the SDK
+    consumes — a single user message that concatenates the week anchor
+    with the per-unit dynamic blocks.
+    """
+    body_parts = [
+        f"# Week starting {week_start}",
+        "",
+        f"Total units this week: {len(units)}",
+        "",
+    ]
+    for unit in units:
+        body_parts.append(_format_unit_block(unit, unit_transcripts.get(unit["unit_id"], "")))
+        # Timeline is a compact Markdown list — one line per event.
+        timeline = unit_timelines.get(unit["unit_id"], [])
+        if timeline:
+            body_parts.append("#### timeline")
+            for ev in timeline:
+                body_parts.append(
+                    f"- {ev['timestamp']} {ev['type']} {ev['description']}"
+                )
+            body_parts.append("")
+
+    user_content = "\n".join(body_parts)
+    return _STATIC_SYSTEM_PROMPT, [{"role": "user", "content": user_content}]
+
+
+# ---------------------------------------------------------------------------
+# Client selection
+# ---------------------------------------------------------------------------
+
+
+def _get_client(config: SynthesisConfig):
+    """Return the client to use for the synthesis call.
+
+    * ``AMIS_SYNTHESIS_LIVE`` unset / falsy → the offline fake.
+    * ``AMIS_SYNTHESIS_LIVE=1``              → the live Anthropic SDK.
+      Import is lazy so an unset ``anthropic`` install does not break
+      offline runs. The ``ANTHROPIC_API_KEY`` env var (or whichever var
+      ``config.anthropic_api_key_env`` names) must be set — the SDK
+      picks it up via its usual env-var dance.
+    """
+    if not os.environ.get("AMIS_SYNTHESIS_LIVE"):
+        return FakeAnthropicClient()
+
+    # Live path — lazy import so the anthropic dep is not required at
+    # import time, only when actually called with AMIS_SYNTHESIS_LIVE=1.
+    import anthropic  # noqa: WPS433 — deliberate lazy import
+
+    api_key = os.environ.get(config.anthropic_api_key_env)
+    if not api_key:
+        raise RuntimeError(
+            f"AMIS_SYNTHESIS_LIVE is set but {config.anthropic_api_key_env} "
+            f"is empty — cannot call the Anthropic API"
+        )
+    return anthropic.Anthropic(api_key=api_key)
+
+
+def _call_llm(client, config: SynthesisConfig, system_prompt: str, messages: list) -> str:
+    """Dispatch the synthesis call and return the Markdown text.
+
+    When ``AMIS_SYNTHESIS_LIVE=1`` the system prompt is wrapped in a
+    list-of-blocks shape with ``cache_control`` so the Anthropic API
+    treats it as an ephemeral cache entry. The fake client accepts the
+    same shape (ignores the caching hint) so the call site needs no
+    branching.
+    """
+    if os.environ.get("AMIS_SYNTHESIS_LIVE"):
+        # List-of-blocks form enables prompt caching on the static
+        # context. See https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
+        system_blocks = [
+            {
+                "type": "text",
+                "text": system_prompt,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+    else:
+        # Fake client accepts either a plain string or the blocks form.
+        # We use the plain form offline so the offline path never
+        # silently depends on the SDK's block parser.
+        system_blocks = system_prompt
+
+    resp = client.messages.create(
+        model=config.model,
+        max_tokens=_MAX_OUTPUT_TOKENS,
+        system=system_blocks,
+        messages=messages,
+    )
+    # Both the real SDK's Message and our FakeMessage expose
+    # ``content[0].text`` for a single-block text response, which is
+    # what a non-tool-use synthesis call returns.
+    return resp.content[0].text
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run_synthesis(
+    config: SynthesisConfig,
+    github_db: Union[str, Path],
+    sessions_db: Union[str, Path],
+    week_start: str,
+    dry_run: bool = False,
+) -> Optional[Path]:
+    """End-to-end weekly synthesis for *week_start*.
+
+    Parameters
+    ----------
+    config:
+        Validated :class:`SynthesisConfig`. Names the env var that
+        holds the Anthropic key, the model, and the output directory.
+    github_db, sessions_db:
+        Paths to the collector DBs. The fixture packs both schemas into
+        one file; in production they are two files under
+        ``config.data_dir``.
+    week_start:
+        ``YYYY-MM-DD`` anchor. Must match a value in
+        ``units.week_start`` — no units → no retrospective is written
+        (function returns ``None``).
+    dry_run:
+        When ``True``, writes the assembled prompt to
+        ``<output_dir>/.dry-run/<week_start>.prompt.txt`` and returns
+        that path. No LLM call, no retrospective file. Useful for
+        iterating on the prompt without burning tokens.
+
+    Returns
+    -------
+    * Production path (``dry_run=False``):
+      - Path to the newly-written retrospective, or
+      - ``None`` if the file already existed (refuse-to-overwrite), or
+      - ``None`` if the week has no units.
+    * Dry-run path (``dry_run=True``):
+      - Path to the ``.prompt.txt`` that was written, or
+      - ``None`` if the week has no units.
+    """
+    gh_path = Path(github_db)
+    sess_path = Path(sessions_db)
+    gh_conn = sqlite3.connect(str(gh_path))
+    sess_conn = gh_conn if sess_path == gh_path else sqlite3.connect(str(sess_path))
+
+    try:
+        units = _load_units(gh_conn, week_start)
+        if not units:
+            logger.info(
+                "No units found for week_start=%s; skipping synthesis", week_start
+            )
+            return None
+
+        # Resolve every unit's component so we can pull the session
+        # UUIDs (for transcripts) and feed the timeline renderer.
+        unit_components: dict = {}
+        all_session_uuids: List[str] = []
+        per_unit_uuids: dict = {}
+        for u in units:
+            comp = _unit_nodes(gh_conn, week_start, u["root_node_id"])
+            unit_components[u["unit_id"]] = comp
+            uuids = [nr for nid, nt, nr in comp if nt == "session" and nr]
+            per_unit_uuids[u["unit_id"]] = uuids
+            all_session_uuids.extend(uuids)
+
+        # Water-fill the transcripts across ALL sessions in ALL units
+        # so the 512 KB budget is global, not per-unit. ADR Decision 4
+        # phrases it as "cumulative budget".
+        raw = _load_session_transcripts(sess_conn, all_session_uuids)
+        # raw is aligned with all_session_uuids by construction.
+        truncated = water_fill_truncate(
+            [content for _uid, content in raw],
+            TRANSCRIPT_BUDGET_BYTES,
+        )
+        by_uuid = {uid: tc for (uid, _), tc in zip(raw, truncated)}
+
+        # Per-unit transcript = concatenation of the unit's (truncated)
+        # sessions. Blank units yield an empty transcript block — the
+        # prompt still renders them so the LLM can reason about
+        # "why is this unit empty".
+        unit_transcripts: dict = {}
+        unit_timelines: dict = {}
+        for u in units:
+            parts = [by_uuid.get(uid, "") for uid in per_unit_uuids[u["unit_id"]]]
+            unit_transcripts[u["unit_id"]] = "\n\n".join(p for p in parts if p)
+            unit_timelines[u["unit_id"]] = render_timeline(
+                unit_components[u["unit_id"]], gh_conn, sess_conn
+            )
+
+        system_prompt, messages = _assemble_prompt(
+            units, unit_transcripts, unit_timelines, week_start
+        )
+
+        # --- dry-run short-circuit ------------------------------------
+        if dry_run:
+            dry_dir = Path(config.output_dir) / ".dry-run"
+            dry_dir.mkdir(parents=True, exist_ok=True)
+            dry_path = dry_dir / f"{week_start}.prompt.txt"
+            # Concatenate system + user for a human-readable dump. The
+            # two halves are visually separated so a developer paging
+            # through the file can tell which block is cached.
+            text_content = messages[0]["content"] if messages else ""
+            dump = (
+                "=== SYSTEM (cacheable) ===\n"
+                f"{system_prompt}\n"
+                "=== USER ===\n"
+                f"{text_content}\n"
+            )
+            dry_path.write_text(dump, encoding="utf-8")
+            logger.info("Dry-run prompt written to %s", dry_path)
+            return dry_path
+
+        # --- live / fake synthesis ------------------------------------
+        client = _get_client(config)
+        markdown = _call_llm(client, config, system_prompt, messages)
+
+        return write_retrospective(markdown, config.output_dir, week_start)
+
+    finally:
+        if sess_conn is not gh_conn:
+            sess_conn.close()
+        gh_conn.close()
+
+
+__all__ = [
+    "run_synthesis",
+    "water_fill_truncate",
+    "TRANSCRIPT_BUDGET_BYTES",
+]

--- a/synthesis/weekly.py
+++ b/synthesis/weekly.py
@@ -113,15 +113,19 @@ def water_fill_truncate(
     Example
     -------
     ``budget=10, contents=["aaaaa", "bbbbbbbbbbbbbbb"]`` → ``["aaaaa",
-    "bbbbb"]``. The small session's 5-byte saving does not move budget
-    to the large one because the large one exceeded its share anyway;
-    the net effect is the small one passed through, the large one took
-    a 5-byte haircut.
+    "bbbbb"]``. Two entries, initial share = 10 // 2 = 5. Small session
+    fits its share exactly (5 bytes ≤ share 5) and passes through
+    whole, consuming all 5 bytes of its slice. Remaining budget = 5,
+    remaining count = 1, so the large session's share = 5; it
+    truncates from 15 down to 5. Net: small unchanged, large takes a
+    10-byte haircut.
 
     ``budget=12, contents=["aaaaa", "bbbbbbbbbbbbbbb"]`` → ``["aaaaa",
     "bbbbbbb"]``. First pass gives each session share=6. The 5-byte
-    session consumes 5, leaving 7 for the large session. Large session
-    truncates to 7.
+    session consumes 5 (under its share of 6), leaving 7 for the large
+    session. Large session truncates to 7. This is where the "savings
+    cascade" actually shows up — the small session spent less than its
+    share, and the remainder flowed to the large one.
 
     ``budget=10, contents=["aaaaaaaa", "bbbbbbbbb"]`` → ``["aaaaa",
     "bbbbb"]``. Neither session fits its initial share=5; both
@@ -347,9 +351,15 @@ def _format_unit_block(unit: dict, transcript: str) -> str:
 
     Includes the metrics, flags, and (potentially truncated) transcript.
     Keeps the Markdown readable by an LLM — table-less, heading-heavy.
+
+    ``outlier_flags`` and ``abandonment_flag`` are NULLable in the
+    ``units`` schema (see cross_unit.py migration). We expect both keys
+    to be present — ``_load_units`` always populates them — so the
+    explicit ``is None`` check handles the NULL case only, not a
+    missing key (which would be a programming error elsewhere).
     """
-    flags = unit.get("outlier_flags") or "[]"
-    abandoned = unit.get("abandonment_flag")
+    flags = unit["outlier_flags"] if unit["outlier_flags"] is not None else "[]"
+    abandoned = unit["abandonment_flag"]
     abandoned_str = "yes" if abandoned == 1 else ("no" if abandoned == 0 else "n/a")
     lines = [
         f"### unit {unit['unit_id']}",
@@ -411,18 +421,24 @@ def _assemble_prompt(
 # ---------------------------------------------------------------------------
 
 
-def _get_client(config: SynthesisConfig):
-    """Return the client to use for the synthesis call.
+def _get_client(config: SynthesisConfig) -> Tuple[object, bool]:
+    """Return ``(client, is_live)`` for the synthesis call.
 
-    * ``AMIS_SYNTHESIS_LIVE`` unset / falsy → the offline fake.
-    * ``AMIS_SYNTHESIS_LIVE=1``              → the live Anthropic SDK.
+    * ``AMIS_SYNTHESIS_LIVE`` unset / falsy → ``(FakeAnthropicClient(), False)``.
+    * ``AMIS_SYNTHESIS_LIVE=1``              → ``(anthropic.Anthropic(...), True)``.
       Import is lazy so an unset ``anthropic`` install does not break
       offline runs. The ``ANTHROPIC_API_KEY`` env var (or whichever var
       ``config.anthropic_api_key_env`` names) must be set — the SDK
       picks it up via its usual env-var dance.
+
+    Returning the ``is_live`` flag alongside the client lets
+    :func:`_call_llm` pick the system-prompt shape (plain string vs.
+    list-of-blocks with ``cache_control``) without re-reading the env
+    var. The flag that drove client selection is also the flag that
+    drives the cache shape — they cannot drift.
     """
     if not os.environ.get("AMIS_SYNTHESIS_LIVE"):
-        return FakeAnthropicClient()
+        return FakeAnthropicClient(), False
 
     # Live path — lazy import so the anthropic dep is not required at
     # import time, only when actually called with AMIS_SYNTHESIS_LIVE=1.
@@ -434,19 +450,30 @@ def _get_client(config: SynthesisConfig):
             f"AMIS_SYNTHESIS_LIVE is set but {config.anthropic_api_key_env} "
             f"is empty — cannot call the Anthropic API"
         )
-    return anthropic.Anthropic(api_key=api_key)
+    return anthropic.Anthropic(api_key=api_key), True
 
 
-def _call_llm(client, config: SynthesisConfig, system_prompt: str, messages: list) -> str:
+def _call_llm(
+    client,
+    config: SynthesisConfig,
+    system_prompt: str,
+    messages: list,
+    is_live: bool,
+) -> str:
     """Dispatch the synthesis call and return the Markdown text.
 
-    When ``AMIS_SYNTHESIS_LIVE=1`` the system prompt is wrapped in a
+    When *is_live* is True, the system prompt is wrapped in a
     list-of-blocks shape with ``cache_control`` so the Anthropic API
     treats it as an ephemeral cache entry. The fake client accepts the
     same shape (ignores the caching hint) so the call site needs no
-    branching.
+    branching — but we still use the plain form offline so the offline
+    path never silently depends on the SDK's block parser.
+
+    *is_live* comes from :func:`_get_client` so the flag that drove
+    client selection is also the flag that drives the cache shape;
+    they cannot drift via an env var being toggled mid-run.
     """
-    if os.environ.get("AMIS_SYNTHESIS_LIVE"):
+    if is_live:
         # List-of-blocks form enables prompt caching on the static
         # context. See https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
         system_blocks = [
@@ -520,7 +547,18 @@ def run_synthesis(
     gh_path = Path(github_db)
     sess_path = Path(sessions_db)
     gh_conn = sqlite3.connect(str(gh_path))
-    sess_conn = gh_conn if sess_path == gh_path else sqlite3.connect(str(sess_path))
+    # Share the connection only when both paths resolve to the SAME file
+    # on disk. ``Path.__eq__`` is a string compare, which misses
+    # equivalent-but-non-normalised paths (e.g. ``a/b`` vs ``a/./b``).
+    # ``os.path.samefile`` follows symlinks and normalises, but requires
+    # both files to exist — we only call it after opening ``gh_conn``
+    # (which creates the file if missing) and fall back to string
+    # compare when samefile raises.
+    try:
+        _same = sess_path.exists() and os.path.samefile(str(gh_path), str(sess_path))
+    except OSError:
+        _same = str(gh_path) == str(sess_path)
+    sess_conn = gh_conn if _same else sqlite3.connect(str(sess_path))
 
     try:
         units = _load_units(gh_conn, week_start)
@@ -590,8 +628,8 @@ def run_synthesis(
             return dry_path
 
         # --- live / fake synthesis ------------------------------------
-        client = _get_client(config)
-        markdown = _call_llm(client, config, system_prompt, messages)
+        client, is_live = _get_client(config)
+        markdown = _call_llm(client, config, system_prompt, messages, is_live)
 
         return write_retrospective(markdown, config.output_dir, week_start)
 

--- a/tests/fixtures/synthesis/expected_retrospective.md
+++ b/tests/fixtures/synthesis/expected_retrospective.md
@@ -1,0 +1,38 @@
+# Weekly Retrospective
+
+## Velocity Trend
+
+No historical baseline available yet; this is the first synthesised
+week. Record this week's per-unit elapsed_days and total_reprompts as
+the anchor for next week's delta.
+
+## Unit Summary Table
+
+| unit_id | root_node | elapsed_days | dark_time_pct | total_reprompts | review_cycles | status |
+|---------|-----------|--------------|---------------|-----------------|---------------|--------|
+| (populated from units table for the given week_start) | | | | | | |
+
+## Outlier Units
+
+Outlier units this week are those whose metric value exceeds
+``median + 2sigma`` across the week's population. Empty list means no
+unit breached the threshold — not that the pass did not run.
+
+## Abandoned Units
+
+Units with no graph_nodes event within the last 14 days and no open
+issue/PR are flagged as abandoned. The abandonment flag is a hint for
+triage, not a prescription.
+
+## Dark Time
+
+Dark time is the fraction of the unit's wall-clock span during which
+no session was active. Single-session units report 0.0 by definition
+(see ADR Decision 3).
+
+## Clarifying Questions
+
+1. Of the flagged outlier units, which one surprises you most, and what
+   precondition do you think was missing when the work started?
+2. For the abandoned units, is the plan still valid but deprioritised,
+   or did the motivation evaporate once scoping revealed the true cost?

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -240,6 +240,48 @@ class TestSynthesisConfig:
         assert cfg.synthesis.model == "claude-sonnet-4-5"
 
 
+class TestSynthesisOutputPath:
+    """Issue #39: relative synthesis.output_dir anchors against config dir."""
+
+    def test_relative_output_dir_resolves_against_config_dir(self, tmp_path):
+        # Default "retrospectives" is relative → must land next to the
+        # config file, regardless of where ``data_dir`` points.
+        cfg_path = _write_config(tmp_path, {
+            "session": {"projects_path": "/path"},
+            "github": {"repos": ["a/b"]},
+            "data": {"data_dir": "/var/lib/amis/data"},
+        })
+        cfg = load_config(cfg_path)
+        # Anchor is the config file's directory, NOT /var/lib/amis (the
+        # parent of the data_dir). That's the whole point of F-1-1.
+        assert cfg.synthesis_output_path == tmp_path / "retrospectives"
+
+    def test_absolute_output_dir_is_returned_verbatim(self, tmp_path):
+        absolute = tmp_path / "custom" / "retros"
+        cfg_path = _write_config(tmp_path, {
+            "session": {"projects_path": "/path"},
+            "github": {"repos": ["a/b"]},
+            "synthesis": {"output_dir": str(absolute)},
+        })
+        cfg = load_config(cfg_path)
+        assert cfg.synthesis_output_path == absolute
+
+    def test_relative_output_dir_independent_of_data_dir(self, tmp_path):
+        # Moving data_dir off into /tmp must not shift the retrospectives
+        # location — they are anchored independently now.
+        cfg_path = _write_config(tmp_path, {
+            "session": {"projects_path": "/path"},
+            "github": {"repos": ["a/b"]},
+            "data": {"data_dir": "/tmp/different-data"},
+            "synthesis": {"output_dir": "retros"},
+        })
+        cfg = load_config(cfg_path)
+        assert cfg.synthesis_output_path == tmp_path / "retros"
+        # Sanity: old buggy anchor would have been /tmp/retros
+        # (data_dir.parent / output_dir).
+        assert cfg.synthesis_output_path != Path("/tmp/retros")
+
+
 class TestEpic17FetchFlags:
     """Epic #17 Sub-Issue 2 (#35): E-1 / E-2 config flags."""
 

--- a/tests/test_output_writer.py
+++ b/tests/test_output_writer.py
@@ -1,0 +1,105 @@
+"""Tests for ``synthesis/output_writer.py`` (Epic #17 — Issue #39)."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from synthesis.output_writer import write_retrospective
+
+
+WEEK = "2026-04-12"
+
+
+class TestWriteHappyPath:
+    def test_writes_file_to_configured_directory(self, tmp_path: Path) -> None:
+        out = tmp_path / "retrospectives"
+        result = write_retrospective("# Hello\n", out, WEEK)
+        assert result == out / f"{WEEK}.md"
+        assert result.read_text(encoding="utf-8") == "# Hello\n"
+
+    def test_creates_output_directory_if_missing(self, tmp_path: Path) -> None:
+        out = tmp_path / "nested" / "retrospectives"
+        # Precondition: neither the retrospectives dir nor its parent exist.
+        assert not out.exists()
+        result = write_retrospective("content", out, WEEK)
+        assert result is not None
+        assert out.is_dir()
+        assert result.read_text(encoding="utf-8") == "content"
+
+    def test_returns_path_to_written_file(self, tmp_path: Path) -> None:
+        out = tmp_path / "retrospectives"
+        result = write_retrospective("x", out, WEEK)
+        assert isinstance(result, Path)
+        assert result.name == f"{WEEK}.md"
+        assert result.parent == out
+
+    def test_utf8_content_roundtrips(self, tmp_path: Path) -> None:
+        # Non-ASCII — smoke test that the encoding argument is honoured.
+        content = "hello — world 🌍\n"
+        result = write_retrospective(content, tmp_path, WEEK)
+        assert result is not None
+        assert result.read_text(encoding="utf-8") == content
+
+
+class TestIdempotency:
+    def test_second_call_returns_none(self, tmp_path: Path) -> None:
+        # First call writes.
+        write_retrospective("first", tmp_path, WEEK)
+        # Second call finds the file and declines to overwrite.
+        result = write_retrospective("SECOND", tmp_path, WEEK)
+        assert result is None
+
+    def test_second_call_does_not_overwrite(self, tmp_path: Path) -> None:
+        first = write_retrospective("first write\n", tmp_path, WEEK)
+        assert first is not None
+        write_retrospective("second — should be ignored", tmp_path, WEEK)
+        # File content is unchanged after the refused second call.
+        assert first.read_text(encoding="utf-8") == "first write\n"
+
+    def test_logs_info_on_skip(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        write_retrospective("first", tmp_path, WEEK)
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="synthesis.output_writer"):
+            result = write_retrospective("second", tmp_path, WEEK)
+        assert result is None
+        # At least one INFO message should mention "already exists" / skip.
+        assert any(
+            "already exists" in rec.getMessage().lower()
+            or "skipping" in rec.getMessage().lower()
+            for rec in caplog.records
+        ), [rec.getMessage() for rec in caplog.records]
+
+
+class TestAtomicWrite:
+    def test_no_tmp_file_remains_on_success(self, tmp_path: Path) -> None:
+        result = write_retrospective("content", tmp_path, WEEK)
+        assert result is not None
+        # The .tmp sibling should be gone after the successful rename.
+        tmp_sibling = tmp_path / f"{WEEK}.md.tmp"
+        assert not tmp_sibling.exists()
+
+    def test_tmp_file_cleaned_up_on_write_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If os.replace raises, the .tmp file is unlinked.
+
+        We simulate this by monkeypatching ``os.replace`` inside the
+        module under test to raise.
+        """
+        import synthesis.output_writer as ow
+
+        def boom(*args, **kwargs):  # noqa: ANN001, ARG001
+            raise OSError("simulated rename failure")
+
+        monkeypatch.setattr(ow.os, "replace", boom)
+        with pytest.raises(OSError, match="simulated rename failure"):
+            write_retrospective("content", tmp_path, WEEK)
+        # The .tmp file must have been cleaned up.
+        assert not (tmp_path / f"{WEEK}.md.tmp").exists()
+        # And the final path must not have landed.
+        assert not (tmp_path / f"{WEEK}.md").exists()

--- a/tests/test_weekly.py
+++ b/tests/test_weekly.py
@@ -278,5 +278,11 @@ class TestNoUnitsForWeek:
 class TestWaterFillBudgetConstant:
     def test_budget_is_512kb(self):
         # Pin the constant so a future refactor cannot silently shrink
-        # or grow the budget without a test diff.
-        assert TRANSCRIPT_BUDGET_BYTES == 524288
+        # or grow the budget without a test diff. The number comes from
+        # Epic #17 ADR Decision 4 ("cumulative transcript budget of
+        # 512 KB per synthesis run"); changing it requires an ADR
+        # update, not just a code change.
+        assert TRANSCRIPT_BUDGET_BYTES == 524288, (
+            "TRANSCRIPT_BUDGET_BYTES is pinned by Epic #17 ADR Decision 4 "
+            "(512 KB = 524288 bytes). Update the ADR before changing it."
+        )

--- a/tests/test_weekly.py
+++ b/tests/test_weekly.py
@@ -1,0 +1,282 @@
+"""Tests for ``synthesis/weekly.py`` (Epic #17 — Issue #39)."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from am_i_shipping.config_loader import SynthesisConfig
+from synthesis.weekly import (
+    TRANSCRIPT_BUDGET_BYTES,
+    run_synthesis,
+    water_fill_truncate,
+)
+
+
+FIXTURE_SRC = Path(__file__).parent / "fixtures" / "synthesis" / "golden.sqlite"
+EXPECTED_MD = (
+    Path(__file__).parent
+    / "fixtures"
+    / "synthesis"
+    / "expected_retrospective.md"
+)
+WEEK_START = "2025-01-06"
+
+
+# ---------------------------------------------------------------------------
+# Water-fill unit tests (ADR Decision 4)
+# ---------------------------------------------------------------------------
+
+
+class TestWaterFillTruncate:
+    """The algorithm is the unit of test, per the epic acceptance list."""
+
+    def test_budget_smaller_than_all_contents_equal_share(self):
+        # budget=10, sessions=[8,9] → each fits share=5; both truncate.
+        assert water_fill_truncate(["a" * 8, "b" * 9], 10) == [
+            "a" * 5,
+            "b" * 5,
+        ]
+
+    def test_small_session_fits_whole_large_truncated_to_share(self):
+        # budget=10, sessions=[5,15] → small fits share=5, large truncates
+        # to share=5 (small's savings are exactly zero, all budget goes
+        # to equal share on the first pass).
+        assert water_fill_truncate(["a" * 5, "b" * 15], 10) == [
+            "a" * 5,
+            "b" * 5,
+        ]
+
+    def test_savings_cascade_to_larger_sessions(self):
+        # budget=12, sessions=[5,15] → first pass share=6; small session
+        # consumes 5 (remaining budget=7, count=1); large takes share=7.
+        assert water_fill_truncate(["a" * 5, "b" * 15], 12) == [
+            "a" * 5,
+            "b" * 7,
+        ]
+
+    def test_preserves_input_order(self):
+        # Out-of-order input: large first, small second.
+        result = water_fill_truncate(["b" * 15, "a" * 5], 12)
+        # Same budget as the savings-cascade case; result aligns with
+        # the input positional order.
+        assert result == ["b" * 7, "a" * 5]
+
+    def test_empty_contents_returns_empty_list(self):
+        assert water_fill_truncate([], 1000) == []
+
+    def test_zero_budget_returns_empty_strings(self):
+        assert water_fill_truncate(["abc", "def"], 0) == ["", ""]
+
+    def test_negative_budget_raises(self):
+        with pytest.raises(ValueError):
+            water_fill_truncate(["a"], -1)
+
+    def test_generous_budget_returns_originals(self):
+        contents = ["a" * 5, "b" * 10]
+        # Budget is larger than total demand — nobody is truncated.
+        assert water_fill_truncate(contents, 1000) == contents
+
+    def test_total_bytes_never_exceed_budget(self):
+        # Property-style sanity check on a mixed batch. Two small, two
+        # large; equal-share walk should keep the total at or under
+        # budget.
+        contents = ["a" * 3, "b" * 100, "c" * 50, "d" * 7]
+        result = water_fill_truncate(contents, 40)
+        assert sum(len(s) for s in result) <= 40
+
+    def test_single_session_gets_full_budget(self):
+        assert water_fill_truncate(["a" * 100], 30) == ["a" * 30]
+
+
+# ---------------------------------------------------------------------------
+# run_synthesis happy path + idempotency + dry-run
+# ---------------------------------------------------------------------------
+
+
+def _make_config(tmp_path: Path, output_dir: Path) -> SynthesisConfig:
+    """Build a SynthesisConfig pinned to *output_dir*."""
+    return SynthesisConfig(
+        anthropic_api_key_env="ANTHROPIC_API_KEY",
+        model="claude-sonnet-4-5",
+        output_dir=str(output_dir),
+        week_start="monday",
+        abandonment_days=14,
+        outlier_sigma=2.0,
+    )
+
+
+def _fixture_copy(tmp_path: Path) -> Path:
+    dst = tmp_path / "golden.sqlite"
+    shutil.copy(FIXTURE_SRC, dst)
+    return dst
+
+
+@pytest.fixture(autouse=True)
+def _scrub_live_env(monkeypatch: pytest.MonkeyPatch):
+    """Guarantee offline mode across every test in this module.
+
+    Some environments may have AMIS_SYNTHESIS_LIVE or ANTHROPIC_API_KEY
+    exported. Scrub both so no test accidentally tries a real API call.
+    """
+    monkeypatch.delenv("AMIS_SYNTHESIS_LIVE", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    yield
+
+
+class TestRunSynthesisOffline:
+    def test_writes_retrospective_using_fake_client(self, tmp_path: Path):
+        db = _fixture_copy(tmp_path)
+        out = tmp_path / "retrospectives"
+        cfg = _make_config(tmp_path, out)
+
+        result = run_synthesis(cfg, db, db, WEEK_START, dry_run=False)
+
+        assert result is not None
+        assert result == out / f"{WEEK_START}.md"
+        assert result.exists()
+        # Sanity: file has content.
+        assert result.read_text(encoding="utf-8").startswith("# Weekly Retrospective")
+
+    def test_snapshot_matches_committed_fixture(self, tmp_path: Path):
+        """Fake-client output byte-matches the committed snapshot."""
+        db = _fixture_copy(tmp_path)
+        out = tmp_path / "retrospectives"
+        cfg = _make_config(tmp_path, out)
+
+        result = run_synthesis(cfg, db, db, WEEK_START)
+        assert result is not None
+
+        actual = result.read_text(encoding="utf-8")
+        expected = EXPECTED_MD.read_text(encoding="utf-8")
+        assert actual == expected
+
+    def test_rendered_markdown_has_required_sections(self, tmp_path: Path):
+        db = _fixture_copy(tmp_path)
+        out = tmp_path / "retrospectives"
+        cfg = _make_config(tmp_path, out)
+        result = run_synthesis(cfg, db, db, WEEK_START)
+        assert result is not None
+        md = result.read_text(encoding="utf-8")
+        for heading in (
+            "Velocity Trend",
+            "Unit Summary Table",
+            "Outlier Units",
+            "Abandoned Units",
+            "Dark Time",
+            "Clarifying Questions",
+        ):
+            assert f"## {heading}" in md, f"missing heading: {heading}"
+
+    def test_at_most_two_clarifying_questions(self, tmp_path: Path):
+        import re
+
+        db = _fixture_copy(tmp_path)
+        out = tmp_path / "retrospectives"
+        cfg = _make_config(tmp_path, out)
+        result = run_synthesis(cfg, db, db, WEEK_START)
+        assert result is not None
+        md = result.read_text(encoding="utf-8")
+        # Grab the ``## Clarifying Questions`` section only.
+        _, _, tail = md.partition("## Clarifying Questions")
+        # Stop at the next ``## `` heading if any.
+        section = tail.split("\n## ", 1)[0]
+        numbered = re.findall(r"^\d+\.", section, flags=re.MULTILINE)
+        assert len(numbered) <= 2, numbered
+
+    def test_no_recommendations_section(self, tmp_path: Path):
+        db = _fixture_copy(tmp_path)
+        out = tmp_path / "retrospectives"
+        cfg = _make_config(tmp_path, out)
+        result = run_synthesis(cfg, db, db, WEEK_START)
+        assert result is not None
+        md = result.read_text(encoding="utf-8").lower()
+        assert "## recommendations" not in md
+        assert "# recommendations" not in md
+
+
+class TestRunSynthesisIdempotency:
+    def test_second_run_returns_none(self, tmp_path: Path):
+        db = _fixture_copy(tmp_path)
+        out = tmp_path / "retrospectives"
+        cfg = _make_config(tmp_path, out)
+
+        first = run_synthesis(cfg, db, db, WEEK_START)
+        assert first is not None
+        second = run_synthesis(cfg, db, db, WEEK_START)
+        assert second is None
+
+    def test_second_run_does_not_overwrite_file(self, tmp_path: Path):
+        db = _fixture_copy(tmp_path)
+        out = tmp_path / "retrospectives"
+        cfg = _make_config(tmp_path, out)
+
+        result = run_synthesis(cfg, db, db, WEEK_START)
+        assert result is not None
+        # Stash the bytes we wrote.
+        before = result.read_bytes()
+        # Stomp the file with sentinel content, then run again — the
+        # second run must refuse to overwrite our sentinel.
+        sentinel = b"USER HAND-EDITED NOTE\n"
+        result.write_bytes(sentinel)
+        _ = run_synthesis(cfg, db, db, WEEK_START)
+        assert result.read_bytes() == sentinel, (
+            "idempotent run overwrote user-edited file"
+        )
+        # And to round-trip, check that the first run wrote something
+        # other than the sentinel (so the test is meaningful).
+        assert before != sentinel
+
+
+class TestDryRun:
+    def test_dry_run_writes_prompt_only(self, tmp_path: Path):
+        db = _fixture_copy(tmp_path)
+        out = tmp_path / "retrospectives"
+        cfg = _make_config(tmp_path, out)
+
+        result = run_synthesis(cfg, db, db, WEEK_START, dry_run=True)
+
+        assert result is not None
+        assert result.name == f"{WEEK_START}.prompt.txt"
+        assert result.parent.name == ".dry-run"
+        assert result.exists()
+        # Dry-run must NOT produce the final retrospective file.
+        assert not (out / f"{WEEK_START}.md").exists()
+
+    def test_dry_run_prompt_contains_system_and_user_halves(self, tmp_path: Path):
+        db = _fixture_copy(tmp_path)
+        out = tmp_path / "retrospectives"
+        cfg = _make_config(tmp_path, out)
+
+        result = run_synthesis(cfg, db, db, WEEK_START, dry_run=True)
+        assert result is not None
+        content = result.read_text(encoding="utf-8")
+        assert "=== SYSTEM" in content
+        assert "=== USER" in content
+        # The per-unit block should render something recognisable from
+        # the fixture — at least one of the unit IDs.
+        assert "unit-0001-multi" in content or "unit-0003-singleton" in content
+
+
+class TestNoUnitsForWeek:
+    def test_missing_week_returns_none(self, tmp_path: Path):
+        db = _fixture_copy(tmp_path)
+        out = tmp_path / "retrospectives"
+        cfg = _make_config(tmp_path, out)
+        # 1999-01-04 is a Monday with no units.
+        result = run_synthesis(cfg, db, db, "1999-01-04")
+        assert result is None
+        # And no retrospective file was written.
+        assert not (out / "1999-01-04.md").exists()
+
+
+class TestWaterFillBudgetConstant:
+    def test_budget_is_512kb(self):
+        # Pin the constant so a future refactor cannot silently shrink
+        # or grow the budget without a test diff.
+        assert TRANSCRIPT_BUDGET_BYTES == 524288


### PR DESCRIPTION
Closes #39. Part of epic #17.

## Changes
- `synthesis/fake_client.py`: deterministic offline Anthropic client
- `synthesis/weekly.py`: prompt assembly with water-fill transcript truncation (512 KB budget)
- `synthesis/output_writer.py`: atomic write + refuse-to-overwrite idempotency
- `synthesis/cli.py` + `am-synthesize` entry point
- `retrospectives/.gitkeep`: new output directory
- `concept.md`: reconcile clarifying question limit to <=2 total
- Tests: water-fill unit tests, idempotency, dry-run, snapshot

## Acceptance criteria
- [x] am-synthesize --week 2026-04-12 (offline) writes retrospectives/2026-04-12.md
- [x] Re-running is a no-op (refuse-to-overwrite)
- [x] Rendered Markdown has required sections and <=2 clarifying questions
- [x] No recommendations section
- [x] Snapshot test byte-matches committed snapshot
- [x] pytest passes with ANTHROPIC_API_KEY unset (404 passed, 15 skipped)
- [x] --dry-run writes prompt only, no API call
- [x] Water-fill truncation unit tests pass