### PR TITLE
feat(#72): X-1 expectation extraction — Sonnet classifier + expectations.db

### DIFF
--- a/am_i_shipping/db.py
+++ b/am_i_shipping/db.py
@@ -252,6 +252,45 @@ CREATE TABLE IF NOT EXISTS unit_summaries (
 );
 """
 
+# Epic #27 — X-1 (#72): expectations.db schema.
+# Standalone SQLite file under ``config.data_path``. Later slices in the epic
+# (X-2 through X-5) will add their own tables to the same DB but must NOT
+# rename the columns this slice writes — X-4 user corrections accumulate
+# against these column names and renaming is expensive.
+SYNTHESIS_EXPECTATIONS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS expectations (
+    week_start       TEXT NOT NULL,
+    unit_id          TEXT NOT NULL,
+    commitment_point TEXT,
+    expected_scope   TEXT,
+    expected_effort  TEXT,
+    expected_outcome TEXT,
+    confidence       REAL,
+    model            TEXT,
+    input_bytes      INTEGER,
+    extracted_at     TEXT DEFAULT (datetime('now')),
+    skip_reason      TEXT,
+    PRIMARY KEY (week_start, unit_id)
+);
+"""
+
+EXPECTED_EXPECTATIONS_TABLES: dict[str, set[str]] = {
+    "expectations": {
+        "week_start",
+        "unit_id",
+        "commitment_point",
+        "expected_scope",
+        "expected_effort",
+        "expected_outcome",
+        "confidence",
+        "model",
+        "input_bytes",
+        "extracted_at",
+        "skip_reason",
+    },
+}
+
+
 SYNTHESIS_SESSION_GH_EVENTS_SCHEMA = """
 CREATE TABLE IF NOT EXISTS session_gh_events (
     session_uuid  TEXT NOT NULL,
@@ -622,14 +661,33 @@ def init_appswitch_db(db_path: Path) -> None:
         conn.close()
 
 
+def init_expectations_db(db_path: Path) -> None:
+    """Create ``expectations.db`` with the expectations table (Epic #27, X-1).
+
+    Idempotent (``CREATE TABLE IF NOT EXISTS``). Later slices of Epic #27
+    (X-2 through X-5) are expected to add additional tables to the same
+    DB file via their own ``init_*`` functions.
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(SYNTHESIS_EXPECTATIONS_SCHEMA)
+        conn.commit()
+        # Assert on the same connection we just wrote to (for ':memory:'
+        # databases; see init_sessions_db for the rationale).
+        assert_schema(conn, EXPECTED_EXPECTATIONS_TABLES)
+    finally:
+        conn.close()
+
+
 def init_all(config: Config) -> None:
-    """Initialize all three databases under the configured data directory."""
+    """Initialize all four databases under the configured data directory."""
     data_dir = config.data_path
     data_dir.mkdir(parents=True, exist_ok=True)
 
     init_sessions_db(data_dir / "sessions.db")
     init_github_db(data_dir / "github.db")
     init_appswitch_db(data_dir / "appswitch.db")
+    init_expectations_db(data_dir / "expectations.db")
 
     print(f"Databases initialized in {data_dir}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ am-appswitch-export = "collector.appswitch.export:main"
 am-synthesize = "synthesis.cli:main"
 am-prepare-week = "synthesis.prepare:main"
 am-summarize-units = "synthesis.summarize:main"
+am-extract-expectations = "synthesis.expectations:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/synthesis/expectations.py
+++ b/synthesis/expectations.py
@@ -1,0 +1,730 @@
+"""Epic #27 — X-1 (#72): per-unit expectation extraction.
+
+Reads the ``units`` and ``graph_*`` tables populated by Phase 2, plus session
+transcripts from ``sessions.db``, and for each unit invokes Sonnet (or the
+offline :class:`FakeAnthropicClient` in test mode) to identify the
+**commitment point** — the user turn where an implicit or explicit plan is
+accepted — and classify four expectation facets at that point: ``scope``
+(what files/surfaces), ``effort`` (how many sessions / reprompts / days the
+user implicitly expected), ``outcome`` (what "done" means), and
+``confidence`` (0-1 self-reported by the classifier).
+
+Output rows land in a new ``expectations.db`` created by
+:func:`am_i_shipping.db.init_expectations_db`.
+
+Behavioral invariants (from the refined spec):
+
+* **Every unit in the week gets at least one row.** Either a populated
+  expectation row, or exactly one row with a non-NULL ``skip_reason``
+  naming the cause. No unit is ever silently absent from the table.
+* **Hybrid commitment-point detection.** A pure structural detector
+  (last user text turn before the first tool-use turn) produces a
+  candidate; that candidate plus ±2 surrounding text turns are sent to
+  Sonnet, which either confirms or reassigns it. The final
+  ``commitment_point`` and ``confidence`` are recorded as-returned — low
+  confidence rows are NOT silently suppressed.
+* **Idempotency.** Re-running without ``--rebuild`` issues zero new LLM
+  calls for units already present in ``expectations``.
+* **Diagnostic logging.** The per-unit ``input_bytes`` value is logged at
+  INFO level (surfaces the system-feared failure mode: semantically empty
+  input producing structurally-valid-but-meaningless expectations), and
+  the run-level structural-vs-LLM commitment-point agreement rate is
+  emitted when the run completes.
+
+Architecture notes
+------------------
+* Reuses :func:`synthesis.weekly._unit_nodes` and
+  :func:`synthesis.weekly._load_session_transcripts` unchanged — these are
+  the graph-walk + session-lookup helpers the rest of the synthesis
+  pipeline shares.
+* Reuses :func:`synthesis.llm_adapter._get_adapter` for offline/live
+  client selection. ``AMIS_SYNTHESIS_LIVE`` unset (the default in tests)
+  routes to :class:`FakeAnthropicClient`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sqlite3
+import sys
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from am_i_shipping.config_loader import SynthesisConfig, load_config
+from am_i_shipping.db import init_expectations_db, init_github_db
+from synthesis.llm_adapter import _get_adapter
+from synthesis.weekly import _load_session_transcripts, _unit_nodes
+
+
+logger = logging.getLogger(__name__)
+
+
+# Upper bound on the classifier's JSON output. A populated facet block is
+# a handful of short strings; 1024 tokens is generous headroom.
+_MAX_OUTPUT_TOKENS = 1024
+
+
+_EXPECTATIONS_SYSTEM_PROMPT = """You are extracting the user's expectations at the \
+commitment point of a software development unit for a retrospective \
+calibration system.
+
+A "unit" is one complete development cycle (issue -> PR -> merge or \
+abandon). The "commitment point" is the user turn where an implicit or \
+explicit plan is accepted by the user — the moment after which execution \
+is expected to proceed without further design-phase disambiguation.
+
+You will be given (1) a structurally-detected candidate commitment turn \
+and (2) the ±2 surrounding user text turns from the transcript. Decide \
+whether the candidate is correct or reassign it, then classify four \
+facets of what the user expected at that moment:
+
+- expected_scope: which files / surfaces / modules the user expected to \
+change. Prefer concrete names if mentioned; otherwise a phrase.
+- expected_effort: how much work the user implicitly expected. Free-text \
+matching the raw user language (e.g. "one session, ~2 hours", "a few \
+reprompts", "one afternoon").
+- expected_outcome: what "done" means for this unit, as the user framed \
+it at the commitment point.
+- confidence: your self-reported certainty on the overall classification, \
+as a float in [0.0, 1.0].
+
+Return a single JSON object with exactly these keys:
+  commitment_point, expected_scope, expected_effort, expected_outcome, confidence
+
+commitment_point should be a short string identifying the turn (e.g.
+"turn 5: 'go ahead'" or "candidate confirmed"). If you cannot identify a \
+commitment point from the supplied context, return null for \
+commitment_point and the other facet strings, and set confidence to 0.0.
+
+Do NOT add extra keys. Do NOT wrap the JSON in markdown fences. Do NOT \
+invent signals that are not present in the supplied turns."""
+
+
+# ---------------------------------------------------------------------------
+# Transcript parsing — structural commitment-point detection
+# ---------------------------------------------------------------------------
+
+
+def _extract_turns(raw_content_json: str) -> List[Dict[str, Any]]:
+    """Parse a raw_content_json blob into a normalized turn list.
+
+    Each returned dict has keys:
+      role: "user" | "assistant" | "system" | other
+      kind: "text" | "tool_use" | "tool_result" | "other"
+      text: str (empty for non-text turns)
+      index: int (position in the source transcript)
+
+    The session_parser stores ``raw_content_json`` as a JSON-serialized
+    list of message dicts. Formats seen in the wild:
+      * Plain string content: ``{"role": "user", "content": "hi"}``
+      * Structured content list:
+        ``{"role": "assistant", "content": [{"type": "text", "text": "..."},
+        {"type": "tool_use", ...}]}``
+    We normalize both into one flat turn list.
+    """
+    if not raw_content_json:
+        return []
+    try:
+        messages = json.loads(raw_content_json)
+    except (ValueError, TypeError):
+        return []
+    if not isinstance(messages, list):
+        return []
+
+    turns: List[Dict[str, Any]] = []
+    for idx, msg in enumerate(messages):
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role") or ""
+        content = msg.get("content")
+
+        if isinstance(content, str):
+            turns.append(
+                {"role": role, "kind": "text", "text": content, "index": idx}
+            )
+            continue
+
+        if isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                btype = block.get("type") or ""
+                if btype == "text":
+                    turns.append(
+                        {
+                            "role": role,
+                            "kind": "text",
+                            "text": block.get("text") or "",
+                            "index": idx,
+                        }
+                    )
+                elif btype == "tool_use":
+                    turns.append(
+                        {
+                            "role": role,
+                            "kind": "tool_use",
+                            "text": "",
+                            "index": idx,
+                        }
+                    )
+                elif btype == "tool_result":
+                    turns.append(
+                        {
+                            "role": role,
+                            "kind": "tool_result",
+                            "text": "",
+                            "index": idx,
+                        }
+                    )
+                else:
+                    turns.append(
+                        {"role": role, "kind": "other", "text": "", "index": idx}
+                    )
+            continue
+
+        # Unknown content shape — skip.
+    return turns
+
+
+def detect_structural_commitment_point(
+    turns: Sequence[Dict[str, Any]],
+) -> Optional[int]:
+    """Return the index of the structurally-detected commitment turn, or None.
+
+    Heuristic (per the refined spec):
+
+    The commitment point is the **last user text turn before the first
+    tool-use turn**. This captures the pattern "user plans, user accepts,
+    assistant begins execution with tool calls".
+
+    If there are no tool-use turns at all, falls back to the last user
+    text turn in the transcript (if any).
+
+    Pure function — no DB, no I/O. Unit-testable in isolation.
+    """
+    if not turns:
+        return None
+
+    # Find index of first tool-use turn.
+    first_tool_use: Optional[int] = None
+    for i, t in enumerate(turns):
+        if t["kind"] == "tool_use":
+            first_tool_use = i
+            break
+
+    # Walk user text turns; pick the last one before first_tool_use
+    # (or the last one overall if no tool-use).
+    upper = first_tool_use if first_tool_use is not None else len(turns)
+    last_user_text: Optional[int] = None
+    for i in range(upper):
+        t = turns[i]
+        if t["role"] == "user" and t["kind"] == "text" and t["text"].strip():
+            last_user_text = i
+    if last_user_text is not None:
+        return last_user_text
+
+    # Fallback: any user text turn anywhere in the transcript.
+    for i, t in enumerate(turns):
+        if t["role"] == "user" and t["kind"] == "text" and t["text"].strip():
+            return i
+    return None
+
+
+def _surrounding_user_text(
+    turns: Sequence[Dict[str, Any]],
+    anchor_idx: int,
+    window: int = 2,
+) -> List[Tuple[int, str]]:
+    """Return ``[(turn_idx, text), ...]`` for up to ``±window`` user text turns.
+
+    Anchored on ``anchor_idx``. Only user text turns are returned; the
+    anchor itself is included. Pure function.
+    """
+    if anchor_idx < 0 or anchor_idx >= len(turns):
+        return []
+    user_text_indices = [
+        i
+        for i, t in enumerate(turns)
+        if t["role"] == "user" and t["kind"] == "text" and t["text"].strip()
+    ]
+    if anchor_idx not in user_text_indices:
+        # Still surface anchor so the LLM can see it (even if non-text).
+        return [(anchor_idx, turns[anchor_idx].get("text") or "")]
+    pos = user_text_indices.index(anchor_idx)
+    lo = max(0, pos - window)
+    hi = min(len(user_text_indices), pos + window + 1)
+    return [
+        (user_text_indices[p], turns[user_text_indices[p]]["text"])
+        for p in range(lo, hi)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Unit input assembly
+# ---------------------------------------------------------------------------
+
+
+def _build_unit_input(
+    gh_conn: sqlite3.Connection,
+    sessions_conn: sqlite3.Connection,
+    unit_id: str,
+    week_start: str,
+) -> Tuple[str, int, Optional[int], str]:
+    """Assemble the classifier input for *unit_id*.
+
+    Returns ``(input_text, input_bytes, structural_candidate_turn_idx,
+    skip_reason)``. ``skip_reason`` is an empty string when extraction
+    should proceed; otherwise it names the cause
+    (``raw_content_json_empty`` / ``no_text_turns``).
+    ``structural_candidate_turn_idx`` is None when no candidate could be
+    found.
+    """
+    # Walk the unit's graph component to collect its session UUIDs.
+    unit_row = gh_conn.execute(
+        "SELECT root_node_id FROM units WHERE week_start = ? AND unit_id = ?",
+        (week_start, unit_id),
+    ).fetchone()
+    root_node_id = unit_row[0] if unit_row else ""
+    component = _unit_nodes(gh_conn, week_start, root_node_id or "")
+    session_uuids: List[str] = [
+        node_ref
+        for _nid, node_type, node_ref in component
+        if node_type == "session" and node_ref
+    ]
+
+    transcripts = _load_session_transcripts(sessions_conn, session_uuids)
+    # Concatenate turns from every transcript in the unit, preserving order.
+    all_turns: List[Dict[str, Any]] = []
+    have_any_content = False
+    for _uid, content in transcripts:
+        if not content:
+            continue
+        have_any_content = True
+        turns = _extract_turns(content)
+        all_turns.extend(turns)
+
+    if not have_any_content:
+        return "", 0, None, "raw_content_json_empty"
+
+    # Structural candidate.
+    candidate_idx = detect_structural_commitment_point(all_turns)
+    if candidate_idx is None:
+        return "", 0, None, "no_text_turns"
+
+    context = _surrounding_user_text(all_turns, candidate_idx, window=2)
+
+    parts: List[str] = []
+    parts.append(f"## Unit: {unit_id}")
+    parts.append(f"## Week: {week_start}")
+    parts.append(
+        f"## Structural commitment-point candidate: turn index {candidate_idx}"
+    )
+    parts.append("")
+    parts.append("### Candidate turn")
+    cand_text = all_turns[candidate_idx].get("text") or ""
+    parts.append(f"turn {candidate_idx}: {cand_text}")
+    parts.append("")
+    parts.append("### ±2 surrounding user text turns")
+    for turn_idx, text in context:
+        marker = " [CANDIDATE]" if turn_idx == candidate_idx else ""
+        parts.append(f"turn {turn_idx}{marker}: {text}")
+
+    assembled = "\n".join(parts)
+    return assembled, len(assembled.encode()), candidate_idx, ""
+
+
+# ---------------------------------------------------------------------------
+# LLM parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_llm_response(response_text: str) -> Optional[Dict[str, Any]]:
+    """Parse the classifier's JSON response.
+
+    Returns the parsed dict, or ``None`` if parsing fails. Tolerates
+    surrounding whitespace and stripped ```json fences.
+    """
+    if not response_text:
+        return None
+    text = response_text.strip()
+    # Strip common ```json fences just in case the model ignores the
+    # "no markdown fences" instruction.
+    m = re.search(r"\{.*\}", text, re.DOTALL)
+    if not m:
+        return None
+    try:
+        obj = json.loads(m.group(0))
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(obj, dict):
+        return None
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_extracted_unit_ids(
+    exp_conn: sqlite3.Connection, week_start: str
+) -> set[str]:
+    """Return the set of ``unit_id`` values already in ``expectations`` for the week."""
+    rows = exp_conn.execute(
+        "SELECT unit_id FROM expectations WHERE week_start = ?",
+        (week_start,),
+    ).fetchall()
+    return {r[0] for r in rows}
+
+
+def _load_week_units(
+    gh_conn: sqlite3.Connection, week_start: str
+) -> List[str]:
+    """Return all ``unit_id`` values in ``units`` for *week_start*, sorted."""
+    rows = gh_conn.execute(
+        "SELECT unit_id FROM units WHERE week_start = ? ORDER BY unit_id",
+        (week_start,),
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+def _store_expectation(
+    exp_conn: sqlite3.Connection,
+    *,
+    week_start: str,
+    unit_id: str,
+    commitment_point: Optional[str],
+    expected_scope: Optional[str],
+    expected_effort: Optional[str],
+    expected_outcome: Optional[str],
+    confidence: Optional[float],
+    model: Optional[str],
+    input_bytes: int,
+    skip_reason: Optional[str],
+) -> None:
+    """Insert or replace an expectations row."""
+    exp_conn.execute(
+        "INSERT OR REPLACE INTO expectations "
+        "(week_start, unit_id, commitment_point, expected_scope, "
+        " expected_effort, expected_outcome, confidence, model, "
+        " input_bytes, skip_reason) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            week_start,
+            unit_id,
+            commitment_point,
+            expected_scope,
+            expected_effort,
+            expected_outcome,
+            confidence,
+            model,
+            input_bytes,
+            skip_reason,
+        ),
+    )
+    exp_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run_extraction(
+    config: SynthesisConfig,
+    *,
+    github_db: str,
+    sessions_db: str,
+    expectations_db: str,
+    week_start: str,
+    rebuild: bool = False,
+) -> int:
+    """Extract expectations for every unit in *week_start*.
+
+    Parameters
+    ----------
+    config:
+        Validated :class:`SynthesisConfig`. Supplies ``model`` (Sonnet)
+        and ``anthropic_api_key_env``.
+    github_db, sessions_db, expectations_db:
+        Filesystem paths to the collector/expectation DBs.
+    week_start:
+        ``YYYY-MM-DD`` anchor. Must match a value in ``units.week_start``.
+    rebuild:
+        When True, existing ``expectations`` rows for the week are deleted
+        before the pass so every unit is re-extracted.
+
+    Returns
+    -------
+    ``0`` on success (even if zero units were processed — an empty week is
+    a valid no-op). ``1`` if at least one unit raised during the LLM call
+    (the run still completes for the rest — no unit is left absent).
+    """
+    # Pre-flight: ensure both DBs exist with the right schema.
+    init_github_db(github_db)
+    init_expectations_db(expectations_db)
+
+    adapter = _get_adapter(config)
+
+    gh_conn = sqlite3.connect(github_db)
+    exp_conn = sqlite3.connect(expectations_db)
+    sessions_conn = None
+    try:
+        _same = sessions_db == github_db
+        try:
+            if not _same:
+                _same = os.path.samefile(github_db, sessions_db)
+        except OSError:
+            pass
+        sessions_conn = gh_conn if _same else sqlite3.connect(sessions_db)
+
+        if rebuild:
+            exp_conn.execute(
+                "DELETE FROM expectations WHERE week_start = ?", (week_start,)
+            )
+            exp_conn.commit()
+
+        all_units = _load_week_units(gh_conn, week_start)
+        if not all_units:
+            logger.info(
+                "No units for week_start=%s; nothing to extract", week_start
+            )
+            return 0
+
+        already_extracted = _load_extracted_unit_ids(exp_conn, week_start)
+
+        structural_count = 0
+        llm_agree_count = 0
+        failure_count = 0
+
+        for unit_id in all_units:
+            if unit_id in already_extracted:
+                logger.debug(
+                    "Unit %s already extracted for week %s — skipping",
+                    unit_id,
+                    week_start,
+                )
+                continue
+
+            unit_input, input_bytes, candidate_idx, skip_reason = (
+                _build_unit_input(gh_conn, sessions_conn, unit_id, week_start)
+            )
+
+            logger.info(
+                "unit=%s week=%s input_bytes=%d skip_reason=%s",
+                unit_id,
+                week_start,
+                input_bytes,
+                skip_reason or "",
+            )
+
+            if skip_reason:
+                _store_expectation(
+                    exp_conn,
+                    week_start=week_start,
+                    unit_id=unit_id,
+                    commitment_point=None,
+                    expected_scope=None,
+                    expected_effort=None,
+                    expected_outcome=None,
+                    confidence=None,
+                    model=config.model,
+                    input_bytes=input_bytes,
+                    skip_reason=skip_reason,
+                )
+                continue
+
+            # Live call — we have a structural candidate and non-empty input.
+            structural_count += 1
+            try:
+                result = adapter.call(
+                    _EXPECTATIONS_SYSTEM_PROMPT,
+                    unit_input,
+                    config.model,
+                    _MAX_OUTPUT_TOKENS,
+                )
+                parsed = _parse_llm_response(result.text)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to extract expectations for unit %s: %s — "
+                    "storing skip row",
+                    unit_id,
+                    exc,
+                )
+                failure_count += 1
+                _store_expectation(
+                    exp_conn,
+                    week_start=week_start,
+                    unit_id=unit_id,
+                    commitment_point=None,
+                    expected_scope=None,
+                    expected_effort=None,
+                    expected_outcome=None,
+                    confidence=None,
+                    model=config.model,
+                    input_bytes=input_bytes,
+                    skip_reason="structural_detection_failed_and_llm_declined",
+                )
+                continue
+
+            if not parsed:
+                # LLM declined (unparseable response).
+                _store_expectation(
+                    exp_conn,
+                    week_start=week_start,
+                    unit_id=unit_id,
+                    commitment_point=None,
+                    expected_scope=None,
+                    expected_effort=None,
+                    expected_outcome=None,
+                    confidence=None,
+                    model=config.model,
+                    input_bytes=input_bytes,
+                    skip_reason="structural_detection_failed_and_llm_declined",
+                )
+                continue
+
+            llm_commit = parsed.get("commitment_point")
+            confidence_raw = parsed.get("confidence")
+            try:
+                confidence = (
+                    float(confidence_raw)
+                    if confidence_raw is not None
+                    else None
+                )
+            except (ValueError, TypeError):
+                confidence = None
+
+            # Agreement heuristic: does the LLM's commitment_point string
+            # reference the structural candidate's turn index? The offline
+            # FakeAnthropicClient returns a canned Markdown retrospective,
+            # not this JSON format — agreement for that path is measured
+            # as "LLM returned something parseable that references the
+            # candidate index". We treat absence of a parseable JSON as
+            # disagreement.
+            if (
+                isinstance(llm_commit, str)
+                and candidate_idx is not None
+                and str(candidate_idx) in llm_commit
+            ):
+                llm_agree_count += 1
+
+            _store_expectation(
+                exp_conn,
+                week_start=week_start,
+                unit_id=unit_id,
+                commitment_point=(
+                    str(llm_commit) if llm_commit is not None else None
+                ),
+                expected_scope=parsed.get("expected_scope"),
+                expected_effort=parsed.get("expected_effort"),
+                expected_outcome=parsed.get("expected_outcome"),
+                confidence=confidence,
+                model=config.model,
+                input_bytes=input_bytes,
+                skip_reason=None,
+            )
+
+        # Emit the run-level diagnostic summary. This is the signal that
+        # surfaces the system-feared failure mode (sparse raw_content_json
+        # producing structurally-valid-but-meaningless expectations).
+        if structural_count > 0:
+            agreement_rate = llm_agree_count / structural_count
+        else:
+            agreement_rate = 0.0
+        logger.info(
+            "expectations extraction complete: week=%s units=%d "
+            "structural_candidates=%d llm_agreements=%d "
+            "agreement_rate=%.3f failures=%d",
+            week_start,
+            len(all_units),
+            structural_count,
+            llm_agree_count,
+            agreement_rate,
+            failure_count,
+        )
+
+        if failure_count > 0:
+            return 1
+
+    finally:
+        if sessions_conn is not None and sessions_conn is not gh_conn:
+            sessions_conn.close()
+        exp_conn.close()
+        gh_conn.close()
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="am-extract-expectations",
+        description=(
+            "Extract per-unit expectations (commitment point + scope / "
+            "effort / outcome / confidence) for a given week and store "
+            "them in expectations.db. Already-extracted units are "
+            "skipped unless --rebuild is passed."
+        ),
+    )
+    parser.add_argument(
+        "--week",
+        required=True,
+        help=(
+            "Week start date (YYYY-MM-DD). Must match a value in "
+            "units.week_start."
+        ),
+    )
+    parser.add_argument(
+        "--rebuild",
+        action="store_true",
+        default=False,
+        help=(
+            "Delete existing expectations rows for the week before "
+            "re-extracting. Without this flag, already-extracted units "
+            "are skipped (idempotent default)."
+        ),
+    )
+    parser.add_argument(
+        "--config",
+        default="config.yaml",
+        help="Path to config.yaml (default: config.yaml in repo root).",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    """Entry point for the ``am-extract-expectations`` CLI."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    config = load_config(args.config)
+    data_dir = config.data_path
+    github_db = str(data_dir / "github.db")
+    sessions_db = str(data_dir / "sessions.db")
+    expectations_db = str(data_dir / "expectations.db")
+
+    result = run_extraction(
+        config.synthesis,
+        github_db=github_db,
+        sessions_db=sessions_db,
+        expectations_db=expectations_db,
+        week_start=args.week,
+        rebuild=args.rebuild,
+    )
+    sys.exit(result)
+
+
+if __name__ == "__main__":  # pragma: no cover — CLI plumbing
+    main()

--- a/tests/test_expectations.py
+++ b/tests/test_expectations.py
@@ -1,0 +1,708 @@
+"""Tests for ``synthesis/expectations.py`` (Epic #27 — X-1, Issue #72)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import time
+import unittest.mock as mock
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from am_i_shipping.config_loader import SynthesisConfig
+from am_i_shipping.db import (
+    EXPECTED_EXPECTATIONS_TABLES,
+    assert_schema,
+    init_expectations_db,
+    init_github_db,
+    init_sessions_db,
+)
+from synthesis.expectations import (
+    _extract_turns,
+    _parse_llm_response,
+    _surrounding_user_text,
+    detect_structural_commitment_point,
+    run_extraction,
+)
+
+
+WEEK_START = "2026-04-14"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_synthesis_config(**overrides) -> SynthesisConfig:
+    base = SynthesisConfig(
+        anthropic_api_key_env="ANTHROPIC_API_KEY",
+        model="claude-sonnet-4-5",
+        summary_model="claude-haiku-4-5",
+        output_dir="retrospectives",
+        week_start="monday",
+        abandonment_days=14,
+        outlier_sigma=2.0,
+    )
+    if overrides:
+        return replace(base, **overrides)
+    return base
+
+
+def _init_dbs(tmp_path: Path) -> tuple[Path, Path, Path]:
+    gh = tmp_path / "github.db"
+    sess = tmp_path / "sessions.db"
+    exp = tmp_path / "expectations.db"
+    init_github_db(gh)
+    init_sessions_db(sess)
+    init_expectations_db(exp)
+    return gh, sess, exp
+
+
+def _seed_unit(
+    db_path: Path,
+    *,
+    week_start: str = WEEK_START,
+    unit_id: str,
+    root_node_id: str = "",
+) -> None:
+    if not root_node_id:
+        root_node_id = f"n-{unit_id}"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "INSERT INTO units "
+            "(week_start, unit_id, root_node_type, root_node_id, "
+            " elapsed_days, dark_time_pct, total_reprompts, "
+            " review_cycles, status, outlier_flags, abandonment_flag) "
+            "VALUES (?, ?, 'session', ?, 1.0, 0.0, 0, 0, 'closed', '[]', 0)",
+            (week_start, unit_id, root_node_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_session_and_node(
+    gh_db: Path,
+    sess_db: Path,
+    *,
+    week_start: str = WEEK_START,
+    unit_root_id: str,
+    session_uuid: str,
+    raw_content_json: Any,
+) -> None:
+    """Seed a graph_node referencing a session, and the session row itself."""
+    conn = sqlite3.connect(str(gh_db))
+    try:
+        conn.execute(
+            "INSERT INTO graph_nodes "
+            "(week_start, node_id, node_type, node_ref) "
+            "VALUES (?, ?, 'session', ?)",
+            (week_start, unit_root_id, session_uuid),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    payload = (
+        raw_content_json
+        if isinstance(raw_content_json, str) or raw_content_json is None
+        else json.dumps(raw_content_json)
+    )
+    conn = sqlite3.connect(str(sess_db))
+    try:
+        conn.execute(
+            "INSERT INTO sessions (session_uuid, raw_content_json) "
+            "VALUES (?, ?)",
+            (session_uuid, payload),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _expectation_rows(exp_db: Path, week_start: str = WEEK_START) -> list[dict]:
+    conn = sqlite3.connect(str(exp_db))
+    try:
+        rows = conn.execute(
+            "SELECT week_start, unit_id, commitment_point, expected_scope, "
+            "       expected_effort, expected_outcome, confidence, model, "
+            "       input_bytes, extracted_at, skip_reason "
+            "FROM expectations WHERE week_start = ? ORDER BY unit_id",
+            (week_start,),
+        ).fetchall()
+        return [
+            {
+                "week_start": r[0],
+                "unit_id": r[1],
+                "commitment_point": r[2],
+                "expected_scope": r[3],
+                "expected_effort": r[4],
+                "expected_outcome": r[5],
+                "confidence": r[6],
+                "model": r[7],
+                "input_bytes": r[8],
+                "extracted_at": r[9],
+                "skip_reason": r[10],
+            }
+            for r in rows
+        ]
+    finally:
+        conn.close()
+
+
+@pytest.fixture(autouse=True)
+def _scrub_live_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("AMIS_SYNTHESIS_LIVE", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Schema (AS-1)
+# ---------------------------------------------------------------------------
+
+
+def test_init_expectations_db_creates_schema(tmp_path: Path):
+    """init_expectations_db creates the expectations table with all columns."""
+    db = tmp_path / "expectations.db"
+    init_expectations_db(db)
+
+    assert db.exists()
+    assert_schema(db, EXPECTED_EXPECTATIONS_TABLES)
+
+
+def test_init_expectations_db_idempotent(tmp_path: Path):
+    """Re-initializing against an existing DB is a no-op."""
+    db = tmp_path / "expectations.db"
+    init_expectations_db(db)
+    init_expectations_db(db)
+    assert_schema(db, EXPECTED_EXPECTATIONS_TABLES)
+
+
+def test_init_all_creates_expectations_db(tmp_path: Path):
+    """init_all wires expectations.db in alongside the other three DBs."""
+    from am_i_shipping.config_loader import (
+        AppSwitchConfig,
+        Config,
+        DataConfig,
+        GitHubConfig,
+        SessionConfig,
+    )
+    from am_i_shipping.db import init_all
+
+    config = Config(
+        session=SessionConfig(projects_path="/fake"),
+        github=GitHubConfig(repos=["a/b"]),
+        appswitch=AppSwitchConfig(),
+        data=DataConfig(data_dir=str(tmp_path / "data")),
+    )
+    init_all(config)
+    assert (tmp_path / "data" / "expectations.db").exists()
+    assert_schema(
+        tmp_path / "data" / "expectations.db", EXPECTED_EXPECTATIONS_TABLES
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure structural detector
+# ---------------------------------------------------------------------------
+
+
+def test_structural_detector_selects_last_user_text_before_tool_use():
+    """Last user text turn before first tool-use is the candidate."""
+    turns = [
+        {"role": "user", "kind": "text", "text": "hi", "index": 0},
+        {"role": "assistant", "kind": "text", "text": "what?", "index": 1},
+        {"role": "user", "kind": "text", "text": "go ahead", "index": 2},
+        {"role": "assistant", "kind": "tool_use", "text": "", "index": 3},
+        {"role": "user", "kind": "text", "text": "later", "index": 4},
+    ]
+    idx = detect_structural_commitment_point(turns)
+    assert idx == 2
+
+
+def test_structural_detector_falls_back_to_last_user_text_if_no_tool_use():
+    turns = [
+        {"role": "user", "kind": "text", "text": "first", "index": 0},
+        {"role": "assistant", "kind": "text", "text": "ok", "index": 1},
+        {"role": "user", "kind": "text", "text": "final", "index": 2},
+    ]
+    idx = detect_structural_commitment_point(turns)
+    assert idx == 2
+
+
+def test_structural_detector_returns_none_for_empty_turns():
+    assert detect_structural_commitment_point([]) is None
+
+
+def test_structural_detector_returns_none_when_no_user_text():
+    turns = [
+        {"role": "assistant", "kind": "text", "text": "hi", "index": 0},
+        {"role": "assistant", "kind": "tool_use", "text": "", "index": 1},
+    ]
+    assert detect_structural_commitment_point(turns) is None
+
+
+# ---------------------------------------------------------------------------
+# Turn extraction + context window
+# ---------------------------------------------------------------------------
+
+
+def test_extract_turns_handles_plain_string_content():
+    blob = json.dumps(
+        [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+    )
+    turns = _extract_turns(blob)
+    assert len(turns) == 2
+    assert turns[0]["role"] == "user" and turns[0]["text"] == "hello"
+
+
+def test_extract_turns_handles_structured_content_list():
+    blob = json.dumps(
+        [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "thinking"},
+                    {"type": "tool_use", "name": "Read"},
+                ],
+            }
+        ]
+    )
+    turns = _extract_turns(blob)
+    assert [t["kind"] for t in turns] == ["text", "tool_use"]
+
+
+def test_extract_turns_handles_malformed_json():
+    assert _extract_turns("{not json") == []
+    assert _extract_turns("") == []
+
+
+def test_surrounding_user_text_window():
+    turns = [
+        {"role": "user", "kind": "text", "text": "a", "index": 0},
+        {"role": "user", "kind": "text", "text": "b", "index": 1},
+        {"role": "user", "kind": "text", "text": "c", "index": 2},
+        {"role": "user", "kind": "text", "text": "d", "index": 3},
+        {"role": "user", "kind": "text", "text": "e", "index": 4},
+    ]
+    ctx = _surrounding_user_text(turns, anchor_idx=2, window=2)
+    assert [text for _i, text in ctx] == ["a", "b", "c", "d", "e"]
+    ctx = _surrounding_user_text(turns, anchor_idx=0, window=2)
+    assert [text for _i, text in ctx] == ["a", "b", "c"]
+
+
+# ---------------------------------------------------------------------------
+# LLM response parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_llm_response_parses_bare_json():
+    text = (
+        '{"commitment_point": "turn 2", "expected_scope": "foo.py", '
+        '"expected_effort": "1 session", "expected_outcome": "tests pass", '
+        '"confidence": 0.8}'
+    )
+    obj = _parse_llm_response(text)
+    assert obj is not None
+    assert obj["commitment_point"] == "turn 2"
+    assert obj["confidence"] == 0.8
+
+
+def test_parse_llm_response_strips_fences():
+    text = "```json\n{\"commitment_point\": \"t\", \"confidence\": 0.3}\n```"
+    obj = _parse_llm_response(text)
+    assert obj is not None
+    assert obj["commitment_point"] == "t"
+
+
+def test_parse_llm_response_returns_none_on_junk():
+    assert _parse_llm_response("no json here") is None
+    assert _parse_llm_response("") is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end (AS-2, AS-3, AS-5, AS-6)
+# ---------------------------------------------------------------------------
+
+
+def _stub_adapter_json(expected_scope: str = "foo.py"):
+    """Return an object with a `.call` method that returns a JSON response."""
+
+    class _Result:
+        def __init__(self, text: str):
+            self.text = text
+            self.cost_usd = 0.0
+            self.input_chars = 0
+            self.output_chars = len(text)
+
+    class _Adapter:
+        def __init__(self):
+            self.calls: list[tuple[str, str, str, int]] = []
+
+        def call(self, system, user, model, max_tokens):
+            self.calls.append((system, user, model, max_tokens))
+            body = {
+                "commitment_point": "turn 0",
+                "expected_scope": expected_scope,
+                "expected_effort": "one session",
+                "expected_outcome": "tests pass",
+                "confidence": 0.75,
+            }
+            return _Result(json.dumps(body))
+
+    return _Adapter()
+
+
+def test_run_extraction_happy_path(tmp_path: Path):
+    """One unit with transcript data → one populated expectations row."""
+    gh, sess, exp = _init_dbs(tmp_path)
+    _seed_unit(gh, unit_id="unit-1", root_node_id="n-unit-1")
+    _seed_session_and_node(
+        gh,
+        sess,
+        unit_root_id="n-unit-1",
+        session_uuid="sess-1",
+        raw_content_json=[
+            {"role": "user", "content": "please refactor foo"},
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "name": "Edit"}],
+            },
+        ],
+    )
+
+    adapter = _stub_adapter_json()
+    with mock.patch(
+        "synthesis.expectations._get_adapter", return_value=adapter
+    ):
+        rc = run_extraction(
+            _make_synthesis_config(),
+            github_db=str(gh),
+            sessions_db=str(sess),
+            expectations_db=str(exp),
+            week_start=WEEK_START,
+        )
+
+    assert rc == 0
+    rows = _expectation_rows(exp)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["unit_id"] == "unit-1"
+    assert row["skip_reason"] is None
+    assert row["commitment_point"] == "turn 0"
+    assert row["expected_scope"] == "foo.py"
+    assert row["confidence"] == 0.75
+    assert row["input_bytes"] > 0
+    assert len(adapter.calls) == 1
+
+
+def test_run_extraction_skip_reason_for_empty_transcript(tmp_path: Path):
+    """A unit whose only session has empty raw_content_json → skip row."""
+    gh, sess, exp = _init_dbs(tmp_path)
+    _seed_unit(gh, unit_id="unit-empty", root_node_id="n-unit-empty")
+    _seed_session_and_node(
+        gh,
+        sess,
+        unit_root_id="n-unit-empty",
+        session_uuid="sess-empty",
+        raw_content_json=None,
+    )
+
+    adapter = _stub_adapter_json()
+    with mock.patch(
+        "synthesis.expectations._get_adapter", return_value=adapter
+    ):
+        rc = run_extraction(
+            _make_synthesis_config(),
+            github_db=str(gh),
+            sessions_db=str(sess),
+            expectations_db=str(exp),
+            week_start=WEEK_START,
+        )
+
+    assert rc == 0
+    rows = _expectation_rows(exp)
+    assert len(rows) == 1
+    assert rows[0]["skip_reason"] == "raw_content_json_empty"
+    assert rows[0]["commitment_point"] is None
+    # LLM was not called for the skipped unit.
+    assert len(adapter.calls) == 0
+
+
+def test_run_extraction_covers_every_unit(tmp_path: Path):
+    """3 units with varying data shapes — all 3 get rows in expectations."""
+    gh, sess, exp = _init_dbs(tmp_path)
+    # Unit A — has transcript.
+    _seed_unit(gh, unit_id="unit-a", root_node_id="n-a")
+    _seed_session_and_node(
+        gh,
+        sess,
+        unit_root_id="n-a",
+        session_uuid="sess-a",
+        raw_content_json=[
+            {"role": "user", "content": "plan accepted"},
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "name": "Edit"}],
+            },
+        ],
+    )
+    # Unit B — session exists but transcript is empty.
+    _seed_unit(gh, unit_id="unit-b", root_node_id="n-b")
+    _seed_session_and_node(
+        gh,
+        sess,
+        unit_root_id="n-b",
+        session_uuid="sess-b",
+        raw_content_json=None,
+    )
+    # Unit C — no graph_nodes at all (unit_root_id isn't referenced).
+    _seed_unit(gh, unit_id="unit-c", root_node_id="n-c-missing")
+
+    adapter = _stub_adapter_json()
+    with mock.patch(
+        "synthesis.expectations._get_adapter", return_value=adapter
+    ):
+        rc = run_extraction(
+            _make_synthesis_config(),
+            github_db=str(gh),
+            sessions_db=str(sess),
+            expectations_db=str(exp),
+            week_start=WEEK_START,
+        )
+
+    assert rc == 0
+    rows = _expectation_rows(exp)
+    got_unit_ids = {r["unit_id"] for r in rows}
+    assert got_unit_ids == {"unit-a", "unit-b", "unit-c"}, (
+        f"expected a row for every unit, got {got_unit_ids}"
+    )
+
+    by_id = {r["unit_id"]: r for r in rows}
+    assert by_id["unit-a"]["skip_reason"] is None
+    assert by_id["unit-b"]["skip_reason"] == "raw_content_json_empty"
+    assert by_id["unit-c"]["skip_reason"] == "raw_content_json_empty"
+
+
+def test_run_extraction_is_idempotent(tmp_path: Path):
+    """Re-running without --rebuild issues zero new LLM calls."""
+    gh, sess, exp = _init_dbs(tmp_path)
+    _seed_unit(gh, unit_id="unit-idem", root_node_id="n-idem")
+    _seed_session_and_node(
+        gh,
+        sess,
+        unit_root_id="n-idem",
+        session_uuid="sess-idem",
+        raw_content_json=[
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "name": "Bash"}],
+            },
+        ],
+    )
+
+    adapter = _stub_adapter_json()
+    with mock.patch(
+        "synthesis.expectations._get_adapter", return_value=adapter
+    ):
+        run_extraction(
+            _make_synthesis_config(),
+            github_db=str(gh),
+            sessions_db=str(sess),
+            expectations_db=str(exp),
+            week_start=WEEK_START,
+        )
+        first_call_count = len(adapter.calls)
+
+        # Second run — no --rebuild flag, should issue zero new calls.
+        run_extraction(
+            _make_synthesis_config(),
+            github_db=str(gh),
+            sessions_db=str(sess),
+            expectations_db=str(exp),
+            week_start=WEEK_START,
+        )
+
+    assert first_call_count == 1
+    assert len(adapter.calls) == 1, (
+        f"idempotent re-run triggered extra calls: {len(adapter.calls)}"
+    )
+
+    rows = _expectation_rows(exp)
+    assert len(rows) == 1
+
+
+def test_run_extraction_rebuild_flag_wipes_and_rebuilds(tmp_path: Path):
+    """--rebuild deletes the week's rows and re-extracts."""
+    gh, sess, exp = _init_dbs(tmp_path)
+    _seed_unit(gh, unit_id="unit-rb", root_node_id="n-rb")
+    _seed_session_and_node(
+        gh,
+        sess,
+        unit_root_id="n-rb",
+        session_uuid="sess-rb",
+        raw_content_json=[
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "name": "Bash"}],
+            },
+        ],
+    )
+
+    adapter = _stub_adapter_json(expected_scope="first.py")
+    with mock.patch(
+        "synthesis.expectations._get_adapter", return_value=adapter
+    ):
+        run_extraction(
+            _make_synthesis_config(),
+            github_db=str(gh),
+            sessions_db=str(sess),
+            expectations_db=str(exp),
+            week_start=WEEK_START,
+        )
+    first_rows = _expectation_rows(exp)
+    assert first_rows[0]["expected_scope"] == "first.py"
+
+    adapter2 = _stub_adapter_json(expected_scope="second.py")
+    with mock.patch(
+        "synthesis.expectations._get_adapter", return_value=adapter2
+    ):
+        run_extraction(
+            _make_synthesis_config(),
+            github_db=str(gh),
+            sessions_db=str(sess),
+            expectations_db=str(exp),
+            week_start=WEEK_START,
+            rebuild=True,
+        )
+
+    second_rows = _expectation_rows(exp)
+    assert len(second_rows) == 1
+    assert second_rows[0]["expected_scope"] == "second.py"
+    assert len(adapter2.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic log (AS-8)
+# ---------------------------------------------------------------------------
+
+
+def test_run_extraction_logs_input_bytes_and_agreement_rate(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
+    gh, sess, exp = _init_dbs(tmp_path)
+    _seed_unit(gh, unit_id="unit-log", root_node_id="n-log")
+    _seed_session_and_node(
+        gh,
+        sess,
+        unit_root_id="n-log",
+        session_uuid="sess-log",
+        raw_content_json=[
+            {"role": "user", "content": "plan"},
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "name": "Edit"}],
+            },
+        ],
+    )
+
+    adapter = _stub_adapter_json()
+    with caplog.at_level(logging.INFO, logger="synthesis.expectations"):
+        with mock.patch(
+            "synthesis.expectations._get_adapter", return_value=adapter
+        ):
+            run_extraction(
+                _make_synthesis_config(),
+                github_db=str(gh),
+                sessions_db=str(sess),
+                expectations_db=str(exp),
+                week_start=WEEK_START,
+            )
+
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "input_bytes=" in joined, (
+        f"expected per-unit input_bytes log line, got: {joined}"
+    )
+    assert "agreement_rate=" in joined, (
+        f"expected run-level agreement_rate summary, got: {joined}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Performance budget (AS-7)
+# ---------------------------------------------------------------------------
+
+
+def test_run_extraction_50_units_under_120s(tmp_path: Path):
+    """50 units with offline adapter completes in <120s."""
+    gh, sess, exp = _init_dbs(tmp_path)
+
+    # Seed 50 units. Half have transcripts (LLM path), half don't (skip).
+    for i in range(50):
+        unit_id = f"unit-{i:02d}"
+        root = f"n-{i:02d}"
+        _seed_unit(gh, unit_id=unit_id, root_node_id=root)
+        if i % 2 == 0:
+            _seed_session_and_node(
+                gh,
+                sess,
+                unit_root_id=root,
+                session_uuid=f"sess-{i:02d}",
+                raw_content_json=[
+                    {"role": "user", "content": f"plan {i}"},
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "tool_use", "name": "Edit"}],
+                    },
+                ],
+            )
+
+    adapter = _stub_adapter_json()
+    start = time.time()
+    with mock.patch(
+        "synthesis.expectations._get_adapter", return_value=adapter
+    ):
+        rc = run_extraction(
+            _make_synthesis_config(),
+            github_db=str(gh),
+            sessions_db=str(sess),
+            expectations_db=str(exp),
+            week_start=WEEK_START,
+        )
+    elapsed = time.time() - start
+
+    assert rc == 0
+    assert elapsed < 120.0, f"50-unit extraction took {elapsed:.1f}s (>120)"
+
+    rows = _expectation_rows(exp)
+    assert len(rows) == 50
+
+
+# ---------------------------------------------------------------------------
+# Empty week is a no-op
+# ---------------------------------------------------------------------------
+
+
+def test_run_extraction_empty_week_is_noop(tmp_path: Path):
+    gh, sess, exp = _init_dbs(tmp_path)
+    rc = run_extraction(
+        _make_synthesis_config(),
+        github_db=str(gh),
+        sessions_db=str(sess),
+        expectations_db=str(exp),
+        week_start="2099-01-01",
+    )
+    assert rc == 0
+    assert _expectation_rows(exp, "2099-01-01") == []


