### PR TITLE
fix(#70): X-0 raw_content_json coverage diagnostic and backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,37 @@ collectors still run unconditionally — only the synthesis step is gated
 on weekly cadence. See [setup.md](setup.md) for the weekly schedule
 step.
 
+### Coverage diagnostic (pre-synthesis health check)
+
+Before synthesis can be trusted, every session in `sessions.db` needs a
+recoverable transcript in `raw_content_json` — otherwise the expectation
+extractor (Epic #27) reads empty strings and emits plausible-looking
+output with no signal. Run the coverage diagnostic at any time to see the
+fill state and surface sessions needing attention:
+
+```bash
+am-synthesize coverage              # human-readable report
+am-synthesize coverage --json       # machine-readable (for scripts)
+am-synthesize coverage --backfill   # populate NULL rows from JSONL (idempotent)
+am-synthesize coverage --backfill --full   # delete and re-ingest every session
+```
+
+The report gives total / NULL / `"[]"` / non-empty counts bucketed
+per-week, per-project, and per-unit (where "unit" is a mechanical GitHub
+reference parse from the raw JSONL, independent of the synthesis unit
+identifier). Four diagnostic lists surface sessions that need human
+attention: unprocessed JSONLs, orphan DB rows, `"[]"` rows whose JSONL
+has text turns (parser-bug candidates), and `"[]"` rows whose JSONL is
+genuinely empty (degenerate candidates).
+
+**Coverage gate (qualitative).** The gate for trusting expectation
+extraction is not a percentage threshold: *every session should have a
+transcript OR be on a documented exclusion list with a reason*. Use
+`coverage` to find the exceptions; use `--backfill` (partial) to recover
+what the filesystem still has; use `--backfill --full` only when you
+know the DB has drifted from the JSONLs (e.g. a prior parser bug that
+needs a clean re-ingest).
+
 ---
 
 ## Project Structure

--- a/synthesis/cli.py
+++ b/synthesis/cli.py
@@ -1,18 +1,26 @@
-"""``am-synthesize`` CLI entry point (Epic #17 — Issue #39).
+"""``am-synthesize`` CLI entry point.
 
-Thin wrapper around :func:`synthesis.weekly.run_synthesis`. The CLI's
-job is to parse flags and resolve DB paths from ``config.yaml``; the
-synthesis pipeline itself lives in ``synthesis.weekly``.
+Thin wrapper around the synthesis pipeline and the coverage diagnostic.
+Two invocation shapes are supported:
 
-Usage::
+Weekly synthesis (Epic #17 — Issue #39; the original command)::
 
     am-synthesize --week 2026-04-12
     am-synthesize --week 2026-04-12 --dry-run
-    AMIS_SYNTHESIS_LIVE=1 ANTHROPIC_API_KEY=sk-... am-synthesize --week 2026-04-12
 
-When ``AMIS_SYNTHESIS_LIVE`` is unset, the run uses the offline
-:class:`synthesis.fake_client.FakeAnthropicClient` and does not require
-an API key.
+Coverage diagnostic (Issue #70 — pre-synthesis health check)::
+
+    am-synthesize coverage
+    am-synthesize coverage --json
+    am-synthesize coverage --backfill
+    am-synthesize coverage --backfill --full
+
+The bare ``--week`` form is preserved verbatim so scripts and cron entries
+that predate the coverage subcommand continue to work — no breaking change.
+
+When ``AMIS_SYNTHESIS_LIVE`` is unset, weekly runs use the offline
+:class:`synthesis.fake_client.FakeAnthropicClient` and do not require an API
+key.
 """
 
 from __future__ import annotations
@@ -25,6 +33,7 @@ from pathlib import Path
 from typing import Optional, Sequence
 
 from am_i_shipping.config_loader import load_config
+from synthesis.coverage import add_coverage_subparser, run_coverage
 from synthesis.weekly import run_synthesis
 
 
@@ -32,14 +41,19 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="am-synthesize",
         description=(
-            "Run the weekly synthesis engine for a given week_start. "
-            "Writes retrospectives/<week>.md. Use --dry-run to emit the "
-            "assembled prompt without calling the API."
+            "Run the weekly synthesis engine for a given week_start, or the "
+            "coverage diagnostic (pre-synthesis health check). "
+            "Weekly: writes retrospectives/<week>.md. "
+            "Coverage: reports raw_content_json fill state across sessions.db "
+            "and JSONL files on disk."
         ),
     )
+    # Top-level ``--week`` / ``--dry-run`` / ``--config`` are retained for
+    # backward compatibility with ``am-synthesize --week YYYY-MM-DD``. When a
+    # subcommand is used they are ignored.
     parser.add_argument(
         "--week",
-        required=True,
+        default=None,
         help="Week start date (YYYY-MM-DD). Must match units.week_start.",
     )
     parser.add_argument(
@@ -55,49 +69,32 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Path to config.yaml (default: config.yaml in repo root).",
     )
+
+    subparsers = parser.add_subparsers(dest="subcommand")
+    add_coverage_subparser(subparsers)
     return parser
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
-    """Entry point. Returns a shell-suitable exit code.
-
-    Exit codes
-    ----------
-    * ``0`` — retrospective written, dry-run prompt written, the file
-      already existed (idempotent success), or no units were found for
-      the requested week. All of these are non-error conditions.
-    * ``2`` — unexpected error (traceback logged).
-
-    The "no units for the week" and "file already exists" cases both
-    collapse to exit 0 because re-running ``am-synthesize --week
-    <same-week>`` is expected to be a cheap no-op per ADR Decision 2
-    (idempotency). A human driver will notice the stderr message
-    ``No retrospective written (...)`` when the run produced nothing.
-    """
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
-    parser = _build_parser()
-    args = parser.parse_args(argv)
+def _run_weekly(args: argparse.Namespace) -> int:
+    """Preserve the original ``--week``-driven synthesis entry point."""
+    if not args.week:
+        print(
+            "am-synthesize: either use a subcommand (e.g. 'coverage') "
+            "or pass --week YYYY-MM-DD for weekly synthesis.",
+            file=sys.stderr,
+        )
+        return 2
 
     config = load_config(args.config)
-    # Resolve DB paths against the config's data directory. ``data_path``
-    # on the Config returns an absolute Path relative to the config file
-    # so the CLI works regardless of the caller's cwd.
+    # Resolve DB paths against the config's data directory. ``data_path`` on
+    # the Config returns an absolute Path relative to the config file so the
+    # CLI works regardless of the caller's cwd.
     data_dir: Path = config.data_path
     github_db = data_dir / "github.db"
     sessions_db = data_dir / "sessions.db"
 
-    # Resolve the synthesis output dir the same way — via the Config's
-    # own property, which anchors relative paths against the config
-    # file's directory (NOT against ``data_dir.parent``, which only
-    # coincided with the config dir for the default ``data_dir="data"``
-    # layout). See Config.synthesis_output_path.
     synthesis_cfg = config.synthesis
     output_dir = config.synthesis_output_path
-    # Mutate via a fresh dataclass copy so we don't silently rewrite
-    # the caller's config object — replace only the resolved path.
     resolved_cfg = replace(synthesis_cfg, output_dir=str(output_dir))
 
     try:
@@ -113,11 +110,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return 2
 
     if result is None and not args.dry_run:
-        # Two cases reach here: (a) no units for the week, (b) the
-        # retrospective already existed and we skipped. Both are
-        # non-errors — idempotent success for case (b), and no-op for
-        # case (a). We log INFO in both cases inside the pipeline so
-        # the CLI simply surfaces a zero exit.
         print(
             "No retrospective written (no units for week, or file already exists)",
             file=sys.stderr,
@@ -127,6 +119,44 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     if result is not None:
         print(str(result))
     return 0
+
+
+def _run_coverage(args: argparse.Namespace) -> int:
+    config = load_config(args.config)
+    data_dir: Path = config.data_path
+    sessions_db = data_dir / "sessions.db"
+    projects_path = Path(config.session.projects_path)
+    return run_coverage(
+        sessions_db=sessions_db,
+        projects_path=projects_path,
+        week_start=config.synthesis.week_start,
+        data_dir=data_dir,
+        emit_json=bool(getattr(args, "emit_json", False)),
+        do_backfill=bool(getattr(args, "backfill", False)),
+        full_rebuild=bool(getattr(args, "full", False)),
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Entry point. Returns a shell-suitable exit code.
+
+    Exit codes
+    ----------
+    * ``0`` — retrospective written, dry-run prompt written, the file already
+      existed (idempotent success), no units were found for the requested
+      week, or coverage report completed. All of these are non-error.
+    * ``2`` — unexpected error (traceback logged) or invalid argument combo.
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.subcommand == "coverage":
+        return _run_coverage(args)
+    return _run_weekly(args)
 
 
 if __name__ == "__main__":  # pragma: no cover — CLI plumbing

--- a/synthesis/coverage.py
+++ b/synthesis/coverage.py
@@ -457,8 +457,12 @@ def collect_coverage(
                 _bump(report.per_unit, ref.bucket_key(), fill)
 
         # ---- "[]" classification ----
-        if fill == _FILL_EMPTY:
-            if jsonl_rec is not None and _get_has_text(jsonl_rec.path):
+        # Only classify when the JSONL is on disk — a missing JSONL is
+        # already surfaced via ``orphan_db_rows`` and calling such a row
+        # "truly empty" would be an unsupported claim (we can't read the
+        # source to verify).
+        if fill == _FILL_EMPTY and jsonl_rec is not None:
+            if _get_has_text(jsonl_rec.path):
                 report.empty_but_jsonl_has_text.append(session_uuid)
             else:
                 report.empty_and_jsonl_truly_empty.append(session_uuid)

--- a/synthesis/coverage.py
+++ b/synthesis/coverage.py
@@ -21,10 +21,13 @@ Two backfill modes repair the DB when the operator opts in:
     ``raw_content_json IS NULL`` whose JSONL is on disk. Rows with
     ``raw_content_json = "[]"`` or non-empty are NOT touched.
 
-``--backfill --full`` (delete-rebuild)
-    For every JSONL on disk, delete the corresponding DB row and re-ingest
-    from scratch via ``parse_session`` + ``upsert_session``. Orphan DB
-    rows (DB row, no JSONL) are surfaced in the summary and preserved.
+``--backfill --full`` (overwrite-in-place)
+    For every JSONL on disk, re-parse via ``parse_session`` and overwrite
+    every column of the matching DB row via ``upsert_session``'s
+    ``INSERT ... ON CONFLICT(session_uuid) DO UPDATE SET ...`` clause.
+    Atomic per session: a ``parse_session`` failure leaves the previous
+    DB row intact. Orphan DB rows (DB row, no JSONL) are surfaced in the
+    summary and preserved.
 
 ``"[]"`` is never a normal state — it is either a parser bug (JSONL has
 text turns but parse produced empty) or a degenerate case (JSONL truly
@@ -551,7 +554,7 @@ class BackfillSummary:
     skipped_missing_jsonl: int = 0
     errored: int = 0
     # --full only
-    deleted_and_reingested: int = 0
+    reingested: int = 0
     orphans_preserved: int = 0
 
 
@@ -682,7 +685,7 @@ def backfill_full(
                 skip_init=True,
                 skip_health=True,
             )
-            summary.deleted_and_reingested += 1
+            summary.reingested += 1
         except Exception as exc:  # noqa: BLE001
             _logger.warning(
                 "backfill_full: parse/upsert failed for session_uuid=%s jsonl=%s: %s",
@@ -734,7 +737,7 @@ def run_coverage(
         summary = backfill_full(sessions_db, projects_path, data_dir=data_dir)
         print(
             f"Backfill (--full) complete: "
-            f"deleted+reingested={summary.deleted_and_reingested}, "
+            f"reingested={summary.reingested}, "
             f"orphans_preserved={summary.orphans_preserved}, "
             f"errored={summary.errored}",
             file=stderr,
@@ -786,8 +789,9 @@ def add_coverage_subparser(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument(
         "--full", action="store_true",
         help=(
-            "With --backfill: delete every session row whose JSONL is on "
-            "disk and re-ingest from scratch. Orphan rows are preserved."
+            "With --backfill: re-parse every JSONL on disk and overwrite "
+            "the matching DB row's columns in place (atomic per session, "
+            "via ON CONFLICT DO UPDATE). Orphan rows are preserved."
         ),
     )
     p.add_argument(

--- a/synthesis/coverage.py
+++ b/synthesis/coverage.py
@@ -1,0 +1,767 @@
+"""Coverage diagnostic for ``sessions.db`` × JSONL-on-disk (Issue #70).
+
+This module is the engine behind the ``am-synthesize coverage`` CLI
+subcommand. It is a **permanent pre-synthesis health check** that answers
+one question: for the current state of ``sessions.db`` and the JSONL files
+on disk, which sessions have a recoverable ``raw_content_json`` transcript
+and which do not?
+
+The diagnostic is decoupled from ``synthesis.unit_identifier``: unit
+bucketing here is a **mechanical GH-reference parse** of the raw JSONL
+(issue numbers, PR numbers, commit SHAs, URLs — including references that
+appear inside ``tool_use`` / ``tool_result`` blocks that ``_strip_content_blocks``
+removes from ``raw_content_json``). A session with multiple GH references is
+counted in every bucket it hits; a session with zero references falls into
+an ``unattributed`` bucket. Sessions are never silently excluded.
+
+Two backfill modes repair the DB when the operator opts in:
+
+``--backfill`` (partial, idempotent)
+    Re-run ``parse_session`` + ``upsert_session`` only for rows with
+    ``raw_content_json IS NULL`` whose JSONL is on disk. Rows with
+    ``raw_content_json = "[]"`` or non-empty are NOT touched.
+
+``--backfill --full`` (delete-rebuild)
+    For every JSONL on disk, delete the corresponding DB row and re-ingest
+    from scratch via ``parse_session`` + ``upsert_session``. Orphan DB
+    rows (DB row, no JSONL) are surfaced in the summary and preserved.
+
+``"[]"`` is never a normal state — it is either a parser bug (JSONL has
+text turns but parse produced empty) or a degenerate case (JSONL truly
+has no text turns). Both are surfaced as distinct lists; no auto-fix.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from collector.session_parser import (
+    _strip_content_blocks,
+    parse_session,
+)
+from collector.store import upsert_session
+
+
+# ---------------------------------------------------------------------------
+# Fill-state classification
+# ---------------------------------------------------------------------------
+
+_FILL_NULL = "null"
+_FILL_EMPTY = "empty"  # literally "[]"
+_FILL_NONEMPTY = "nonempty"
+
+
+def _classify_fill(raw: Optional[str]) -> str:
+    """Map ``raw_content_json`` column value to a fill-state label."""
+    if raw is None:
+        return _FILL_NULL
+    # Preserve the exact literal check from the spec: "[]" is the empty-array
+    # JSON serialization written by parse_session when every turn was stripped.
+    if raw.strip() == "[]":
+        return _FILL_EMPTY
+    return _FILL_NONEMPTY
+
+
+# ---------------------------------------------------------------------------
+# GitHub-reference mechanical parser
+# ---------------------------------------------------------------------------
+#
+# These patterns MUST NOT import from ``collector.session_parser`` or
+# ``synthesis.graph_builder`` — this module is explicitly decoupled from the
+# synthesis unit identifier (see issue #70 refined spec). Patterns are
+# duplicated intentionally so future changes to the synthesis-pipeline parser
+# do not silently reshape the coverage diagnostic's bucket keys.
+
+# ``#123`` inside free text. Word-boundary guard keeps us out of SHAs and URLs.
+_HASH_REF_RE = re.compile(r"(?:^|[^\w])#(\d+)\b")
+
+# ``gh issue|pr (view|comment|create|edit) N [--repo OWNER/REPO]``
+_GH_CLI_RE = re.compile(
+    r"gh\s+(issue|pr)\s+(view|comment|create|edit|close|reopen)\s+"
+    r"(?:(\d+)\s+)?(?:.*?--repo\s+([\w.\-]+/[\w.\-]+))?",
+    re.DOTALL,
+)
+
+# Bare issue / PR URLs
+_GH_URL_RE = re.compile(
+    r"https?://github\.com/([\w.\-]+/[\w.\-]+)/(issues|pull)/(\d+)"
+)
+
+# Commit SHAs — 7 to 40 hex chars, as a standalone token. Word boundaries
+# mean `abc123` inside `abc1234x` won't match. Accept surrounding spaces,
+# punctuation, parentheses, and quotes.
+_SHA_RE = re.compile(r"(?:^|[^0-9a-f])([0-9a-f]{7,40})(?=[^0-9a-f]|$)")
+
+
+@dataclass(frozen=True)
+class GhRef:
+    """Single mechanical reference extracted from a JSONL.
+
+    ``repo`` is ``""`` when the reference source didn't include one (e.g. a
+    bare ``#42`` or a raw SHA). Bucketing uses the full tuple, so a bare
+    ``#42`` in one session and ``owner/repo#42`` in another are DIFFERENT
+    buckets — matching the refined-spec's intent to surface, not resolve.
+    """
+
+    repo: str
+    kind: str  # "issue" | "pr" | "sha"
+    ref: str
+
+    def bucket_key(self) -> str:
+        """Human-readable bucket label, e.g. ``owner/repo#42`` or ``sha:abc1234``."""
+        if self.kind == "sha":
+            return f"sha:{self.ref}"
+        prefix = f"{self.repo}" if self.repo else ""
+        return f"{prefix}#{self.ref}" if prefix else f"#{self.ref}"
+
+
+def _scan_text_for_refs(text: str) -> set[GhRef]:
+    """Extract every GH reference from a single text blob."""
+    refs: set[GhRef] = set()
+
+    for m in _GH_URL_RE.finditer(text):
+        repo, kind_word, num = m.group(1), m.group(2), m.group(3)
+        refs.add(GhRef(repo=repo, kind="pr" if kind_word == "pull" else "issue", ref=num))
+
+    for m in _GH_CLI_RE.finditer(text):
+        obj_kind = m.group(1)  # "issue" or "pr"
+        num = m.group(3)
+        repo = m.group(4) or ""
+        if num:
+            refs.add(GhRef(repo=repo, kind=obj_kind, ref=num))
+
+    # ``#42`` — kind left as ``issue`` mechanically; we cannot disambiguate
+    # issue vs PR from a bare hash. Bucket key is ``[repo]#42`` regardless.
+    for m in _HASH_REF_RE.finditer(text):
+        refs.add(GhRef(repo="", kind="issue", ref=m.group(1)))
+
+    for m in _SHA_RE.finditer(text):
+        refs.add(GhRef(repo="", kind="sha", ref=m.group(1)))
+
+    return refs
+
+
+def _extract_jsonl_refs(jsonl_path: Path) -> set[GhRef]:
+    """Scan every line of a JSONL and return the union of GH references.
+
+    Unlike ``raw_content_json``, this scan **includes** ``tool_use`` and
+    ``tool_result`` blocks — which is the whole point: a session that only
+    references issue #70 inside a ``gh issue view 70`` Bash call must still
+    be bucketed into that unit.
+    """
+    refs: set[GhRef] = set()
+    try:
+        with open(jsonl_path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                # Cheapest path: stringify the whole entry and regex over it.
+                # Avoids a bespoke walk over nested content blocks; patterns
+                # are anchored enough that JSON delimiters don't false-match.
+                refs.update(_scan_text_for_refs(json.dumps(entry, ensure_ascii=False)))
+    except OSError:
+        return set()
+    return refs
+
+
+def _jsonl_has_text_turns(jsonl_path: Path) -> bool:
+    """True iff ``_strip_content_blocks`` would produce at least one non-empty turn.
+
+    Mirrors ``session_parser.parse_session``'s logic: iterate user/assistant
+    entries, strip ``thinking``/``tool_use``/``tool_result`` blocks, keep the
+    turn iff what remains is a non-empty string or a non-empty list.
+    """
+    try:
+        with open(jsonl_path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("type") not in ("user", "assistant"):
+                    continue
+                msg = entry.get("message", {})
+                content = msg.get("content", "")
+                stripped = _strip_content_blocks(content)
+                if stripped is not None and stripped != [] and stripped != "":
+                    return True
+    except OSError:
+        return False
+    return False
+
+
+# ---------------------------------------------------------------------------
+# JSONL discovery + session-UUID indexing
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class JsonlRecord:
+    """One JSONL file and the metadata needed to bucket it."""
+
+    path: Path
+    session_uuid: Optional[str]
+    project: str  # parent directory name under projects_path
+    first_ts: Optional[datetime]
+
+
+def _discover_jsonls(projects_path: Path) -> List[Path]:
+    """Replicates ``session_parser._discover_session_files`` (subagent skip)."""
+    if not projects_path.exists():
+        return []
+    out: List[Path] = []
+    for jsonl in projects_path.rglob("*.jsonl"):
+        if "subagents" in jsonl.parts:
+            continue
+        out.append(jsonl)
+    return sorted(out)
+
+
+def _read_jsonl_header(jsonl: Path, projects_path: Path) -> JsonlRecord:
+    """Extract (session_uuid, project, first_ts) in one pass."""
+    uuid: Optional[str] = None
+    project = ""
+    first_ts: Optional[datetime] = None
+
+    # Project = JSONL's parent directory name relative to projects_path.
+    # When the JSONL sits deeper, take the first directory under projects_path.
+    try:
+        rel = jsonl.relative_to(projects_path)
+        project = rel.parts[0] if len(rel.parts) > 1 else ""
+    except ValueError:
+        project = jsonl.parent.name
+
+    try:
+        with open(jsonl, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if uuid is None and "sessionId" in entry:
+                    uuid = entry["sessionId"]
+                if first_ts is None:
+                    ts_str = entry.get("timestamp")
+                    if ts_str:
+                        try:
+                            first_ts = datetime.fromisoformat(
+                                ts_str.replace("Z", "+00:00")
+                            )
+                        except ValueError:
+                            pass
+                if uuid is not None and first_ts is not None:
+                    break
+    except OSError:
+        pass
+
+    return JsonlRecord(path=jsonl, session_uuid=uuid, project=project, first_ts=first_ts)
+
+
+# ---------------------------------------------------------------------------
+# Week bucketing
+# ---------------------------------------------------------------------------
+
+
+def _week_start_of(dt: datetime, week_start: str) -> date:
+    """Return the date of the week-start boundary containing ``dt``.
+
+    ``week_start`` ∈ {``"monday"``, ``"sunday"``}. Matches the convention used
+    by the rest of the synthesis pipeline (``config.synthesis.week_start``).
+    """
+    d = dt.date()
+    if week_start == "sunday":
+        # Python's weekday(): Mon=0..Sun=6. For Sunday-start, offset = (d.weekday() + 1) % 7.
+        offset = (d.weekday() + 1) % 7
+    else:
+        # Monday-start (default).
+        offset = d.weekday()
+    return d - timedelta(days=offset)
+
+
+# ---------------------------------------------------------------------------
+# Coverage report data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CoverageReport:
+    total: int = 0
+    null_count: int = 0
+    empty_count: int = 0
+    nonempty_count: int = 0
+
+    per_week: Dict[str, Dict[str, int]] = field(default_factory=dict)
+    per_project: Dict[str, Dict[str, int]] = field(default_factory=dict)
+    per_unit: Dict[str, Dict[str, int]] = field(default_factory=dict)
+
+    # Diagnostic lists — session_uuids and/or JSONL paths.
+    unprocessed_jsonls: List[str] = field(default_factory=list)
+    orphan_db_rows: List[str] = field(default_factory=list)
+    empty_but_jsonl_has_text: List[str] = field(default_factory=list)
+    empty_and_jsonl_truly_empty: List[str] = field(default_factory=list)
+
+    def to_json(self) -> str:
+        """Deterministic JSON serialization (keys sorted, lists pre-sorted)."""
+        d = asdict(self)
+        # Sort diagnostic lists for determinism. Bucket dicts rely on key-sort
+        # via ``sort_keys=True`` below.
+        for key in (
+            "unprocessed_jsonls",
+            "orphan_db_rows",
+            "empty_but_jsonl_has_text",
+            "empty_and_jsonl_truly_empty",
+        ):
+            d[key] = sorted(d[key])
+        return json.dumps(d, sort_keys=True, indent=2, ensure_ascii=False)
+
+
+def _bump(bucket: Dict[str, Dict[str, int]], key: str, fill: str) -> None:
+    row = bucket.setdefault(
+        key,
+        {"total": 0, "null": 0, "empty": 0, "nonempty": 0},
+    )
+    row["total"] += 1
+    row[fill] += 1
+
+
+# ---------------------------------------------------------------------------
+# Main entry point — collect_coverage
+# ---------------------------------------------------------------------------
+
+
+def collect_coverage(
+    sessions_db: Path,
+    projects_path: Path,
+    *,
+    week_start: str = "monday",
+) -> CoverageReport:
+    """Read ``sessions.db`` + JSONL files on disk; return a CoverageReport.
+
+    Pure function — no writes. All DB writes are confined to
+    :func:`backfill_partial` / :func:`backfill_full`.
+    """
+    report = CoverageReport()
+
+    # ---- Scan JSONLs once ----
+    jsonls = _discover_jsonls(projects_path)
+    jsonl_by_uuid: Dict[str, JsonlRecord] = {}
+    for jsonl in jsonls:
+        rec = _read_jsonl_header(jsonl, projects_path)
+        if rec.session_uuid:
+            # First writer wins — matches ``_build_session_index``.
+            jsonl_by_uuid.setdefault(rec.session_uuid, rec)
+
+    # ---- Read sessions.db ----
+    db_rows: List[Tuple[str, Optional[str], Optional[str]]] = []
+    if sessions_db.exists():
+        conn = sqlite3.connect(str(sessions_db))
+        try:
+            cursor = conn.execute(
+                "SELECT session_uuid, raw_content_json, session_started_at "
+                "FROM sessions"
+            )
+            db_rows = list(cursor.fetchall())
+        except sqlite3.OperationalError:
+            # Table missing — treat as empty DB.
+            db_rows = []
+        finally:
+            conn.close()
+
+    db_uuids: set[str] = set()
+
+    # ---- Per-row bucketing ----
+    # Cache extracted refs and text-turn flags per JSONL so we pay each JSONL
+    # cost at most once.
+    refs_cache: Dict[Path, set[GhRef]] = {}
+    text_cache: Dict[Path, bool] = {}
+
+    def _get_refs(p: Path) -> set[GhRef]:
+        r = refs_cache.get(p)
+        if r is None:
+            r = _extract_jsonl_refs(p)
+            refs_cache[p] = r
+        return r
+
+    def _get_has_text(p: Path) -> bool:
+        v = text_cache.get(p)
+        if v is None:
+            v = _jsonl_has_text_turns(p)
+            text_cache[p] = v
+        return v
+
+    for session_uuid, raw_content, session_started_at in db_rows:
+        db_uuids.add(session_uuid)
+        fill = _classify_fill(raw_content)
+        report.total += 1
+        if fill == _FILL_NULL:
+            report.null_count += 1
+        elif fill == _FILL_EMPTY:
+            report.empty_count += 1
+        else:
+            report.nonempty_count += 1
+
+        jsonl_rec = jsonl_by_uuid.get(session_uuid)
+
+        # ---- Week bucket ----
+        first_ts: Optional[datetime] = None
+        if jsonl_rec is not None:
+            first_ts = jsonl_rec.first_ts
+        if first_ts is None and session_started_at:
+            try:
+                first_ts = datetime.fromisoformat(
+                    session_started_at.replace("Z", "+00:00")
+                )
+            except ValueError:
+                first_ts = None
+        week_key = (
+            _week_start_of(first_ts, week_start).isoformat()
+            if first_ts is not None
+            else "unknown"
+        )
+        _bump(report.per_week, week_key, fill)
+
+        # ---- Project bucket ----
+        project = jsonl_rec.project if jsonl_rec is not None else "unknown"
+        if not project:
+            project = "unknown"
+        _bump(report.per_project, project, fill)
+
+        # ---- Unit bucket (mechanical GH-ref parse from JSONL) ----
+        if jsonl_rec is not None:
+            refs = _get_refs(jsonl_rec.path)
+        else:
+            refs = set()
+        if not refs:
+            _bump(report.per_unit, "unattributed", fill)
+        else:
+            for ref in refs:
+                _bump(report.per_unit, ref.bucket_key(), fill)
+
+        # ---- "[]" classification ----
+        if fill == _FILL_EMPTY:
+            if jsonl_rec is not None and _get_has_text(jsonl_rec.path):
+                report.empty_but_jsonl_has_text.append(session_uuid)
+            else:
+                report.empty_and_jsonl_truly_empty.append(session_uuid)
+
+    # ---- Two-way diff: unprocessed JSONLs + orphan DB rows ----
+    for uuid_on_disk, rec in jsonl_by_uuid.items():
+        if uuid_on_disk not in db_uuids:
+            report.unprocessed_jsonls.append(str(rec.path))
+
+    for uuid_in_db in db_uuids:
+        if uuid_in_db not in jsonl_by_uuid:
+            report.orphan_db_rows.append(uuid_in_db)
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Text formatter
+# ---------------------------------------------------------------------------
+
+
+def format_text(report: CoverageReport) -> str:
+    """Human-readable report for stdout."""
+    lines: List[str] = []
+    lines.append("Coverage diagnostic — sessions.db × JSONL on disk")
+    lines.append("=" * 52)
+    lines.append(
+        f"Total:     {report.total}   "
+        f"NULL: {report.null_count}   "
+        f"'[]': {report.empty_count}   "
+        f"non-empty: {report.nonempty_count}"
+    )
+    lines.append("")
+
+    def _section(title: str, bucket: Dict[str, Dict[str, int]]) -> None:
+        lines.append(title)
+        lines.append("-" * len(title))
+        if not bucket:
+            lines.append("  (no data)")
+            lines.append("")
+            return
+        for key in sorted(bucket.keys()):
+            row = bucket[key]
+            lines.append(
+                f"  {key}: total={row['total']} "
+                f"null={row['null']} empty={row['empty']} "
+                f"nonempty={row['nonempty']}"
+            )
+        lines.append("")
+
+    _section("Per week", report.per_week)
+    _section("Per project", report.per_project)
+    _section("Per unit (mechanical GH-ref parse from JSONL)", report.per_unit)
+
+    lines.append("Diagnostic lists")
+    lines.append("-" * 16)
+    lines.append(f"  unprocessed JSONL (JSONL present, no DB row):      {len(report.unprocessed_jsonls)}")
+    lines.append(f"  orphan DB rows   (DB row, JSONL missing):           {len(report.orphan_db_rows)}")
+    lines.append(f"  '[]' but JSONL has text turns (parser-bug suspect): {len(report.empty_but_jsonl_has_text)}")
+    lines.append(f"  '[]' and JSONL truly empty (degenerate):            {len(report.empty_and_jsonl_truly_empty)}")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Backfill — partial and full
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BackfillSummary:
+    updated: int = 0
+    skipped_already_populated: int = 0
+    skipped_missing_jsonl: int = 0
+    errored: int = 0
+    # --full only
+    deleted_and_reingested: int = 0
+    orphans_preserved: int = 0
+
+
+def _build_uuid_index(projects_path: Path) -> Dict[str, Path]:
+    """Scan JSONLs and return ``{session_uuid: path}``."""
+    index: Dict[str, Path] = {}
+    for jsonl in _discover_jsonls(projects_path):
+        try:
+            with open(jsonl, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    sid = entry.get("sessionId")
+                    if sid:
+                        index.setdefault(sid, jsonl)
+                        break
+        except OSError:
+            continue
+    return index
+
+
+def backfill_partial(
+    sessions_db: Path,
+    projects_path: Path,
+    *,
+    data_dir: Optional[Path] = None,
+) -> BackfillSummary:
+    """Populate ``raw_content_json`` only for rows that are currently NULL.
+
+    Idempotent: rows with any non-NULL ``raw_content_json`` (including ``"[]"``)
+    are NOT touched. Re-running against the same state produces zero updates.
+    """
+    summary = BackfillSummary()
+    if not sessions_db.exists():
+        return summary
+
+    index = _build_uuid_index(projects_path)
+
+    conn = sqlite3.connect(str(sessions_db))
+    try:
+        cursor = conn.execute(
+            "SELECT session_uuid FROM sessions WHERE raw_content_json IS NULL"
+        )
+        targets = [row[0] for row in cursor.fetchall()]
+    finally:
+        conn.close()
+
+    for session_uuid in targets:
+        jsonl = index.get(session_uuid)
+        if jsonl is None:
+            summary.skipped_missing_jsonl += 1
+            continue
+        try:
+            record = parse_session(jsonl)
+            upsert_session(
+                record,
+                db_path=sessions_db,
+                data_dir=data_dir,
+                skip_init=True,
+                skip_health=True,
+            )
+            summary.updated += 1
+        except Exception:  # noqa: BLE001 — surface count, keep the loop going
+            summary.errored += 1
+
+    return summary
+
+
+def backfill_full(
+    sessions_db: Path,
+    projects_path: Path,
+    *,
+    data_dir: Optional[Path] = None,
+) -> BackfillSummary:
+    """Delete every DB row whose JSONL is on disk and re-ingest from scratch.
+
+    Orphan rows (DB row present, JSONL absent) are LEFT IN PLACE and surfaced
+    in ``summary.orphans_preserved`` — never silently dropped. Requires an
+    explicit ``--full`` flag at the CLI layer; this function assumes the
+    caller has already asserted that.
+    """
+    summary = BackfillSummary()
+    if not sessions_db.exists():
+        return summary
+
+    index = _build_uuid_index(projects_path)
+
+    # Determine orphans BEFORE deletions (so they survive the loop below).
+    conn = sqlite3.connect(str(sessions_db))
+    try:
+        cursor = conn.execute("SELECT session_uuid FROM sessions")
+        db_uuids = {row[0] for row in cursor.fetchall()}
+    finally:
+        conn.close()
+
+    summary.orphans_preserved = sum(1 for u in db_uuids if u not in index)
+
+    for session_uuid, jsonl in index.items():
+        # Delete the existing row (if any). Orphans (JSONL only) are a no-op DELETE.
+        conn = sqlite3.connect(str(sessions_db))
+        try:
+            conn.execute(
+                "DELETE FROM sessions WHERE session_uuid = ?",
+                (session_uuid,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        try:
+            record = parse_session(jsonl)
+            upsert_session(
+                record,
+                db_path=sessions_db,
+                data_dir=data_dir,
+                skip_init=True,
+                skip_health=True,
+            )
+            summary.deleted_and_reingested += 1
+        except Exception:  # noqa: BLE001
+            summary.errored += 1
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# CLI glue (called from synthesis.cli)
+# ---------------------------------------------------------------------------
+
+
+def run_coverage(
+    *,
+    sessions_db: Path,
+    projects_path: Path,
+    week_start: str,
+    data_dir: Optional[Path],
+    emit_json: bool = False,
+    do_backfill: bool = False,
+    full_rebuild: bool = False,
+    stdout=None,
+    stderr=None,
+) -> int:
+    # Resolve stdout/stderr at call time so pytest's capsys (which re-binds
+    # sys.stdout per test) captures output correctly. Using defaults like
+    # ``stdout=sys.stdout`` in the signature would bind to the interpreter-
+    # startup stream and bypass the capture.
+    if stdout is None:
+        stdout = sys.stdout
+    if stderr is None:
+        stderr = sys.stderr
+    """Dispatch the four coverage modes. Returns a shell-suitable exit code.
+
+    Modes (mutually exclusive at the orchestration level, enforced by the CLI):
+
+    * ``do_backfill=False, full_rebuild=False`` → report only.
+    * ``do_backfill=True,  full_rebuild=False`` → partial backfill + summary.
+    * ``do_backfill=True,  full_rebuild=True``  → delete-rebuild + summary.
+    """
+    if full_rebuild and not do_backfill:
+        print("--full requires --backfill", file=stderr)
+        return 2
+
+    if do_backfill and full_rebuild:
+        summary = backfill_full(sessions_db, projects_path, data_dir=data_dir)
+        print(
+            f"Backfill (--full) complete: "
+            f"deleted+reingested={summary.deleted_and_reingested}, "
+            f"orphans_preserved={summary.orphans_preserved}, "
+            f"errored={summary.errored}",
+            file=stderr,
+        )
+        return 0
+
+    if do_backfill:
+        summary = backfill_partial(sessions_db, projects_path, data_dir=data_dir)
+        print(
+            f"Backfill complete: "
+            f"updated={summary.updated}, "
+            f"skipped_missing_jsonl={summary.skipped_missing_jsonl}, "
+            f"errored={summary.errored}",
+            file=stderr,
+        )
+        return 0
+
+    # Report-only mode.
+    report = collect_coverage(
+        sessions_db, projects_path, week_start=week_start
+    )
+    if emit_json:
+        stdout.write(report.to_json() + "\n")
+    else:
+        stdout.write(format_text(report))
+    return 0
+
+
+def add_coverage_subparser(subparsers: argparse._SubParsersAction) -> None:
+    """Attach ``coverage`` subcommand to an existing ``subparsers`` action."""
+    p = subparsers.add_parser(
+        "coverage",
+        help=(
+            "Report raw_content_json coverage across sessions.db and the "
+            "JSONL files on disk. Optional backfill modes."
+        ),
+    )
+    p.add_argument(
+        "--json", dest="emit_json", action="store_true",
+        help="Emit machine-readable JSON to stdout instead of prose.",
+    )
+    p.add_argument(
+        "--backfill", action="store_true",
+        help=(
+            "Re-run parse_session for rows with raw_content_json IS NULL "
+            "whose JSONL is on disk. Idempotent."
+        ),
+    )
+    p.add_argument(
+        "--full", action="store_true",
+        help=(
+            "With --backfill: delete every session row whose JSONL is on "
+            "disk and re-ingest from scratch. Orphan rows are preserved."
+        ),
+    )
+    p.add_argument(
+        "--config", default=None,
+        help="Path to config.yaml (default: config.yaml in repo root).",
+    )

--- a/synthesis/coverage.py
+++ b/synthesis/coverage.py
@@ -628,12 +628,23 @@ def backfill_full(
     *,
     data_dir: Optional[Path] = None,
 ) -> BackfillSummary:
-    """Delete every DB row whose JSONL is on disk and re-ingest from scratch.
+    """Re-ingest every JSONL on disk, overwriting every column of the matching
+    DB row.
 
     Orphan rows (DB row present, JSONL absent) are LEFT IN PLACE and surfaced
     in ``summary.orphans_preserved`` — never silently dropped. Requires an
     explicit ``--full`` flag at the CLI layer; this function assumes the
     caller has already asserted that.
+
+    Implementation note: we rely on ``upsert_session``'s
+    ``INSERT ... ON CONFLICT(session_uuid) DO UPDATE SET ...`` clause (see
+    ``collector/store.py``) to overwrite every column. An earlier
+    implementation issued a ``DELETE`` before the upsert, but that opened a
+    destructive window: if ``parse_session`` raised mid-loop (malformed
+    JSONL, truncated file) the row was already gone from the DB with no
+    rollback path, even when the pre-rebuild DB value was the only surviving
+    copy. The upsert-only path is atomic per-session and preserves the DB
+    row on parse failure.
     """
     summary = BackfillSummary()
     if not sessions_db.exists():
@@ -641,7 +652,7 @@ def backfill_full(
 
     index = _build_uuid_index(projects_path)
 
-    # Determine orphans BEFORE deletions (so they survive the loop below).
+    # Determine orphans BEFORE the loop (so counting is independent of order).
     conn = sqlite3.connect(str(sessions_db))
     try:
         cursor = conn.execute("SELECT session_uuid FROM sessions")
@@ -652,16 +663,6 @@ def backfill_full(
     summary.orphans_preserved = sum(1 for u in db_uuids if u not in index)
 
     for session_uuid, jsonl in index.items():
-        # Delete the existing row (if any). Orphans (JSONL only) are a no-op DELETE.
-        conn = sqlite3.connect(str(sessions_db))
-        try:
-            conn.execute(
-                "DELETE FROM sessions WHERE session_uuid = ?",
-                (session_uuid,),
-            )
-            conn.commit()
-        finally:
-            conn.close()
         try:
             record = parse_session(jsonl)
             upsert_session(

--- a/synthesis/coverage.py
+++ b/synthesis/coverage.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import re
 import sqlite3
 import sys
@@ -49,6 +50,8 @@ from collector.session_parser import (
     parse_session,
 )
 from collector.store import upsert_session
+
+_logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -616,7 +619,14 @@ def backfill_partial(
                 skip_health=True,
             )
             summary.updated += 1
-        except Exception:  # noqa: BLE001 — surface count, keep the loop going
+        except Exception as exc:  # noqa: BLE001 — surface count, keep the loop going
+            # Log so operators can investigate. A bare errored=N count with no
+            # trail defeats the whole "surface sessions needing attention"
+            # purpose of the diagnostic.
+            _logger.warning(
+                "backfill_partial: parse/upsert failed for session_uuid=%s jsonl=%s: %s",
+                session_uuid, jsonl, exc,
+            )
             summary.errored += 1
 
     return summary
@@ -673,7 +683,11 @@ def backfill_full(
                 skip_health=True,
             )
             summary.deleted_and_reingested += 1
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            _logger.warning(
+                "backfill_full: parse/upsert failed for session_uuid=%s jsonl=%s: %s",
+                session_uuid, jsonl, exc,
+            )
             summary.errored += 1
 
     return summary

--- a/synthesis/coverage.py
+++ b/synthesis/coverage.py
@@ -44,6 +44,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from collector.session_parser import (
+    _discover_session_files,
     _strip_content_blocks,
     parse_session,
 )
@@ -60,12 +61,24 @@ _FILL_NONEMPTY = "nonempty"
 
 
 def _classify_fill(raw: Optional[str]) -> str:
-    """Map ``raw_content_json`` column value to a fill-state label."""
+    """Map ``raw_content_json`` column value to a fill-state label.
+
+    ``parse_session`` currently serializes an empty transcript as exactly
+    ``"[]"``; this function additionally accepts any serializer-variant that
+    parses to the empty JSON array (e.g. ``"[ ]"``, ``"[\\n]"``) so a future
+    switch to ``json.dumps(..., indent=2)`` or similar would not silently
+    reclassify empty rows as non-empty and defeat the diagnostic.
+    """
     if raw is None:
         return _FILL_NULL
-    # Preserve the exact literal check from the spec: "[]" is the empty-array
-    # JSON serialization written by parse_session when every turn was stripped.
-    if raw.strip() == "[]":
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        # Malformed JSON counts as nonempty — we still have *something* the
+        # operator needs to see, and misclassifying it as empty would hide it
+        # from the parser-bug diagnostic list.
+        return _FILL_NONEMPTY
+    if parsed == []:
         return _FILL_EMPTY
     return _FILL_NONEMPTY
 
@@ -222,15 +235,12 @@ class JsonlRecord:
 
 
 def _discover_jsonls(projects_path: Path) -> List[Path]:
-    """Replicates ``session_parser._discover_session_files`` (subagent skip)."""
-    if not projects_path.exists():
-        return []
-    out: List[Path] = []
-    for jsonl in projects_path.rglob("*.jsonl"):
-        if "subagents" in jsonl.parts:
-            continue
-        out.append(jsonl)
-    return sorted(out)
+    """Delegate to the canonical discovery helper in ``collector.session_parser``.
+
+    Kept as a thin wrapper so callers within this module don't need to know the
+    origin — and so that the subagent-skip rule has a single source of truth.
+    """
+    return _discover_session_files(projects_path)
 
 
 def _read_jsonl_header(jsonl: Path, projects_path: Path) -> JsonlRecord:
@@ -685,14 +695,6 @@ def run_coverage(
     stdout=None,
     stderr=None,
 ) -> int:
-    # Resolve stdout/stderr at call time so pytest's capsys (which re-binds
-    # sys.stdout per test) captures output correctly. Using defaults like
-    # ``stdout=sys.stdout`` in the signature would bind to the interpreter-
-    # startup stream and bypass the capture.
-    if stdout is None:
-        stdout = sys.stdout
-    if stderr is None:
-        stderr = sys.stderr
     """Dispatch the four coverage modes. Returns a shell-suitable exit code.
 
     Modes (mutually exclusive at the orchestration level, enforced by the CLI):
@@ -701,6 +703,14 @@ def run_coverage(
     * ``do_backfill=True,  full_rebuild=False`` → partial backfill + summary.
     * ``do_backfill=True,  full_rebuild=True``  → delete-rebuild + summary.
     """
+    # Resolve stdout/stderr at call time so pytest's capsys (which re-binds
+    # sys.stdout per test) captures output correctly. Using defaults like
+    # ``stdout=sys.stdout`` in the signature would bind to the interpreter-
+    # startup stream and bypass the capture.
+    if stdout is None:
+        stdout = sys.stdout
+    if stderr is None:
+        stderr = sys.stderr
     if full_rebuild and not do_backfill:
         print("--full requires --backfill", file=stderr)
         return 2

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -342,7 +342,7 @@ class TestFullBackfill:
 
         # --full must repair.
         full = backfill_full(db, projects)
-        assert full.deleted_and_reingested == 1
+        assert full.reingested == 1
         assert full.orphans_preserved == 1
 
         conn = sqlite3.connect(str(db))
@@ -423,7 +423,7 @@ class TestFullBackfillParseFailurePreservesRow:
 
         summary = backfill_full(db, projects)
         assert summary.errored == 1
-        assert summary.deleted_and_reingested == 0
+        assert summary.reingested == 0
 
         # Critical invariant: the pre-existing row is still there, unchanged.
         conn = sqlite3.connect(str(db))

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -359,6 +359,41 @@ class TestFullBackfill:
         assert rows["uuid-orphan"] == "[]"
 
 
+class TestBackfillLogging:
+    """F-3: exception swallowing must emit a logging.warning with uuid + path
+    so the operator has a trail beyond the opaque summary.errored count.
+    """
+
+    def test_partial_backfill_logs_on_failure(self, db_and_projects, caplog):
+        import logging as _logging
+        db, projects = db_and_projects
+        _insert_session(db, "uuid-bad", None, None)
+        path = projects / "proj" / "bad.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"sessionId": "uuid-bad", "type": "summary"})
+            + "\n{not json\n"
+        )
+        with caplog.at_level(_logging.WARNING, logger="synthesis.coverage"):
+            summary = backfill_partial(db, projects)
+        assert summary.errored == 1
+        assert any("uuid-bad" in rec.message for rec in caplog.records)
+
+    def test_full_backfill_logs_on_failure(self, db_and_projects, caplog):
+        import logging as _logging
+        db, projects = db_and_projects
+        path = projects / "proj" / "bad.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"sessionId": "uuid-bad", "type": "summary"})
+            + "\n{not json\n"
+        )
+        with caplog.at_level(_logging.WARNING, logger="synthesis.coverage"):
+            summary = backfill_full(db, projects)
+        assert summary.errored == 1
+        assert any("uuid-bad" in rec.message for rec in caplog.records)
+
+
 class TestFullBackfillParseFailurePreservesRow:
     """Regression (F-2): a parse_session failure mid-rebuild must not destroy
     the pre-existing DB row. Earlier implementation issued DELETE + commit

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,0 +1,483 @@
+"""Tests for synthesis.coverage (Issue #70).
+
+One test class per acceptance scenario in the refined spec. Fixtures mirror
+the style of ``tests/test_backfill_session_timestamps.py``: small JSONL
+builders + bare-row inserts.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from am_i_shipping.db import init_sessions_db
+from synthesis.coverage import (
+    _classify_fill,
+    _extract_jsonl_refs,
+    _jsonl_has_text_turns,
+    backfill_full,
+    backfill_partial,
+    collect_coverage,
+    run_coverage,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _write_jsonl(
+    path: Path,
+    session_uuid: str,
+    entries: list[dict],
+) -> None:
+    """Write an arbitrary list of JSONL entries."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = []
+    for entry in entries:
+        entry = dict(entry)  # shallow copy so tests can reuse dicts
+        entry.setdefault("sessionId", session_uuid)
+        lines.append(json.dumps(entry))
+    path.write_text("\n".join(lines) + "\n")
+
+
+def _text_turn(
+    role: str = "user",
+    text: str = "hello",
+    timestamp: str = "2026-04-15T10:00:00Z",
+) -> dict:
+    return {
+        "type": role,
+        "timestamp": timestamp,
+        "message": {"role": role, "content": [{"type": "text", "text": text}]},
+    }
+
+
+def _tool_use_turn(
+    command: str,
+    timestamp: str = "2026-04-15T10:05:00Z",
+) -> dict:
+    return {
+        "type": "assistant",
+        "timestamp": timestamp,
+        "message": {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "tool_xyz",
+                    "name": "Bash",
+                    "input": {"command": command},
+                }
+            ],
+        },
+    }
+
+
+def _insert_session(
+    db: Path,
+    session_uuid: str,
+    raw_content_json,
+    session_started_at: str | None = None,
+) -> None:
+    """Insert a session row with a specified raw_content_json value."""
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute(
+            """
+            INSERT INTO sessions (
+                session_uuid, turn_count, tool_call_count, tool_failure_count,
+                reprompt_count, bail_out, session_duration_seconds,
+                working_directory, git_branch, raw_content_json,
+                input_tokens, output_tokens, cache_creation_tokens,
+                cache_read_tokens, fast_mode_turns, session_started_at
+            ) VALUES (?, 1, 0, 0, 0, 0, 0.0, NULL, NULL, ?, 0, 0, 0, 0, 0, ?)
+            """,
+            (session_uuid, raw_content_json, session_started_at),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def db_and_projects(tmp_path):
+    db = tmp_path / "sessions.db"
+    init_sessions_db(db)
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    return db, projects
+
+
+# ---------------------------------------------------------------------------
+# Unit helpers
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyFill:
+    def test_null(self):
+        assert _classify_fill(None) == "null"
+
+    def test_empty_array(self):
+        assert _classify_fill("[]") == "empty"
+        assert _classify_fill("  []  ") == "empty"
+
+    def test_nonempty(self):
+        assert _classify_fill('[{"role":"user"}]') == "nonempty"
+
+
+class TestJsonlHasTextTurns:
+    def test_true_for_text(self, tmp_path):
+        p = tmp_path / "a.jsonl"
+        _write_jsonl(p, "uuid-a", [_text_turn(text="hi")])
+        assert _jsonl_has_text_turns(p) is True
+
+    def test_false_for_tool_only(self, tmp_path):
+        p = tmp_path / "b.jsonl"
+        _write_jsonl(p, "uuid-b", [_tool_use_turn("ls")])
+        assert _jsonl_has_text_turns(p) is False
+
+
+class TestExtractJsonlRefs:
+    def test_hash_and_url(self, tmp_path):
+        p = tmp_path / "c.jsonl"
+        _write_jsonl(
+            p, "uuid-c",
+            [_text_turn(text="see #42 and https://github.com/a/b/pull/99")],
+        )
+        refs = _extract_jsonl_refs(p)
+        keys = {r.bucket_key() for r in refs}
+        assert "#42" in keys
+        assert "a/b#99" in keys
+
+    def test_gh_cli_inside_tool_use(self, tmp_path):
+        p = tmp_path / "d.jsonl"
+        _write_jsonl(
+            p, "uuid-d",
+            [_tool_use_turn("gh issue view 70 --repo owner/repo")],
+        )
+        refs = _extract_jsonl_refs(p)
+        keys = {r.bucket_key() for r in refs}
+        assert "owner/repo#70" in keys
+
+
+# ---------------------------------------------------------------------------
+# Scenario tests
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultReport:
+    """Scenario: `am-synthesize coverage` default report mode."""
+
+    def test_counts_and_buckets(self, db_and_projects):
+        db, projects = db_and_projects
+
+        # Row 1: NULL. JSONL present.
+        _insert_session(db, "uuid-null", None, "2026-04-15T10:00:00Z")
+        _write_jsonl(
+            projects / "proj-A" / "null.jsonl", "uuid-null",
+            [_text_turn(text="pre-migration text")],
+        )
+        # Row 2: "[]" with text turns in JSONL (parser-bug candidate).
+        _insert_session(db, "uuid-empty-text", "[]", "2026-04-15T10:00:00Z")
+        _write_jsonl(
+            projects / "proj-A" / "empty-text.jsonl", "uuid-empty-text",
+            [_text_turn(text="real text")],
+        )
+        # Row 3: "[]" with no text turns (degenerate).
+        _insert_session(db, "uuid-empty-degen", "[]", "2026-04-15T10:00:00Z")
+        _write_jsonl(
+            projects / "proj-B" / "empty-degen.jsonl", "uuid-empty-degen",
+            [_tool_use_turn("ls")],
+        )
+        # Row 4: non-empty.
+        _insert_session(
+            db, "uuid-good",
+            '[{"role":"user","content":"hi"}]',
+            "2026-04-15T10:00:00Z",
+        )
+        _write_jsonl(
+            projects / "proj-B" / "good.jsonl", "uuid-good",
+            [_text_turn(text="hi")],
+        )
+        # Row 5: JSONL on disk, no DB row (unprocessed).
+        _write_jsonl(
+            projects / "proj-C" / "unprocessed.jsonl", "uuid-unprocessed",
+            [_text_turn(text="new")],
+        )
+
+        report = collect_coverage(db, projects, week_start="monday")
+
+        assert report.total == 4
+        assert report.null_count == 1
+        assert report.empty_count == 2
+        assert report.nonempty_count == 1
+        # Four diagnostic lists — sizes.
+        assert len(report.unprocessed_jsonls) == 1
+        assert len(report.orphan_db_rows) == 0
+        assert len(report.empty_but_jsonl_has_text) == 1
+        assert len(report.empty_and_jsonl_truly_empty) == 1
+        # Per-project bucketing exists.
+        assert "proj-A" in report.per_project
+        assert "proj-B" in report.per_project
+        # No DB rows were changed — verify raw_content_json is untouched.
+        conn = sqlite3.connect(str(db))
+        try:
+            rows = dict(conn.execute(
+                "SELECT session_uuid, raw_content_json FROM sessions"
+            ).fetchall())
+        finally:
+            conn.close()
+        assert rows["uuid-null"] is None
+        assert rows["uuid-empty-text"] == "[]"
+
+
+class TestJsonOutput:
+    """Scenario: `--json` emits a parseable JSON document."""
+
+    def test_json_deterministic(self, db_and_projects):
+        db, projects = db_and_projects
+        _insert_session(db, "uuid-a", '[{"role":"user"}]', "2026-04-15T10:00:00Z")
+        _write_jsonl(
+            projects / "proj-A" / "a.jsonl", "uuid-a",
+            [_text_turn(text="hi")],
+        )
+        r1 = collect_coverage(db, projects, week_start="monday").to_json()
+        r2 = collect_coverage(db, projects, week_start="monday").to_json()
+        assert r1 == r2  # byte-identical under unchanged inputs
+        parsed = json.loads(r1)
+        assert parsed["total"] == 1
+        assert parsed["nonempty_count"] == 1
+
+
+class TestPartialBackfill:
+    """Scenario: `--backfill` populates only NULL rows; idempotent."""
+
+    def test_updates_only_null_rows(self, db_and_projects):
+        db, projects = db_and_projects
+
+        _insert_session(db, "uuid-null", None, None)
+        _write_jsonl(
+            projects / "proj" / "null.jsonl", "uuid-null",
+            [_text_turn(text="recoverable")],
+        )
+        _insert_session(db, "uuid-empty", "[]", "2026-04-15T10:00:00Z")
+        _write_jsonl(
+            projects / "proj" / "empty.jsonl", "uuid-empty",
+            [_text_turn(text="also recoverable")],
+        )
+        _insert_session(
+            db, "uuid-good",
+            '[{"role":"user","content":"prior"}]',
+            "2026-04-15T10:00:00Z",
+        )
+        _write_jsonl(
+            projects / "proj" / "good.jsonl", "uuid-good",
+            [_text_turn(text="new text")],
+        )
+
+        summary = backfill_partial(db, projects)
+        assert summary.updated == 1
+        assert summary.skipped_missing_jsonl == 0
+
+        conn = sqlite3.connect(str(db))
+        try:
+            rows = dict(conn.execute(
+                "SELECT session_uuid, raw_content_json FROM sessions"
+            ).fetchall())
+        finally:
+            conn.close()
+        assert rows["uuid-null"] is not None  # populated
+        assert rows["uuid-null"] != "[]"
+        assert rows["uuid-empty"] == "[]"  # NOT touched
+        assert rows["uuid-good"] == '[{"role":"user","content":"prior"}]'  # NOT touched
+
+        # Idempotent: re-run is a no-op.
+        summary2 = backfill_partial(db, projects)
+        assert summary2.updated == 0
+
+    def test_skipped_missing_jsonl(self, db_and_projects):
+        db, projects = db_and_projects
+        _insert_session(db, "uuid-lost", None, None)
+        # No JSONL written.
+        summary = backfill_partial(db, projects)
+        assert summary.updated == 0
+        assert summary.skipped_missing_jsonl == 1
+
+
+class TestFullBackfill:
+    """Scenario: `--backfill --full` delete-rebuilds and preserves orphans."""
+
+    def test_full_rebuild_updates_empty_row(self, db_and_projects):
+        db, projects = db_and_projects
+
+        # A row with "[]" whose JSONL has text turns — partial backfill will
+        # skip this but --full must fix it.
+        _insert_session(db, "uuid-broken", "[]", "2026-04-15T10:00:00Z")
+        _write_jsonl(
+            projects / "proj" / "broken.jsonl", "uuid-broken",
+            [_text_turn(text="was lost")],
+        )
+        # Orphan: DB row with no JSONL.
+        _insert_session(db, "uuid-orphan", "[]", "2026-04-15T10:00:00Z")
+
+        # Sanity: partial backfill leaves "[]" alone.
+        partial = backfill_partial(db, projects)
+        assert partial.updated == 0
+
+        # --full must repair.
+        full = backfill_full(db, projects)
+        assert full.deleted_and_reingested == 1
+        assert full.orphans_preserved == 1
+
+        conn = sqlite3.connect(str(db))
+        try:
+            rows = dict(conn.execute(
+                "SELECT session_uuid, raw_content_json FROM sessions"
+            ).fetchall())
+        finally:
+            conn.close()
+        assert rows["uuid-broken"] != "[]"
+        assert rows["uuid-broken"] is not None
+        # Orphan preserved byte-for-byte.
+        assert "uuid-orphan" in rows
+        assert rows["uuid-orphan"] == "[]"
+
+
+class TestTwoWayDiff:
+    """Scenario: unprocessed JSONLs and orphan DB rows appear in distinct lists."""
+
+    def test_diff_lists(self, db_and_projects):
+        db, projects = db_and_projects
+        # S: JSONL on disk, no DB row.
+        _write_jsonl(
+            projects / "proj" / "s.jsonl", "uuid-S",
+            [_text_turn(text="unprocessed")],
+        )
+        # T: DB row with no JSONL.
+        _insert_session(
+            db, "uuid-T", '[{"role":"user","content":"x"}]',
+            "2026-04-15T10:00:00Z",
+        )
+
+        report = collect_coverage(db, projects, week_start="monday")
+        assert any(
+            "s.jsonl" in path for path in report.unprocessed_jsonls
+        )
+        assert "uuid-T" in report.orphan_db_rows
+        # Neither list contaminates the other.
+        assert "uuid-T" not in report.unprocessed_jsonls
+        assert not any(
+            "uuid-S" in str(u) for u in report.orphan_db_rows
+        )
+
+
+class TestEmptyClassification:
+    """Scenario: `"[]"` rows split by whether JSONL has text turns."""
+
+    def test_parser_bug_vs_degenerate(self, db_and_projects):
+        db, projects = db_and_projects
+
+        _insert_session(db, "uuid-A", "[]", "2026-04-15T10:00:00Z")
+        _write_jsonl(
+            projects / "proj" / "a.jsonl", "uuid-A",
+            [_text_turn(text="has text")],
+        )
+        _insert_session(db, "uuid-B", "[]", "2026-04-15T10:00:00Z")
+        _write_jsonl(
+            projects / "proj" / "b.jsonl", "uuid-B",
+            [_tool_use_turn("ls")],
+        )
+
+        report = collect_coverage(db, projects, week_start="monday")
+        assert "uuid-A" in report.empty_but_jsonl_has_text
+        assert "uuid-A" not in report.empty_and_jsonl_truly_empty
+        assert "uuid-B" in report.empty_and_jsonl_truly_empty
+        assert "uuid-B" not in report.empty_but_jsonl_has_text
+
+
+class TestPerUnitBucketing:
+    """Scenario: mechanical GH-ref parse buckets sessions into units."""
+
+    def test_refs_from_tool_use(self, db_and_projects):
+        db, projects = db_and_projects
+
+        # Session X: reference only inside a tool_use Bash command.
+        _insert_session(db, "uuid-X", '[{"role":"user"}]', "2026-04-15T10:00:00Z")
+        _write_jsonl(
+            projects / "proj" / "x.jsonl", "uuid-X",
+            [_tool_use_turn("gh issue view 70 --repo owner/repo")],
+        )
+        # Session Y: two distinct references.
+        _insert_session(db, "uuid-Y", '[{"role":"user"}]', "2026-04-15T10:00:00Z")
+        _write_jsonl(
+            projects / "proj" / "y.jsonl", "uuid-Y",
+            [_text_turn(text="#42 and https://github.com/a/b/pull/99")],
+        )
+        # Session Z: no references at all.
+        _insert_session(db, "uuid-Z", '[{"role":"user"}]', "2026-04-15T10:00:00Z")
+        _write_jsonl(
+            projects / "proj" / "z.jsonl", "uuid-Z",
+            [_text_turn(text="just a plain message")],
+        )
+
+        report = collect_coverage(db, projects, week_start="monday")
+
+        assert "owner/repo#70" in report.per_unit
+        assert report.per_unit["owner/repo#70"]["total"] == 1
+        assert "#42" in report.per_unit
+        assert "a/b#99" in report.per_unit
+        assert "unattributed" in report.per_unit
+        assert report.per_unit["unattributed"]["total"] == 1
+        # Sum of per-unit totals must be >= total (session Y double-counted).
+        per_unit_sum = sum(v["total"] for v in report.per_unit.values())
+        assert per_unit_sum >= report.total
+
+
+class TestRunCoverageWrapper:
+    """Exercises the `run_coverage` CLI glue."""
+
+    def test_report_mode_exits_zero(self, db_and_projects, capsys):
+        db, projects = db_and_projects
+        rc = run_coverage(
+            sessions_db=db,
+            projects_path=projects,
+            week_start="monday",
+            data_dir=None,
+            emit_json=False,
+        )
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "Coverage diagnostic" in captured.out
+
+    def test_json_mode(self, db_and_projects, capsys):
+        db, projects = db_and_projects
+        _insert_session(db, "uuid-A", None, None)
+        rc = run_coverage(
+            sessions_db=db,
+            projects_path=projects,
+            week_start="monday",
+            data_dir=None,
+            emit_json=True,
+        )
+        assert rc == 0
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed["total"] == 1
+        assert parsed["null_count"] == 1
+
+    def test_full_without_backfill_errors(self, db_and_projects, capsys):
+        db, projects = db_and_projects
+        rc = run_coverage(
+            sessions_db=db,
+            projects_path=projects,
+            week_start="monday",
+            data_dir=None,
+            do_backfill=False,
+            full_rebuild=True,
+        )
+        assert rc == 2

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -126,8 +126,19 @@ class TestClassifyFill:
         assert _classify_fill("[]") == "empty"
         assert _classify_fill("  []  ") == "empty"
 
+    def test_empty_array_with_inner_whitespace(self):
+        # A future serializer (e.g. indent=2) could produce these — they must
+        # still classify as empty so the diagnostic isn't silently defeated.
+        assert _classify_fill("[ ]") == "empty"
+        assert _classify_fill("[\n]") == "empty"
+
     def test_nonempty(self):
         assert _classify_fill('[{"role":"user"}]') == "nonempty"
+
+    def test_malformed_json_is_nonempty(self):
+        # Misclassifying malformed JSON as empty would hide it from the
+        # parser-bug diagnostic list.
+        assert _classify_fill("not json") == "nonempty"
 
 
 class TestJsonlHasTextTurns:
@@ -481,3 +492,8 @@ class TestRunCoverageWrapper:
             full_rebuild=True,
         )
         assert rc == 2
+        captured = capsys.readouterr()
+        # Operators hitting this case must see the flag name in the guidance,
+        # not just an opaque exit code. Pin the text so a silent regression
+        # (e.g. dropping "--full") breaks this test instead of breaking users.
+        assert "--full requires --backfill" in captured.err

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -359,6 +359,49 @@ class TestFullBackfill:
         assert rows["uuid-orphan"] == "[]"
 
 
+class TestFullBackfillParseFailurePreservesRow:
+    """Regression (F-2): a parse_session failure mid-rebuild must not destroy
+    the pre-existing DB row. Earlier implementation issued DELETE + commit
+    before re-ingest, so a raised parse_session dropped the row permanently.
+    """
+
+    def test_parse_failure_preserves_existing_row(self, db_and_projects):
+        db, projects = db_and_projects
+
+        # Row with a valid pre-existing raw_content_json value — this is the
+        # "last good copy" scenario the regression is about.
+        _insert_session(
+            db,
+            "uuid-valuable",
+            '[{"role":"user","content":"irreplaceable"}]',
+            "2026-04-15T10:00:00Z",
+        )
+        # Write a JSONL that has the right sessionId (so it's picked up) but
+        # malformed JSON on a later line so parse_session raises
+        # SessionParseError.
+        path = projects / "proj" / "malformed.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"sessionId": "uuid-valuable", "type": "summary"})
+            + "\n{not valid json\n"
+        )
+
+        summary = backfill_full(db, projects)
+        assert summary.errored == 1
+        assert summary.deleted_and_reingested == 0
+
+        # Critical invariant: the pre-existing row is still there, unchanged.
+        conn = sqlite3.connect(str(db))
+        try:
+            rows = dict(conn.execute(
+                "SELECT session_uuid, raw_content_json FROM sessions"
+            ).fetchall())
+        finally:
+            conn.close()
+        assert "uuid-valuable" in rows
+        assert rows["uuid-valuable"] == '[{"role":"user","content":"irreplaceable"}]'
+
+
 class TestTwoWayDiff:
     """Scenario: unprocessed JSONLs and orphan DB rows appear in distinct lists."""
 


### PR DESCRIPTION
Closes #70

## What changed

Adds `am-synthesize coverage` as a new subcommand that reports
`raw_content_json` fill state across `sessions.db` and the JSONL files
on disk. The diagnostic is a permanent pre-synthesis health check — it
answers "is X-1 (expectation extraction) safe to turn on?" by one
command.

The command prints total / NULL / `"[]"` / non-empty counts bucketed
per-week, per-project, and per-unit, plus four diagnostic lists that
surface sessions needing human attention. Two backfill modes repair the
DB when the operator opts in.

## Tier / approach
Tier 2 — Planner + single-Coder (coverage engine, CLI router, tests, README).

## Implementation walkthrough

### `synthesis/coverage.py` (new)
Pure-function coverage engine. `collect_coverage(sessions_db, projects_path, week_start)` reads the DB once, scans every JSONL under `projects_path` once (excluding `subagents/`), and returns a `CoverageReport` dataclass. All bucket dicts and diagnostic lists are populated in a single pass; per-JSONL GH-ref extraction and text-turn detection are cached so each JSONL is read at most twice.

`GhRef` is a frozen dataclass holding `(repo, kind, ref)`. References are extracted mechanically from the raw JSONL (including `tool_use` / `tool_result` blocks that `_strip_content_blocks` removes from `raw_content_json`): `#N`, `gh issue|pr view|comment|create N --repo X`, `https://github.com/OWNER/REPO/(issues|pull)/N`, and 7–40 char hex SHAs. The patterns are duplicated locally — `synthesis.unit_identifier` is deliberately not imported so the diagnostic stays decoupled from the synthesis pipeline.

`_classify_fill` maps the `raw_content_json` column to one of `null` / `empty` / `nonempty`. `"[]"` is the literal empty-array serialization written by `parse_session` when every turn was stripped.

`backfill_partial` targets only rows with `raw_content_json IS NULL` and reuses the existing `parse_session` + `upsert_session` path — so the narrow-UPDATE invariant from `backfill_session_timestamps` is preserved. Rows with `"[]"` or any non-empty value are left alone; re-running is a no-op.

`backfill_full` is the delete-rebuild mode: for every JSONL on disk, delete the existing DB row (if any) then call `parse_session` + `upsert_session`. Orphan rows (DB row, no JSONL) are counted BEFORE the loop and surfaced in `orphans_preserved` — never silently dropped.

`run_coverage` is the CLI glue. It rejects `--full` without `--backfill` (exit 2), then dispatches to partial backfill, full rebuild, or report generation.

### `synthesis/cli.py` (modified)
Converted the flat `--week`-driven parser into a parser + subparsers structure. The `coverage` subcommand is registered via `add_coverage_subparser`. The top-level `--week` / `--dry-run` / `--config` flags are retained (made optional) so `am-synthesize --week YYYY-MM-DD` keeps working verbatim — scripts and cron entries that predate the coverage subcommand see no breaking change.

### `tests/test_coverage.py` (new)
One `TestCase` class per acceptance scenario in the refined spec. Fixtures follow the `test_backfill_session_timestamps.py` style: `_write_jsonl` for arbitrary entries, `_text_turn` / `_tool_use_turn` builders, `_insert_session` for bare rows. 18 tests, all passing.

### `README.md` (modified)
Added a "Coverage diagnostic" subsection under "Synthesis" that documents the four invocation shapes and spells out the **qualitative** coverage gate: every session should have a transcript OR be on a documented exclusion list with a reason — not a percentage threshold.

### Default execution path

**Before**: no way to check coverage — operators had no way to tell whether X-1 (#27) would read real transcripts or silently produce plausible-looking output on empty strings.

**After**: `am-synthesize coverage` → `collect_coverage` scans DB + JSONLs once → `format_text` / `to_json` emit the report. Backfill modes add one of two paths — `backfill_partial` (NULL-only rows, idempotent) or `backfill_full` (delete-rebuild every JSONL, orphans preserved).

### What was intentionally not changed

Out of scope per the refined spec: no changes to `_strip_content_blocks`, no schema changes, no touch of `synthesis/unit_identifier.py`, no exclusion filter at ingest, no auto-fix for `"[]"` rows, no auto-posting back to Epic #27.

## Acceptance criteria

- [x] CLI reports total / NULL / `"[]"` / non-empty counts + per-week/project/unit buckets + four diagnostic list sizes; no DB writes; exit 0.
- [x] `--json` emits a parseable JSON document; deterministic across runs with identical inputs.
- [x] `--backfill` populates only NULL rows; idempotent; other columns unchanged.
- [x] `--backfill --full` delete-rebuilds every on-disk JSONL; preserves orphan rows; requires explicit `--full`.
- [x] Unprocessed JSONLs and orphan DB rows appear in distinct lists.
- [x] `"[]"` rows are split into `empty_but_jsonl_has_text` and `empty_and_jsonl_truly_empty`.
- [x] Sessions are bucketed in each unit referenced from their JSONL (incl. references inside `tool_use` blocks); zero-ref → `unattributed`.
- [x] Bare `am-synthesize --week YYYY-MM-DD` still works.
- [x] Coverage-gate paragraph added to README.

## Test summary

- 18 new tests in `tests/test_coverage.py` — all passing.
- Full suite: 513 passed, 23 skipped (unchanged baseline).

## Outstanding items

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)