### PR TITLE
feat(config): uncomment synthesis block in config.yaml.example

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -92,28 +92,25 @@ data:
   data_dir: "data"
 
 # -------------------------------------------------------------------
-# Weekly synthesis (Phase 2 — Epic #17) — DISABLED
-# Uncomment to enable. The full synthesis pipeline is delivered across
-# sub-issues #34..#40; the config section is accepted now so downstream
-# sub-issues can be wired incrementally without re-touching config_loader.
+# Weekly synthesis (Phase 2 — Epic #17)
 # -------------------------------------------------------------------
-# synthesis:
-#   # Name of the environment variable holding the Anthropic API key.
-#   # Presence is NOT validated here; the check is activated by Sub-Issue 6.
-#   anthropic_api_key_env: "ANTHROPIC_API_KEY"
-#
-#   # Anthropic model used for the weekly retrospective call.
-#   model: "claude-sonnet-4-5"
-#
-#   # Directory for retrospective markdown files (relative paths
-#   # resolved from the repo root).
-#   output_dir: "retrospectives"
-#
-#   # Start of the synthesis week. One of "monday" or "sunday".
-#   week_start: "monday"
-#
-#   # Days of inactivity before a unit is flagged as abandoned.
-#   abandonment_days: 14
-#
-#   # Sigma multiplier used when flagging outlier units on per-metric medians.
-#   outlier_sigma: 2.0
+synthesis:
+  # Name of the environment variable holding the Anthropic API key.
+  # Presence is NOT validated here; the check is activated by Sub-Issue 6.
+  anthropic_api_key_env: "ANTHROPIC_API_KEY"
+
+  # Anthropic model used for the weekly retrospective call.
+  model: "claude-sonnet-4-5"
+
+  # Directory for retrospective markdown files (relative paths
+  # resolved from the repo root).
+  output_dir: "retrospectives"
+
+  # Start of the synthesis week. One of "monday" or "sunday".
+  week_start: "monday"
+
+  # Days of inactivity before a unit is flagged as abandoned.
+  abandonment_days: 14
+
+  # Sigma multiplier used when flagging outlier units on per-metric medians.
+  outlier_sigma: 2.0


### PR DESCRIPTION
## Summary

Uncomments the `synthesis:` block in `config.yaml.example` (lines 95-119) so users can copy it directly into their local `config.yaml`. The block was previously commented out with a note that it was reserved for future sub-issues; Phase 2 synthesis has since shipped, so the example should present it as live config.

Scope correction: the original issue title referenced `config.yaml`, but `config.yaml` is gitignored (per-user file) and must never be committed. The canonical deliverable is updating `config.yaml.example`. The `SynthesisConfig` loader in `am_i_shipping/config_loader.py` already parses this section with matching defaults.

Values match the loader defaults:
- `output_dir: "retrospectives"`
- `abandonment_days: 14`
- `outlier_sigma: 2.0`
- `model: "claude-sonnet-4-5"`
- `week_start: "monday"`
- `anthropic_api_key_env: "ANTHROPIC_API_KEY"`

Closes #56.

## Test plan

- [x] `pytest tests/test_config_loader.py -q` — 24 passed
- [x] `load_config('config.yaml.example')` (with a populated `projects_path`) returns a `SynthesisConfig` with all expected defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)