### PR TITLE
feat(#40): scheduler integration + health check wiring + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,68 @@ Exit code 0 means all collectors reported recently. Exit code 1 means one or mor
 
 ---
 
+## Synthesis
+
+Once collectors have been running for at least a week, the synthesis layer
+turns the accumulated data into a weekly retrospective. It aggregates your
+workflow units, runs cross-unit outlier / abandonment detection, then asks
+Claude to produce a Markdown retrospective framed around the idealized
+workflow's preconditions — surfacing where you were slow and where effort
+was wasted, and asking at most two clarifying questions. It does **not**
+prescribe recommendations; that is a separate layer.
+
+### What it does
+
+- Loads the week's `units` rows + graph components from `data/github.db`
+  and `data/sessions.db`
+- Apportions a 512 KB transcript budget across the week's sessions (see
+  `synthesis/weekly.py::water_fill_truncate`)
+- Calls the Anthropic API (or an offline fake when `AMIS_SYNTHESIS_LIVE`
+  is unset) to render the retrospective
+- Writes `retrospectives/YYYY-MM-DD.md` atomically; refuses to overwrite
+  an existing file so your hand-written answers under "Clarifying
+  Questions" survive a re-run
+
+### How to run
+
+```bash
+am-synthesize --week YYYY-MM-DD
+```
+
+The `YYYY-MM-DD` anchor must match a value in `units.week_start` (the
+graph builder picks a Sunday for each week). Re-running with the same
+`--week` is a cheap no-op (the output writer refuses to overwrite).
+
+Dry-run to inspect the assembled prompt without calling the API:
+
+```bash
+am-synthesize --week YYYY-MM-DD --dry-run
+```
+
+### Environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `AMIS_SYNTHESIS_LIVE=1` | Use the real Anthropic API instead of the offline fake client. Requires `ANTHROPIC_API_KEY` (or whichever name `config.synthesis.anthropic_api_key_env` resolves to). |
+| `AMIS_FORCE_SYNTHESIS=1` | Run `am-synthesize` inside `run_collectors.sh` / `.ps1` even when today is not Sunday. Useful for ad-hoc re-runs or catching up after a missed Sunday. |
+
+### Where output goes
+
+```
+retrospectives/YYYY-MM-DD.md      # committed retrospective
+retrospectives/.dry-run/*.prompt.txt   # --dry-run artefacts (ignored)
+```
+
+### Cadence
+
+`run_collectors.sh` / `run_collectors.ps1` invoke `am-synthesize`
+automatically on Sundays (or when `AMIS_FORCE_SYNTHESIS=1`). Daily
+collectors still run unconditionally — only the synthesis step is gated
+on weekly cadence. See [setup.md](setup.md) for the weekly schedule
+step.
+
+---
+
 ## Project Structure
 
 ```

--- a/am_i_shipping/health_check.py
+++ b/am_i_shipping/health_check.py
@@ -19,7 +19,19 @@ from pathlib import Path
 from typing import List, Tuple, Union
 
 
-EXPECTED_COLLECTORS = ["session_parser", "github_poller"]
+EXPECTED_COLLECTORS = ["session_parser", "github_poller", "synthesis"]
+# Per-collector staleness threshold. Session parser and GitHub poller run
+# daily, so 48h catches a missed run. Synthesis runs weekly (Sundays only)
+# so its threshold has to allow for a full cadence plus a one-day slack
+# window for clock skew / DST / missed-run catch-up.
+STALE_THRESHOLDS = {
+    "session_parser": timedelta(hours=48),
+    "github_poller": timedelta(hours=48),
+    "synthesis": timedelta(days=8),
+}
+# Default kept for backwards compatibility — any collector not in the map
+# above falls back to the original 48h threshold. Callers that import
+# STALE_THRESHOLD directly continue to see the same value.
 STALE_THRESHOLD = timedelta(hours=48)
 
 
@@ -84,11 +96,12 @@ def check_health(
             continue
 
         age = now - last_success
-        if age > STALE_THRESHOLD:
+        threshold = STALE_THRESHOLDS.get(collector, STALE_THRESHOLD)
+        if age > threshold:
             hours_ago = age.total_seconds() / 3600
             messages.append(
                 f"WARNING: {collector} is stale — last success {hours_ago:.1f}h ago "
-                f"(threshold: {STALE_THRESHOLD.total_seconds() / 3600:.0f}h)"
+                f"(threshold: {threshold.total_seconds() / 3600:.0f}h)"
             )
             all_healthy = False
         else:

--- a/am_i_shipping/health_check.py
+++ b/am_i_shipping/health_check.py
@@ -16,6 +16,7 @@ import json
 import sys
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
+from types import MappingProxyType
 from typing import List, Tuple, Union
 
 
@@ -24,15 +25,42 @@ EXPECTED_COLLECTORS = ["session_parser", "github_poller", "synthesis"]
 # daily, so 48h catches a missed run. Synthesis runs weekly (Sundays only)
 # so its threshold has to allow for a full cadence plus a one-day slack
 # window for clock skew / DST / missed-run catch-up.
-STALE_THRESHOLDS = {
+#
+# If you change STALE_THRESHOLDS["synthesis"] (currently 8 days), also
+# update setup.md §"Weekly synthesis cadence" which documents the same
+# value to human readers. F-8 in the PR-48 review-fix cycle.
+#
+# Wrapped in MappingProxyType so importers cannot mutate the map in
+# place. ``.get(key, default)`` still works on the proxy. F-6 in the
+# same review-fix cycle.
+STALE_THRESHOLDS = MappingProxyType({
     "session_parser": timedelta(hours=48),
     "github_poller": timedelta(hours=48),
     "synthesis": timedelta(days=8),
-}
+})
 # Default kept for backwards compatibility — any collector not in the map
 # above falls back to the original 48h threshold. Callers that import
 # STALE_THRESHOLD directly continue to see the same value.
 STALE_THRESHOLD = timedelta(hours=48)
+
+
+def _format_duration(delta: timedelta) -> str:
+    """Render a timedelta as a human-readable "Xh" or "Xd" string.
+
+    Durations strictly below 72h are shown in hours ("48h"); anything
+    above that is shown in days with one decimal of precision ("8d",
+    "10.0d"). F-7 in the PR-48 review-fix cycle.
+    """
+    total_hours = delta.total_seconds() / 3600
+    if total_hours < 72:
+        return f"{total_hours:.0f}h"
+    total_days = total_hours / 24
+    # Use an integer render when the value is clean (no fractional day),
+    # otherwise one decimal. Avoids "8.0d" in favour of "8d" for the
+    # expected 8-day synthesis threshold.
+    if abs(total_days - round(total_days)) < 0.05:
+        return f"{int(round(total_days))}d"
+    return f"{total_days:.1f}d"
 
 
 def check_health(
@@ -98,10 +126,10 @@ def check_health(
         age = now - last_success
         threshold = STALE_THRESHOLDS.get(collector, STALE_THRESHOLD)
         if age > threshold:
-            hours_ago = age.total_seconds() / 3600
             messages.append(
-                f"WARNING: {collector} is stale — last success {hours_ago:.1f}h ago "
-                f"(threshold: {threshold.total_seconds() / 3600:.0f}h)"
+                f"WARNING: {collector} is stale — last success "
+                f"{_format_duration(age)} ago "
+                f"(threshold: {_format_duration(threshold)})"
             )
             all_healthy = False
         else:

--- a/run_collectors.ps1
+++ b/run_collectors.ps1
@@ -77,26 +77,47 @@ foreach ($Collector in $Collectors) {
 
 # --- Weekly synthesis ---
 # Only run on Sundays or when AMIS_FORCE_SYNTHESIS=1 is set.
-# .NET DayOfWeek: Sunday=0, Monday=1, ..., Saturday=6. Subtracting the
-# current day-of-week numeric value from "today" always lands on Sunday.
+#
+# Week-start semantics: synthesis covers the most recently *completed* week.
+# WEEK_START is ALWAYS the Sunday that began that completed week — i.e. the
+# most recent past Sunday, never today. On Sunday, DayOfWeek=0 so the naive
+# `-DayOfWeek` arithmetic would return today; we explicitly subtract a full
+# 7 days in that case to match the shell-side `date -d 'last sunday'`
+# semantic. This keeps the SH and PS1 schedulers in lock-step (see F-1 in
+# the PR-48 review-fix cycle).
+#
+# .NET DayOfWeek: Sunday=0, Monday=1, ..., Saturday=6.
+#   today - DayOfWeek    = this-week Sunday (== today when today is Sunday)
+#   today - DayOfWeek - 7 (when today is Sunday) = last-week Sunday
+#
+# Exit semantics: a non-zero exit from `am-synthesize` is logged as a
+# WARNING and does NOT increment $FailCount. The overall scheduler's exit
+# code should reflect the daily collectors' health; synthesis is a
+# once-a-week add-on that may legitimately skip (missing API key,
+# AMIS_SYNTHESIS_LIVE=1 without credentials, empty DB, etc.). See F-5.
 $Today = (Get-Date).DayOfWeek
 $ForceSynthesis = $env:AMIS_FORCE_SYNTHESIS -eq "1"
 if ($Today -eq [DayOfWeek]::Sunday -or $ForceSynthesis) {
-    $WeekStart = (Get-Date).AddDays(-[int](Get-Date).DayOfWeek).ToString("yyyy-MM-dd")
+    $DayOfWeekInt = [int](Get-Date).DayOfWeek
+    if ($DayOfWeekInt -eq 0) {
+        # Sunday: go back a full 7 days to land on the previous Sunday.
+        $WeekStart = (Get-Date).AddDays(-7).ToString("yyyy-MM-dd")
+    } else {
+        # Any other day: go back to this week's Sunday.
+        $WeekStart = (Get-Date).AddDays(-$DayOfWeekInt).ToString("yyyy-MM-dd")
+    }
     Write-Log "--- Starting: Weekly Synthesis (week=$WeekStart) ---"
     try {
         $synthArgs = @("--week", $WeekStart) + $ConfigArg
         $synthOutput = & am-synthesize @synthArgs 2>&1
         $synthOutput | ForEach-Object { Write-Log "  $_" }
         if ($LASTEXITCODE -ne 0) {
-            Write-Log "ERROR: Weekly Synthesis exited with code $LASTEXITCODE"
-            $FailCount++
+            Write-Log "WARNING: Weekly Synthesis exited with code $LASTEXITCODE (not counted as a failure)"
         } else {
             Write-Log "OK: Weekly Synthesis completed successfully"
         }
     } catch {
-        Write-Log "ERROR: Weekly Synthesis threw exception: $_"
-        $FailCount++
+        Write-Log "WARNING: Weekly Synthesis threw exception: $_ (not counted as a failure)"
     }
     Write-Log "--- Finished: Weekly Synthesis ---"
 }

--- a/run_collectors.ps1
+++ b/run_collectors.ps1
@@ -75,6 +75,32 @@ foreach ($Collector in $Collectors) {
     Write-Log "--- Finished: $($Collector.Name) ---"
 }
 
+# --- Weekly synthesis ---
+# Only run on Sundays or when AMIS_FORCE_SYNTHESIS=1 is set.
+# .NET DayOfWeek: Sunday=0, Monday=1, ..., Saturday=6. Subtracting the
+# current day-of-week numeric value from "today" always lands on Sunday.
+$Today = (Get-Date).DayOfWeek
+$ForceSynthesis = $env:AMIS_FORCE_SYNTHESIS -eq "1"
+if ($Today -eq [DayOfWeek]::Sunday -or $ForceSynthesis) {
+    $WeekStart = (Get-Date).AddDays(-[int](Get-Date).DayOfWeek).ToString("yyyy-MM-dd")
+    Write-Log "--- Starting: Weekly Synthesis (week=$WeekStart) ---"
+    try {
+        $synthArgs = @("--week", $WeekStart) + $ConfigArg
+        $synthOutput = & am-synthesize @synthArgs 2>&1
+        $synthOutput | ForEach-Object { Write-Log "  $_" }
+        if ($LASTEXITCODE -ne 0) {
+            Write-Log "ERROR: Weekly Synthesis exited with code $LASTEXITCODE"
+            $FailCount++
+        } else {
+            Write-Log "OK: Weekly Synthesis completed successfully"
+        }
+    } catch {
+        Write-Log "ERROR: Weekly Synthesis threw exception: $_"
+        $FailCount++
+    }
+    Write-Log "--- Finished: Weekly Synthesis ---"
+}
+
 # --- Health check ---
 Write-Log "=== Running health check ==="
 try {

--- a/run_collectors.sh
+++ b/run_collectors.sh
@@ -55,6 +55,24 @@ FAIL_COUNT=0
 run_collector "Session Parser" -m collector.session_parser --mode batch
 run_collector "GitHub Poller"  -m collector.github_poller.run
 
+# Weekly synthesis: only run on Sundays, or when AMIS_FORCE_SYNTHESIS=1 is set.
+# `date +%u` returns 1..7 where 7 = Sunday (POSIX). Both GNU date and BSD date
+# support `+%u` the same way, so no per-OS branching is needed here. The
+# per-OS branching below is for `date -d 'last sunday'` (GNU) vs `date -v-sun`
+# (BSD / macOS) because those two flags are NOT cross-compatible.
+if [ "$(date +%u)" = "7" ] || [ "${AMIS_FORCE_SYNTHESIS:-0}" = "1" ]; then
+    WEEK_START="$(date -d 'last sunday' +%Y-%m-%d 2>/dev/null || date -v-sun +%Y-%m-%d)"
+    log "--- Starting: Weekly Synthesis (week=$WEEK_START) ---"
+    if am-synthesize --week "$WEEK_START" "${CONFIG_ARG[@]}" >> "$LOG_FILE" 2>&1; then
+        log "OK: Weekly Synthesis completed successfully"
+    else
+        rc=$?
+        log "ERROR: Weekly Synthesis exited with code $rc"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+    log "--- Finished: Weekly Synthesis ---"
+fi
+
 log "=== Running health check ==="
 if python3 -m am_i_shipping.health_check >> "$LOG_FILE" 2>&1; then
     log "OK: All collectors healthy"

--- a/run_collectors.sh
+++ b/run_collectors.sh
@@ -57,9 +57,24 @@ run_collector "GitHub Poller"  -m collector.github_poller.run
 
 # Weekly synthesis: only run on Sundays, or when AMIS_FORCE_SYNTHESIS=1 is set.
 # `date +%u` returns 1..7 where 7 = Sunday (POSIX). Both GNU date and BSD date
-# support `+%u` the same way, so no per-OS branching is needed here. The
-# per-OS branching below is for `date -d 'last sunday'` (GNU) vs `date -v-sun`
-# (BSD / macOS) because those two flags are NOT cross-compatible.
+# support `+%u` the same way, so no per-OS branching is needed here.
+#
+# Week-start semantics: synthesis covers the most recently *completed* week,
+# so WEEK_START is always the Sunday seven days before today when today IS
+# Sunday, and the most recent past Sunday on every other day. GNU
+# `date -d 'last sunday'` and BSD `date -v-sun` both implement that
+# "previous Sunday, never today" semantic natively, so the output is
+# consistent across OSes and across weekdays. See F-1 / F-9 in the PR-48
+# review-fix cycle: the PowerShell counterpart is aligned to the same
+# convention explicitly.
+#
+# Exit semantics: a non-zero exit from `am-synthesize` is logged as a
+# WARNING and does NOT increment FAIL_COUNT. The overall scheduler's
+# exit code should reflect the daily collectors' health; synthesis is a
+# once-a-week add-on that may legitimately skip (missing API key,
+# AMIS_SYNTHESIS_LIVE=1 without credentials, empty DB, etc.). Only
+# daily-collector failures should flip the scheduler red. See F-5 in the
+# PR-48 review-fix cycle.
 if [ "$(date +%u)" = "7" ] || [ "${AMIS_FORCE_SYNTHESIS:-0}" = "1" ]; then
     WEEK_START="$(date -d 'last sunday' +%Y-%m-%d 2>/dev/null || date -v-sun +%Y-%m-%d)"
     log "--- Starting: Weekly Synthesis (week=$WEEK_START) ---"
@@ -67,8 +82,7 @@ if [ "$(date +%u)" = "7" ] || [ "${AMIS_FORCE_SYNTHESIS:-0}" = "1" ]; then
         log "OK: Weekly Synthesis completed successfully"
     else
         rc=$?
-        log "ERROR: Weekly Synthesis exited with code $rc"
-        FAIL_COUNT=$((FAIL_COUNT + 1))
+        log "WARNING: Weekly Synthesis exited with code $rc (not counted as a failure)"
     fi
     log "--- Finished: Weekly Synthesis ---"
 fi

--- a/setup.md
+++ b/setup.md
@@ -113,7 +113,9 @@ under "Clarifying Questions" are safe.
 `retrospectives/<sunday-date>.md` exists and that `data/health.json`
 contains a fresh `synthesis` entry. `python -m am_i_shipping.health_check`
 will warn if the `synthesis` collector has been silent beyond the weekly
-threshold (8 days).
+threshold (currently 8 days — see
+`am_i_shipping/health_check.py::STALE_THRESHOLDS["synthesis"]` for the
+source of truth).
 
 ---
 

--- a/setup.md
+++ b/setup.md
@@ -71,6 +71,50 @@ bash scripts/uninstall-launchd.sh
 
 All install scripts default to daily at 02:00. They also install a boot-time fallback trigger so that if your PC is off at 02:00, the run happens automatically the next time you log in. Collectors are idempotent — running twice in one day produces no duplicate data.
 
+### Weekly synthesis cadence
+
+`run_collectors.sh` and `run_collectors.ps1` contain a weekly-cadence
+check that runs `am-synthesize` only on Sundays (or when the
+`AMIS_FORCE_SYNTHESIS=1` environment variable is set). **You do not need
+a separate cron entry / Scheduled Task for synthesis** — as long as the
+daily collector job fires on Sunday, synthesis will run with it.
+
+How it works in each entry point:
+
+- **Linux/macOS (`run_collectors.sh`)** — `date +%u` returns `7` on
+  Sunday. When it does, the script resolves the most recent Sunday's
+  date and invokes `am-synthesize --week <YYYY-MM-DD>`. On all other
+  days the block is skipped.
+- **Windows (`run_collectors.ps1`)** — the same logic via
+  `(Get-Date).DayOfWeek -eq [DayOfWeek]::Sunday`.
+
+If you miss a Sunday (PC off, cron didn't fire), re-run catch-up
+manually:
+
+```bash
+# Linux / macOS
+AMIS_FORCE_SYNTHESIS=1 bash run_collectors.sh
+
+# Windows
+$env:AMIS_FORCE_SYNTHESIS = "1"; .\run_collectors.ps1
+```
+
+Or call `am-synthesize` directly with the week you want to re-generate:
+
+```bash
+am-synthesize --week 2026-04-12
+```
+
+Re-running for the same `--week` is a cheap no-op — the output writer
+refuses to overwrite an existing retrospective, so answers you've added
+under "Clarifying Questions" are safe.
+
+**Verify:** On the Sunday after install, check that
+`retrospectives/<sunday-date>.md` exists and that `data/health.json`
+contains a fresh `synthesis` entry. `python -m am_i_shipping.health_check`
+will warn if the `synthesis` collector has been silent beyond the weekly
+threshold (8 days).
+
 ---
 
 ### Manual setup (alternative)

--- a/synthesis/weekly.py
+++ b/synthesis/weekly.py
@@ -46,6 +46,7 @@ from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
 from am_i_shipping.config_loader import SynthesisConfig
+from am_i_shipping.health_writer import write_health
 from synthesis.fake_client import FakeAnthropicClient
 from synthesis.output_writer import write_retrospective
 from synthesis.unit_timeline import render_timeline
@@ -631,7 +632,19 @@ def run_synthesis(
         client, is_live = _get_client(config)
         markdown = _call_llm(client, config, system_prompt, messages, is_live)
 
-        return write_retrospective(markdown, config.output_dir, week_start)
+        result = write_retrospective(markdown, config.output_dir, week_start)
+
+        # Record a successful synthesis run in health.json ONLY when the
+        # retrospective was actually written this invocation. Refuse-to-
+        # overwrite (Decision 2) returns None — that case is idempotent
+        # success, but it's not a new data point so we don't bump the
+        # health timestamp. ``last_record_count`` is the number of units
+        # the run synthesised, giving operators a cheap signal to spot
+        # "synthesis ran but the week was empty" vs. the normal case.
+        if result is not None:
+            write_health("synthesis", len(units))
+
+        return result
 
     finally:
         if sess_conn is not gh_conn:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -7,7 +7,11 @@ from pathlib import Path
 import pytest
 
 from am_i_shipping.health_writer import write_health
-from am_i_shipping.health_check import check_health
+from am_i_shipping.health_check import (
+    check_health,
+    EXPECTED_COLLECTORS,
+    STALE_THRESHOLDS,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -74,6 +78,7 @@ class TestCheckHealth:
         health = {
             "session_parser": {"last_success": now, "last_record_count": 10},
             "github_poller": {"last_success": now, "last_record_count": 20},
+            "synthesis": {"last_success": now, "last_record_count": 3},
         }
         (data_dir / "health.json").write_text(json.dumps(health))
 
@@ -90,6 +95,7 @@ class TestCheckHealth:
         health = {
             "session_parser": {"last_success": stale, "last_record_count": 10},
             "github_poller": {"last_success": fresh, "last_record_count": 20},
+            "synthesis": {"last_success": fresh, "last_record_count": 3},
         }
         (data_dir / "health.json").write_text(json.dumps(health))
 
@@ -101,7 +107,7 @@ class TestCheckHealth:
         data_dir = tmp_path / "data"
         data_dir.mkdir()
         now = datetime.now(timezone.utc).isoformat()
-        # Only one of two expected collectors present
+        # Only one of three expected collectors present
         health = {
             "session_parser": {"last_success": now, "last_record_count": 10},
         }
@@ -127,3 +133,86 @@ class TestCheckHealth:
         healthy, messages = check_health(data_dir=data_dir)
         assert not healthy
         assert any("Failed to read" in m for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# Synthesis collector wiring (issue #40)
+# ---------------------------------------------------------------------------
+
+class TestSynthesisHealthWiring:
+    """Issue #40 adds synthesis to EXPECTED_COLLECTORS with a weekly threshold."""
+
+    def test_synthesis_in_expected_collectors(self):
+        """EXPECTED_COLLECTORS contains 'synthesis' alongside the daily collectors."""
+        assert "synthesis" in EXPECTED_COLLECTORS
+
+    def test_synthesis_has_weekly_threshold(self):
+        """Synthesis runs weekly, so its threshold must exceed the daily 48h."""
+        # 8 days = 192h; must be strictly greater than the daily 48h so a
+        # Sunday-to-Sunday cadence with a day of slack does not flap.
+        assert STALE_THRESHOLDS["synthesis"] > timedelta(hours=48)
+        assert STALE_THRESHOLDS["synthesis"] >= timedelta(days=7)
+
+    def test_write_health_records_synthesis(self, tmp_path):
+        """write_health('synthesis', ...) produces a readable health.json entry."""
+        data_dir = tmp_path / "data"
+        write_health("synthesis", 5, data_dir=data_dir)
+
+        data = json.loads((data_dir / "health.json").read_text())
+        assert "synthesis" in data
+        assert data["synthesis"]["last_record_count"] == 5
+        assert "last_success" in data["synthesis"]
+
+    def test_synthesis_fresh_is_healthy(self, tmp_path):
+        """A recent synthesis run (inside the 8-day window) reports healthy."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        now = datetime.now(timezone.utc)
+        # 5 days ago — well inside the weekly threshold, well outside the
+        # daily 48h threshold. This is the test that proves the per-
+        # collector threshold lookup is actually being used.
+        five_days_ago = (now - timedelta(days=5)).isoformat()
+        fresh = now.isoformat()
+        health = {
+            "session_parser": {"last_success": fresh, "last_record_count": 10},
+            "github_poller": {"last_success": fresh, "last_record_count": 20},
+            "synthesis": {"last_success": five_days_ago, "last_record_count": 3},
+        }
+        (data_dir / "health.json").write_text(json.dumps(health))
+
+        healthy, messages = check_health(data_dir=data_dir)
+        assert healthy, f"expected healthy, got messages={messages!r}"
+
+    def test_synthesis_stale_beyond_weekly_threshold(self, tmp_path):
+        """Synthesis absent for more than 8 days flips health to red."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        now = datetime.now(timezone.utc)
+        fresh = now.isoformat()
+        way_stale = (now - timedelta(days=10)).isoformat()
+        health = {
+            "session_parser": {"last_success": fresh, "last_record_count": 10},
+            "github_poller": {"last_success": fresh, "last_record_count": 20},
+            "synthesis": {"last_success": way_stale, "last_record_count": 3},
+        }
+        (data_dir / "health.json").write_text(json.dumps(health))
+
+        healthy, messages = check_health(data_dir=data_dir)
+        assert not healthy
+        assert any("synthesis" in m and "stale" in m for m in messages)
+
+    def test_synthesis_missing_entry(self, tmp_path):
+        """Missing synthesis entry flips health to red."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        now = datetime.now(timezone.utc).isoformat()
+        health = {
+            "session_parser": {"last_success": now, "last_record_count": 10},
+            "github_poller": {"last_success": now, "last_record_count": 20},
+            # synthesis intentionally absent
+        }
+        (data_dir / "health.json").write_text(json.dumps(health))
+
+        healthy, messages = check_health(data_dir=data_dir)
+        assert not healthy
+        assert any("synthesis" in m and "never reported" in m for m in messages)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -216,3 +216,47 @@ class TestSynthesisHealthWiring:
         healthy, messages = check_health(data_dir=data_dir)
         assert not healthy
         assert any("synthesis" in m and "never reported" in m for m in messages)
+
+    def test_stale_thresholds_is_immutable(self):
+        """STALE_THRESHOLDS cannot be mutated by importers (F-6).
+
+        ``MappingProxyType`` is a read-only view: assignment and ``.pop``
+        both raise ``TypeError``. A plain dict would silently accept the
+        mutation and shift production behaviour.
+        """
+        with pytest.raises(TypeError):
+            STALE_THRESHOLDS["synthesis"] = timedelta(hours=1)  # type: ignore[index]
+
+    def test_synthesis_stale_message_renders_days_not_hours(self, tmp_path):
+        """Stale-message for synthesis reads as "Xd", not "192h" (F-7)."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        now = datetime.now(timezone.utc)
+        fresh = now.isoformat()
+        way_stale = (now - timedelta(days=10)).isoformat()
+        health = {
+            "session_parser": {"last_success": fresh, "last_record_count": 10},
+            "github_poller": {"last_success": fresh, "last_record_count": 20},
+            "synthesis": {"last_success": way_stale, "last_record_count": 3},
+        }
+        (data_dir / "health.json").write_text(json.dumps(health))
+
+        healthy, messages = check_health(data_dir=data_dir)
+        assert not healthy
+        synth_msgs = [m for m in messages if "synthesis" in m and "stale" in m]
+        assert synth_msgs, messages
+        msg = synth_msgs[0]
+        # The 8-day threshold is rendered as "8d", not "192h".
+        assert "8d" in msg, (
+            f"expected '8d' threshold rendering in synthesis message, "
+            f"got: {msg!r}"
+        )
+        # The 192h form must NOT appear in the synthesis message — that
+        # was the F-7 regression.
+        assert "192h" not in msg, (
+            f"synthesis message fell back to hours rendering: {msg!r}"
+        )
+        # The ~10-day age must render in days too.
+        assert "d ago" in msg, (
+            f"age also expected to render in days: {msg!r}"
+        )

--- a/tests/test_integration_gate.py
+++ b/tests/test_integration_gate.py
@@ -31,15 +31,26 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def _run_collectors() -> subprocess.CompletedProcess:
-    """Run run_collectors.sh and return the result."""
+def _run_collectors(
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    """Run run_collectors.sh and return the result.
+
+    ``env_overrides`` lets a test inject extra environment variables
+    (e.g. ``AMIS_FORCE_SYNTHESIS=1`` to exercise the weekly-cadence
+    branch on any day of the week).
+    """
     script = REPO_ROOT / "run_collectors.sh"
+    env = os.environ.copy()
+    if env_overrides:
+        env.update(env_overrides)
     return subprocess.run(
         ["bash", str(script)],
         cwd=str(REPO_ROOT),
         capture_output=True,
         text=True,
         timeout=300,
+        env=env,
     )
 
 
@@ -229,4 +240,74 @@ class TestIntegrationGate:
         assert found_recent, (
             "No collector has a last_success within the last 5 minutes "
             f"in health.json: {data}"
+        )
+
+    # ------------------------------------------------------------------
+    # Weekly synthesis block (issue #40 / F-4 in PR-48 review-fix cycle)
+    # ------------------------------------------------------------------
+    # The scheduler invokes ``am-synthesize`` on Sundays, or on any day
+    # when ``AMIS_FORCE_SYNTHESIS=1``. The existing tests above skip
+    # this branch on non-Sundays, so without these two cases the entire
+    # cadence block has no positive coverage.
+
+    def test_synthesis_block_skipped_on_non_sunday_without_force(self) -> None:
+        """Without FORCE and not on Sunday, the synthesis block is SKIPPED.
+
+        Negative assertion: the log must NOT contain the
+        ``--- Starting: Weekly Synthesis`` marker. Skipped with reason
+        when today happens to be Sunday — the positive case is covered
+        separately.
+        """
+        import datetime as _dt
+
+        if _dt.date.today().weekday() == 6:  # Sunday in Python weekday
+            pytest.skip("today is Sunday; skip-branch not exercised")
+
+        result = _run_collectors()
+        assert result.returncode == 0, (
+            f"run_collectors.sh exited {result.returncode}:\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        log_files = sorted((REPO_ROOT / "logs").glob("run_*.log"))
+        assert log_files, "no log file produced"
+        log_text = log_files[-1].read_text(encoding="utf-8", errors="replace")
+        assert "Starting: Weekly Synthesis" not in log_text, (
+            "synthesis block ran on a non-Sunday without FORCE; "
+            "cadence guard is broken:\n" + log_text
+        )
+
+    def test_synthesis_block_runs_with_force_env(self) -> None:
+        """With ``AMIS_FORCE_SYNTHESIS=1`` the synthesis block always runs.
+
+        Positive assertion: log contains the "Starting: Weekly Synthesis"
+        marker and the WEEK_START is a valid YYYY-MM-DD token. The
+        am-synthesize invocation may legitimately exit non-zero (missing
+        API key, empty DB, etc.); per F-5 that must NOT flip the
+        scheduler to a non-zero exit code, so we also assert exit 0
+        regardless of whether synthesis itself succeeded.
+        """
+        import re
+
+        result = _run_collectors({"AMIS_FORCE_SYNTHESIS": "1"})
+        assert result.returncode == 0, (
+            f"run_collectors.sh exited {result.returncode} with "
+            f"AMIS_FORCE_SYNTHESIS=1 — synthesis failure must NOT flip "
+            f"the scheduler to non-zero.\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        log_files = sorted((REPO_ROOT / "logs").glob("run_*.log"))
+        assert log_files, "no log file produced"
+        log_text = log_files[-1].read_text(encoding="utf-8", errors="replace")
+        assert "Starting: Weekly Synthesis" in log_text, (
+            "synthesis block did not start under AMIS_FORCE_SYNTHESIS=1:\n"
+            + log_text
+        )
+        # WEEK_START must appear as YYYY-MM-DD in the "(week=...)" parens.
+        match = re.search(
+            r"Starting: Weekly Synthesis \(week=(\d{4}-\d{2}-\d{2})\)",
+            log_text,
+        )
+        assert match, (
+            "synthesis block started but WEEK_START not a valid "
+            "YYYY-MM-DD in the log:\n" + log_text
         )

--- a/tests/test_limiters.py
+++ b/tests/test_limiters.py
@@ -418,9 +418,14 @@ class TestAppswitchRemoved:
         data_dir.mkdir()
         from datetime import datetime, timezone
         now = datetime.now(timezone.utc).isoformat()
+        # Issue #40 added ``synthesis`` to EXPECTED_COLLECTORS; supply a
+        # fresh entry for it so this assertion still verifies only that
+        # appswitch's absence is tolerated (the thing the test is named
+        # after), not that synthesis happens to be missing too.
         health = {
             "session_parser": {"last_success": now, "last_record_count": 10},
             "github_poller": {"last_success": now, "last_record_count": 20},
+            "synthesis": {"last_success": now, "last_record_count": 3},
         }
         (data_dir / "health.json").write_text(json.dumps(health))
 

--- a/tests/test_weekly.py
+++ b/tests/test_weekly.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import sqlite3
 from dataclasses import replace
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -127,6 +129,47 @@ def _scrub_live_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("AMIS_SYNTHESIS_LIVE", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     yield
+
+
+# ---------------------------------------------------------------------------
+# Health-write isolation (F-2 in the PR-48 review-fix cycle)
+# ---------------------------------------------------------------------------
+# Issue #40 added ``write_health("synthesis", len(units))`` inside
+# ``run_synthesis``. ``write_health`` with no ``data_dir`` defaults to the
+# real repo's ``data/`` directory, which means every invocation of
+# ``run_synthesis`` from this test module was stomping the developer's
+# production ``data/health.json``. The fixture below redirects the call
+# site so the default-path health writer writes into a tmp_path-scoped
+# data dir and never touches the repo.
+
+@pytest.fixture(autouse=True)
+def _isolate_write_health(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Redirect ``synthesis.weekly.write_health``'s default data_dir to tmp_path.
+
+    Yields the redirected health-data directory. Tests that want to assert
+    "a synthesis entry landed in health.json" can read from
+    ``tmp_path / "data" / "health.json"`` — or request the ``health_data_dir``
+    fixture.
+    """
+    import synthesis.weekly as weekly_module
+
+    health_data_dir = tmp_path / "health_data"
+    real_write_health = weekly_module.write_health
+
+    def _redirecting_write_health(collector_name, record_count, data_dir=None):
+        target = data_dir if data_dir is not None else health_data_dir
+        return real_write_health(collector_name, record_count, data_dir=target)
+
+    monkeypatch.setattr(
+        weekly_module, "write_health", _redirecting_write_health
+    )
+    yield health_data_dir
+
+
+@pytest.fixture
+def health_data_dir(_isolate_write_health) -> Path:
+    """Convenience alias for the redirected health-data directory."""
+    return _isolate_write_health
 
 
 class TestRunSynthesisOffline:
@@ -273,6 +316,134 @@ class TestNoUnitsForWeek:
         assert result is None
         # And no retrospective file was written.
         assert not (out / "1999-01-04.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Health-write integration (issue #40 / F-3 in PR-48 review-fix cycle)
+# ---------------------------------------------------------------------------
+# These tests lock down the invariant that the PR claims to establish:
+# ``run_synthesis`` must call ``write_health("synthesis", ...)`` on the
+# successful-write path, and must NOT call it on the refuse-to-overwrite
+# path. Without these, a future refactor could silently delete the
+# ``write_health`` call and the health-check goes-red-after-one-week
+# invariant regresses without CI signal.
+
+
+class TestRunSynthesisHealthWiring:
+    def test_successful_run_writes_synthesis_health_entry(
+        self, tmp_path: Path, health_data_dir: Path
+    ):
+        """Happy path: the fake-client run lands a synthesis entry in health.json."""
+        db = _fixture_copy(tmp_path)
+        out = tmp_path / "retrospectives"
+        cfg = _make_config(tmp_path, out)
+
+        result = run_synthesis(cfg, db, db, WEEK_START)
+        assert result is not None, "precondition: the happy-path write succeeded"
+
+        health_path = health_data_dir / "health.json"
+        assert health_path.exists(), (
+            "run_synthesis did not call write_health on the success path"
+        )
+
+        data = json.loads(health_path.read_text(encoding="utf-8"))
+        assert "synthesis" in data
+        entry = data["synthesis"]
+        assert "last_success" in entry
+        assert "last_record_count" in entry
+        # last_record_count is len(units); golden fixture has ≥ 1 unit
+        # for WEEK_START, so we just assert it is a non-negative int.
+        assert isinstance(entry["last_record_count"], int)
+        assert entry["last_record_count"] >= 0
+        # last_success is a recent ISO timestamp.
+        ts = datetime.fromisoformat(entry["last_success"])
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        assert (datetime.now(timezone.utc) - ts).total_seconds() < 60, (
+            f"last_success timestamp is not recent: {entry['last_success']!r}"
+        )
+
+    def test_refuse_to_overwrite_does_not_bump_health(
+        self, tmp_path: Path, health_data_dir: Path
+    ):
+        """Decision-2 (refuse-to-overwrite) returns None → health NOT bumped.
+
+        The weekly.py comment at the write_health call site is explicit:
+        "that case is idempotent success, but it's not a new data point
+        so we don't bump the health timestamp". This test nails that
+        invariant down with a negative assertion.
+        """
+        db = _fixture_copy(tmp_path)
+        out = tmp_path / "retrospectives"
+        cfg = _make_config(tmp_path, out)
+
+        # First run writes the retrospective AND the health entry.
+        first = run_synthesis(cfg, db, db, WEEK_START)
+        assert first is not None
+
+        health_path = health_data_dir / "health.json"
+        first_ts = json.loads(health_path.read_text(encoding="utf-8"))[
+            "synthesis"
+        ]["last_success"]
+
+        # Second run hits refuse-to-overwrite and returns None.
+        second = run_synthesis(cfg, db, db, WEEK_START)
+        assert second is None, "precondition: refuse-to-overwrite path taken"
+
+        # The health timestamp MUST NOT have advanced.
+        second_ts = json.loads(health_path.read_text(encoding="utf-8"))[
+            "synthesis"
+        ]["last_success"]
+        assert first_ts == second_ts, (
+            "refuse-to-overwrite run bumped the health timestamp; it must not"
+        )
+
+    def test_no_units_for_week_does_not_write_health(
+        self, tmp_path: Path, health_data_dir: Path
+    ):
+        """Empty-week run returns None → no health entry created.
+
+        An empty week is not a successful synthesis — the LLM was never
+        called, no retrospective was written. It MUST NOT register as a
+        fresh health datapoint, otherwise stale-synthesis detection
+        would be masked by empty-week runs.
+        """
+        db = _fixture_copy(tmp_path)
+        out = tmp_path / "retrospectives"
+        cfg = _make_config(tmp_path, out)
+
+        # 1999-01-04 is a Monday with no units in the golden fixture.
+        result = run_synthesis(cfg, db, db, "1999-01-04")
+        assert result is None, "precondition: no-units path taken"
+
+        health_path = health_data_dir / "health.json"
+        # Either the file doesn't exist, or it exists without a synthesis
+        # entry. Both are acceptable — what must NOT happen is a synthesis
+        # entry appearing from an empty-week run.
+        if health_path.exists():
+            data = json.loads(health_path.read_text(encoding="utf-8"))
+            assert "synthesis" not in data, (
+                "empty-week run wrote a synthesis health entry; it must not"
+            )
+
+    def test_dry_run_does_not_write_health(
+        self, tmp_path: Path, health_data_dir: Path
+    ):
+        """--dry-run emits a prompt artefact and MUST NOT write health."""
+        db = _fixture_copy(tmp_path)
+        out = tmp_path / "retrospectives"
+        cfg = _make_config(tmp_path, out)
+
+        result = run_synthesis(cfg, db, db, WEEK_START, dry_run=True)
+        assert result is not None
+        assert result.name.endswith(".prompt.txt")
+
+        health_path = health_data_dir / "health.json"
+        if health_path.exists():
+            data = json.loads(health_path.read_text(encoding="utf-8"))
+            assert "synthesis" not in data, (
+                "dry-run wrote a synthesis health entry; it must not"
+            )
 
 
 class TestWaterFillBudgetConstant:


### PR DESCRIPTION
Closes #40. Part of epic #17. This is the operational point-of-no-return: adds synthesis to EXPECTED_COLLECTORS.

## Changes
- `run_collectors.sh` / `run_collectors.ps1`: `am-synthesize` invoked on weekly cadence (Sunday or `AMIS_FORCE_SYNTHESIS=1`). Shell variant handles both GNU date (`date -d 'last sunday'`) and BSD date (`date -v-sun`).
- `am_i_shipping/health_check.py`: `synthesis` added to `EXPECTED_COLLECTORS`; new `STALE_THRESHOLDS` map gives synthesis an 8-day window while the daily collectors keep 48h. Default fallback preserved for callers that import `STALE_THRESHOLD` directly.
- `synthesis/weekly.py`: `write_health("synthesis", unit_count)` on successful retrospective write. Refuse-to-overwrite runs intentionally skip the health bump.
- `README.md`: full Synthesis section (what / how / env vars / output path / cadence).
- `setup.md`: weekly synthesis cadence step + manual catch-up instructions.
- `.claude-work/EPIC_17_ADR.md`: rollback procedure appended (local-only — `.claude-work/` is gitignored).
- `tests/test_health.py`: new `TestSynthesisHealthWiring` class (6 cases).
- `tests/test_limiters.py`: `test_health_check_passes_without_appswitch` fixture extended to include the new `synthesis` entry so it continues to test only appswitch-absence.

## Acceptance criteria
- [x] `run_collectors.sh` invokes `am-synthesize` on weekly cadence only
- [x] `am-health-check` green after synthesis run; red if absent beyond cadence (proven by `test_synthesis_fresh_is_healthy` and `test_synthesis_stale_beyond_weekly_threshold`)
- [x] `README.md` documents the synthesis layer
- [x] `setup.md` lists the weekly schedule step
- [x] Rollback steps documented in ADR

## Test results
- `pytest tests/test_health.py -v` — 16 passed
- `pytest tests/` — 413 passed, 15 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)