### PR DESCRIPTION
Resolves #72 (sub-issue 1/5 of epic #27 — Expectation Calibration Layer).

## Summary
- New `expectations.db` with a single `expectations` table — standalone SQLite file under `config.data_path`, initialized by `am-init-db` via `init_expectations_db()` wired into `init_all()`.
- New `am-extract-expectations --week <YYYY-MM-DD> [--rebuild]` CLI that, for every unit in the week, either (a) writes a populated row with `commitment_point`, `expected_scope`, `expected_effort`, `expected_outcome`, `confidence`, or (b) writes exactly one row with a non-NULL `skip_reason`. No unit is ever silently absent.
- Hybrid commitment-point detection: pure structural detector (last user text turn before first tool-use turn) provides a candidate; Sonnet confirms or reassigns via the ±2 surrounding user text turns. Confidence is surfaced as-returned — never silently suppressed.
- Diagnostic logging: per-unit `input_bytes` (INFO) and a run-level structural-vs-LLM `agreement_rate` summary. These are the signals that surface the system-feared failure mode (sparse `raw_content_json` producing structurally-valid-but-meaningless expectations) before downstream calibration in X-2 through X-5 locks in on noise.
- Idempotent: re-running without `--rebuild` issues zero new LLM calls for already-extracted units.

## Design decisions
- `expected_effort` stored as free-text `TEXT` per the refined spec default (OQ-1). Structured effort parsing can be added pre-X-2 without renaming.
- Reuses `synthesis.weekly._unit_nodes`, `synthesis.weekly._load_session_transcripts`, and `synthesis.llm_adapter._get_adapter` unchanged.
- Low-confidence rows are populated, not converted to skip rows; `skip_reason` is reserved for structural failure (empty `raw_content_json`, no text turns, LLM declined / unparseable response).

## Test plan
- [x] `pytest tests/test_expectations.py` — 22 tests pass (schema, pure detector, JSON parsing, happy path, 3-unit coverage, skip reasons, idempotency, rebuild, log output, 50-unit perf budget, empty-week no-op).
- [x] `pytest tests/test_init_db.py tests/test_summarize.py` — 28 passed (no regression).
- [x] Full suite `pytest` — 540 passed, 23 skipped (no regression).

Note: this is `--return-only` mode; PR targets `epic/27-expectation-calibration` and is not merged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)