### PR TITLE
feat(#73): X-2 gap analysis — expectation_gaps + workflow-failure attribution

### DIFF
--- a/am_i_shipping/db.py
+++ b/am_i_shipping/db.py
@@ -274,6 +274,51 @@ CREATE TABLE IF NOT EXISTS expectations (
 );
 """
 
+# Epic #27 — X-2 (#73): expectation_gaps schema.
+#
+# Written by ``synthesis.gap_analysis.run`` during ``am-synthesize``.
+# Every row is joined to an ``expectations`` row by ``(week_start, unit_id)``.
+#
+# IRREVERSIBLE column names (per the epic ADR): ``commitment_point``,
+# ``scope_gap``, ``effort_gap``, ``outcome_gap``. X-4 user corrections and
+# X-5 calibration both key off these names; renaming after X-4 ships is
+# expensive. Locked here.
+#
+# * ``severity``            — one of {``none``, ``minor``, ``major``, ``critical``}.
+# * ``direction``           — one of {``under``, ``over``, ``match``, ``ambiguous``}.
+# * ``failure_precondition``— constrained enum drawn from ``idealized-workflow.md``
+#                             phase/step identifiers. NULL when ``severity='none'``;
+#                             non-NULL otherwise.
+# * ``auto_confirmed``      — introduced in X-2 for X-4's hook. 0 by default;
+#                             flipped to 1 by the auto-confirm sweep for rows
+#                             older than 14 days without a user correction.
+SYNTHESIS_EXPECTATION_GAPS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS expectation_gaps (
+    week_start           TEXT NOT NULL,
+    unit_id              TEXT NOT NULL,
+    commitment_point     TEXT,
+    scope_gap            TEXT,
+    effort_gap           TEXT,
+    outcome_gap          TEXT,
+    severity             TEXT,
+    direction            TEXT,
+    failure_precondition TEXT,
+    computed_at          TEXT DEFAULT (datetime('now')),
+    auto_confirmed       INTEGER DEFAULT 0,
+    PRIMARY KEY (week_start, unit_id)
+);
+"""
+
+# Columns added after the initial schema — migrated on init. Applied inside
+# ``init_expectations_db`` against an already-open connection so repeated runs
+# are a no-op.
+_EXPECTATIONS_MIGRATIONS = [
+    # X-2 added ``auto_confirmed`` to ``expectation_gaps``. The CREATE above
+    # already includes the column on fresh DBs; the migration handles DBs
+    # that shipped X-2 with an earlier column set.
+    "ALTER TABLE expectation_gaps ADD COLUMN auto_confirmed INTEGER DEFAULT 0",
+]
+
 EXPECTED_EXPECTATIONS_TABLES: dict[str, set[str]] = {
     "expectations": {
         "week_start",
@@ -287,6 +332,19 @@ EXPECTED_EXPECTATIONS_TABLES: dict[str, set[str]] = {
         "input_bytes",
         "extracted_at",
         "skip_reason",
+    },
+    "expectation_gaps": {
+        "week_start",
+        "unit_id",
+        "commitment_point",
+        "scope_gap",
+        "effort_gap",
+        "outcome_gap",
+        "severity",
+        "direction",
+        "failure_precondition",
+        "computed_at",
+        "auto_confirmed",
     },
 }
 
@@ -671,6 +729,13 @@ def init_expectations_db(db_path: Path) -> None:
     conn = sqlite3.connect(str(db_path))
     try:
         conn.execute(SYNTHESIS_EXPECTATIONS_SCHEMA)
+        # Epic #27 — X-2 (#73): expectation_gaps lives in the same DB.
+        conn.execute(SYNTHESIS_EXPECTATION_GAPS_SCHEMA)
+        for migration in _EXPECTATIONS_MIGRATIONS:
+            try:
+                conn.execute(migration)
+            except sqlite3.OperationalError:
+                pass  # column already exists
         conn.commit()
         # Assert on the same connection we just wrote to (for ':memory:'
         # databases; see init_sessions_db for the rationale).

--- a/synthesis/cli.py
+++ b/synthesis/cli.py
@@ -92,6 +92,10 @@ def _run_weekly(args: argparse.Namespace) -> int:
     data_dir: Path = config.data_path
     github_db = data_dir / "github.db"
     sessions_db = data_dir / "sessions.db"
+    # Epic #27 — X-2 (#73): expectations.db hosts both X-1 expectation rows
+    # and the X-2 expectation_gaps table. Path only — existence is not
+    # required; ``run_synthesis`` handles the missing-DB case gracefully.
+    expectations_db = data_dir / "expectations.db"
 
     synthesis_cfg = config.synthesis
     output_dir = config.synthesis_output_path
@@ -104,6 +108,7 @@ def _run_weekly(args: argparse.Namespace) -> int:
             sessions_db,
             args.week,
             dry_run=args.dry_run,
+            expectations_db=expectations_db,
         )
     except Exception:  # noqa: BLE001 — CLI is the top of the stack
         logging.exception("Synthesis failed")

--- a/synthesis/gap_analysis.py
+++ b/synthesis/gap_analysis.py
@@ -1,0 +1,663 @@
+"""Epic #27 — X-2 (#73): per-unit expectation vs. actual gap analysis.
+
+Joins ``expectations`` rows (from X-1, stored in ``expectations.db``) with
+actual-outcome metrics (from ``units`` and ``unit_summaries`` in
+``github.db``), computes a per-facet gap (scope / effort / outcome),
+assigns a coarse severity + direction, and attributes any non-``none``
+severity to a specific idealized-workflow precondition.
+
+Output lands in the ``expectation_gaps`` table (schema owned by
+:mod:`am_i_shipping.db`). One row per ``(week_start, unit_id)`` that has
+an expectation row. Column names (``commitment_point``, ``scope_gap``,
+``effort_gap``, ``outcome_gap``) are IRREVERSIBLE per the epic ADR.
+
+Behavioral invariants (from the refined spec):
+
+* **One gap row per expectation row.** Every unit with an expectations
+  row produces exactly one gap row. A unit without an expectations row
+  produces no gap row.
+* **Constrained ``failure_precondition`` enum.** Drawn from
+  ``idealized-workflow.md``. NULL only when ``severity='none'``.
+* **Idempotent re-runs.** On each invocation, existing gap rows for the
+  target week are deleted and rewritten. The retrospective ``.md``
+  refuse-to-overwrite guard (Epic #17 Decision 2) is unaffected — all
+  persistent state lives in ``expectations.db``, never in the ``.md``.
+* **Auto-confirm sweep.** Gap rows with ``computed_at`` older than 14
+  days and ``auto_confirmed=0`` are flipped to 1 on every run. X-4 will
+  read / override this column later.
+* **Offline parity.** When ``AMIS_SYNTHESIS_LIVE`` is unset the
+  :class:`FakeAnthropicClient` path returns a deterministic canned
+  JSON; severity computation is a pure function and does not require an
+  API call.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from am_i_shipping.config_loader import SynthesisConfig
+from synthesis.llm_adapter import _get_adapter
+
+
+logger = logging.getLogger(__name__)
+
+
+_MAX_OUTPUT_TOKENS = 512
+
+
+# The constrained enum for ``failure_precondition``. Any value returned by
+# the classifier that is not in this set is coerced to ``phase_0_setup`` —
+# the setup phase is the "unknown root cause" bucket because it upstream of
+# every design-phase step.
+FAILURE_PRECONDITION_ENUM: tuple[str, ...] = (
+    "phase_0_setup",
+    "step_1_intent",
+    "step_2_motivation",
+    "step_3_motivation_confirmed",
+    "step_4_plan",
+    "step_5_plan_confirmed",
+)
+
+SEVERITY_ENUM: tuple[str, ...] = ("none", "minor", "major", "critical")
+DIRECTION_ENUM: tuple[str, ...] = ("under", "over", "match", "ambiguous")
+
+
+_GAP_SYSTEM_PROMPT = """You are attributing a software-development unit's \
+expectation / actual gap to a specific step of the idealized workflow for \
+a retrospective calibration system.
+
+The idealized workflow steps (closed set):
+- phase_0_setup: CLAUDE.md, hooks, venv, tooling — the standing preconditions.
+- step_1_intent: user stated the intent.
+- step_2_motivation: Claude disambiguated the motivation.
+- step_3_motivation_confirmed: the motivation was locked in.
+- step_4_plan: Claude proposed a bounded plan.
+- step_5_plan_confirmed: the plan was accepted.
+
+You will be given the unit's expectations (scope / effort / outcome at the \
+commitment point), the actual outcome metrics (elapsed_days, \
+total_reprompts, review_cycles, status), and the unit summary text. \
+Decide:
+
+1. severity: one of none | minor | major | critical.
+   Rubric (apply within the LLM, not externally):
+   * none     — actual matched expected across all three facets.
+   * minor    — one facet deviated but the unit completed as expected.
+   * major    — two+ facets deviated OR one facet deviated significantly \
+(>2x expected effort, scope doubled, outcome partially missed).
+   * critical — outcome missed entirely OR unit abandoned.
+2. direction: one of under | over | match | ambiguous.
+3. failure_precondition: which idealized-workflow step was the root cause.
+   Must be one of phase_0_setup, step_1_intent, step_2_motivation, \
+step_3_motivation_confirmed, step_4_plan, step_5_plan_confirmed. \
+Set to null when severity is 'none'.
+4. scope_gap, effort_gap, outcome_gap: one-sentence descriptions of the \
+deviation for each facet. Use empty string (\"\") when there is no gap.
+
+Return a single JSON object with exactly these keys:
+  severity, direction, failure_precondition,
+  scope_gap, effort_gap, outcome_gap
+
+Do NOT wrap in Markdown fences. Do NOT add extra keys."""
+
+
+# ---------------------------------------------------------------------------
+# Pure-function severity / direction heuristic
+# ---------------------------------------------------------------------------
+
+
+def compute_severity_direction(
+    *,
+    status: Optional[str],
+    total_reprompts: Optional[int],
+    review_cycles: Optional[int],
+    elapsed_days: Optional[float],
+    expected_effort: Optional[str],
+    expected_outcome: Optional[str],
+    skip_reason: Optional[str],
+) -> Tuple[str, str]:
+    """Return ``(severity, direction)`` from actual-outcome metrics.
+
+    Pure function, no I/O. Used as a pre-LLM baseline and as the sole
+    severity source in offline mode (the fake client does not return
+    rubric-driven JSON).
+
+    Heuristic:
+
+    * ``skip_reason`` non-empty → severity ``none``, direction
+      ``ambiguous`` (no expectation to compare against).
+    * ``status`` in {abandoned, open, stale} → severity ``critical``,
+      direction ``under`` (the unit did not reach its expected
+      outcome).
+    * ``total_reprompts >= 10`` or ``review_cycles >= 5`` → severity
+      ``major``, direction ``over`` (the user had to intervene far
+      more than expected).
+    * ``total_reprompts >= 4`` or ``review_cycles >= 2`` → severity
+      ``minor``, direction ``over``.
+    * Otherwise → severity ``none``, direction ``match``.
+
+    The thresholds are intentionally coarse — the epic's "ship skeleton
+    over plan to perfection" decision prior. Tune from X-4 corrections.
+    """
+    if skip_reason:
+        return "none", "ambiguous"
+
+    status_norm = (status or "").strip().lower()
+    if status_norm in {"abandoned", "open", "stale", "stalled"}:
+        return "critical", "under"
+
+    reprompts = total_reprompts if isinstance(total_reprompts, (int, float)) else 0
+    reviews = review_cycles if isinstance(review_cycles, (int, float)) else 0
+
+    if reprompts >= 10 or reviews >= 5:
+        return "major", "over"
+    if reprompts >= 4 or reviews >= 2:
+        return "minor", "over"
+    return "none", "match"
+
+
+# ---------------------------------------------------------------------------
+# LLM plumbing
+# ---------------------------------------------------------------------------
+
+
+def _parse_llm_response(response_text: str) -> Optional[Dict[str, Any]]:
+    """Parse the classifier's JSON response. Returns ``None`` on failure."""
+    if not response_text:
+        return None
+    m = re.search(r"\{.*\}", response_text, re.DOTALL)
+    if not m:
+        return None
+    try:
+        obj = json.loads(m.group(0))
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(obj, dict):
+        return None
+    return obj
+
+
+def _coerce_failure_precondition(value: Any, severity: str) -> Optional[str]:
+    """Coerce the LLM's ``failure_precondition`` into the allowed enum.
+
+    Returns ``None`` when ``severity='none'`` (per the spec). Otherwise
+    maps out-of-enum values to ``phase_0_setup`` — the catch-all
+    "something upstream failed" bucket.
+    """
+    if severity == "none":
+        return None
+    if isinstance(value, str) and value in FAILURE_PRECONDITION_ENUM:
+        return value
+    # Unknown / missing → fall back to setup phase (root of all downstream
+    # design-phase failures per idealized-workflow.md).
+    return "phase_0_setup"
+
+
+def _coerce_enum(value: Any, allowed: tuple[str, ...], fallback: str) -> str:
+    if isinstance(value, str) and value in allowed:
+        return value
+    return fallback
+
+
+# ---------------------------------------------------------------------------
+# Input assembly
+# ---------------------------------------------------------------------------
+
+
+def _build_unit_input(
+    expectation: Dict[str, Any],
+    unit: Dict[str, Any],
+    summary_text: Optional[str],
+) -> str:
+    """Assemble the LLM input for one unit.
+
+    Combines the expectation facets with actual-outcome metrics and the
+    summary text. Pure function — tests can feed hand-built dicts.
+    """
+    parts: List[str] = []
+    parts.append(f"## Unit: {expectation['unit_id']}")
+    parts.append(f"## Week: {expectation['week_start']}")
+    parts.append("")
+    parts.append("### Expectations (from X-1 at commitment point)")
+    parts.append(
+        f"- commitment_point: {expectation.get('commitment_point') or '(unknown)'}"
+    )
+    parts.append(
+        f"- expected_scope: {expectation.get('expected_scope') or '(unknown)'}"
+    )
+    parts.append(
+        f"- expected_effort: {expectation.get('expected_effort') or '(unknown)'}"
+    )
+    parts.append(
+        f"- expected_outcome: {expectation.get('expected_outcome') or '(unknown)'}"
+    )
+    parts.append("")
+    parts.append("### Actual outcome (from units table)")
+    parts.append(f"- status: {unit.get('status')}")
+    parts.append(f"- elapsed_days: {unit.get('elapsed_days')}")
+    parts.append(f"- total_reprompts: {unit.get('total_reprompts')}")
+    parts.append(f"- review_cycles: {unit.get('review_cycles')}")
+    parts.append(f"- dark_time_pct: {unit.get('dark_time_pct')}")
+    parts.append(f"- outlier_flags: {unit.get('outlier_flags')}")
+    parts.append(f"- abandonment_flag: {unit.get('abandonment_flag')}")
+    parts.append("")
+    parts.append("### Unit summary (narrative)")
+    parts.append(summary_text or "(no summary available)")
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_expectations(
+    exp_conn: sqlite3.Connection, week_start: str
+) -> List[Dict[str, Any]]:
+    rows = exp_conn.execute(
+        "SELECT week_start, unit_id, commitment_point, expected_scope, "
+        "       expected_effort, expected_outcome, confidence, skip_reason "
+        "FROM expectations WHERE week_start = ? ORDER BY unit_id",
+        (week_start,),
+    ).fetchall()
+    return [
+        {
+            "week_start": r[0],
+            "unit_id": r[1],
+            "commitment_point": r[2],
+            "expected_scope": r[3],
+            "expected_effort": r[4],
+            "expected_outcome": r[5],
+            "confidence": r[6],
+            "skip_reason": r[7],
+        }
+        for r in rows
+    ]
+
+
+def _load_units_by_id(
+    gh_conn: sqlite3.Connection, week_start: str
+) -> Dict[str, Dict[str, Any]]:
+    rows = gh_conn.execute(
+        "SELECT unit_id, root_node_type, root_node_id, elapsed_days, "
+        "       dark_time_pct, total_reprompts, review_cycles, status, "
+        "       outlier_flags, abandonment_flag "
+        "FROM units WHERE week_start = ?",
+        (week_start,),
+    ).fetchall()
+    return {
+        r[0]: {
+            "unit_id": r[0],
+            "root_node_type": r[1],
+            "root_node_id": r[2],
+            "elapsed_days": r[3],
+            "dark_time_pct": r[4],
+            "total_reprompts": r[5],
+            "review_cycles": r[6],
+            "status": r[7],
+            "outlier_flags": r[8],
+            "abandonment_flag": r[9],
+        }
+        for r in rows
+    }
+
+
+def _load_unit_summaries(
+    gh_conn: sqlite3.Connection, week_start: str
+) -> Dict[str, str]:
+    try:
+        rows = gh_conn.execute(
+            "SELECT unit_id, summary_text FROM unit_summaries "
+            "WHERE week_start = ?",
+            (week_start,),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return {}
+    return {r[0]: r[1] for r in rows}
+
+
+def _replace_gap_rows(
+    exp_conn: sqlite3.Connection, week_start: str
+) -> None:
+    """DELETE existing gap rows for the week (idempotent re-run)."""
+    exp_conn.execute(
+        "DELETE FROM expectation_gaps WHERE week_start = ?", (week_start,)
+    )
+    exp_conn.commit()
+
+
+def _insert_gap_row(
+    exp_conn: sqlite3.Connection,
+    *,
+    week_start: str,
+    unit_id: str,
+    commitment_point: Optional[str],
+    scope_gap: Optional[str],
+    effort_gap: Optional[str],
+    outcome_gap: Optional[str],
+    severity: str,
+    direction: str,
+    failure_precondition: Optional[str],
+) -> None:
+    exp_conn.execute(
+        "INSERT OR REPLACE INTO expectation_gaps "
+        "(week_start, unit_id, commitment_point, scope_gap, effort_gap, "
+        " outcome_gap, severity, direction, failure_precondition, "
+        " computed_at, auto_confirmed) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), 0)",
+        (
+            week_start,
+            unit_id,
+            commitment_point,
+            scope_gap,
+            effort_gap,
+            outcome_gap,
+            severity,
+            direction,
+            failure_precondition,
+        ),
+    )
+
+
+def _auto_confirm_sweep(
+    exp_conn: sqlite3.Connection, *, days: int = 14
+) -> int:
+    """Flip ``auto_confirmed=1`` on gap rows older than *days* days.
+
+    Rows younger than *days* are unchanged. Returns the number of rows
+    updated. Safe to call when the table is empty — returns 0.
+    """
+    cutoff = (
+        datetime.now(timezone.utc) - timedelta(days=days)
+    ).strftime("%Y-%m-%d %H:%M:%S")
+    cur = exp_conn.execute(
+        "UPDATE expectation_gaps SET auto_confirmed = 1 "
+        "WHERE auto_confirmed = 0 AND computed_at IS NOT NULL "
+        "  AND computed_at < ?",
+        (cutoff,),
+    )
+    exp_conn.commit()
+    return cur.rowcount or 0
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run(
+    week_start: str,
+    *,
+    github_db: str,
+    expectations_db: str,
+    config: Optional[SynthesisConfig] = None,
+) -> int:
+    """Compute gap rows for every unit with an expectations row in *week_start*.
+
+    Parameters
+    ----------
+    week_start:
+        ``YYYY-MM-DD`` anchor.
+    github_db:
+        Path to ``github.db`` (read-only for this module). Must contain
+        ``units`` and, ideally, ``unit_summaries`` rows.
+    expectations_db:
+        Path to ``expectations.db``. Must already be initialized (the
+        caller is expected to have run ``init_expectations_db``). Written
+        to — both ``expectation_gaps`` and the auto-confirm sweep land
+        here.
+    config:
+        Optional :class:`SynthesisConfig`. Required for the LLM call in
+        live mode. When ``None`` (or in offline / fake-adapter mode) the
+        pure-function severity heuristic is used without an LLM call.
+
+    Returns
+    -------
+    Number of gap rows written for the week. ``0`` is a valid no-op
+    (either no expectations rows exist for the week, or
+    ``expectations.db`` has no ``expectation_gaps`` content post-sweep).
+    """
+    exp_conn = sqlite3.connect(str(expectations_db))
+    gh_conn = sqlite3.connect(str(github_db))
+    # Pre-flight: make sure the auto-confirm sweep does not fail with
+    # ``no such table`` on a freshly-created DB whose X-2 slice has not
+    # been applied. Caller SHOULD have run init already — this is belt +
+    # braces.
+    try:
+        exp_conn.execute("SELECT 1 FROM expectation_gaps LIMIT 1").fetchall()
+    except sqlite3.OperationalError:
+        logger.warning(
+            "expectation_gaps table missing — caller did not run "
+            "init_expectations_db; skipping gap pass for week=%s",
+            week_start,
+        )
+        exp_conn.close()
+        gh_conn.close()
+        return 0
+
+    try:
+        expectations = _load_expectations(exp_conn, week_start)
+        if not expectations:
+            logger.info(
+                "No expectations rows for week=%s; gap pass is a no-op",
+                week_start,
+            )
+            # Still run the auto-confirm sweep — old rows may still exist.
+            _auto_confirm_sweep(exp_conn)
+            return 0
+
+        units_by_id = _load_units_by_id(gh_conn, week_start)
+        summaries = _load_unit_summaries(gh_conn, week_start)
+
+        _replace_gap_rows(exp_conn, week_start)
+
+        # Select adapter lazily: offline mode uses the heuristic only and
+        # never calls the LLM. Live mode calls the LLM for the facet
+        # descriptions + failure_precondition attribution.
+        adapter = None
+        if config is not None:
+            try:
+                adapter = _get_adapter(config)
+            except Exception as exc:  # noqa: BLE001 — don't break pipeline
+                logger.warning(
+                    "gap_analysis: adapter init failed (%s); falling back "
+                    "to heuristic-only severity", exc,
+                )
+                adapter = None
+
+        written = 0
+        for exp in expectations:
+            unit_id = exp["unit_id"]
+            unit = units_by_id.get(unit_id, {})
+            summary = summaries.get(unit_id)
+
+            base_severity, base_direction = compute_severity_direction(
+                status=unit.get("status"),
+                total_reprompts=unit.get("total_reprompts"),
+                review_cycles=unit.get("review_cycles"),
+                elapsed_days=unit.get("elapsed_days"),
+                expected_effort=exp.get("expected_effort"),
+                expected_outcome=exp.get("expected_outcome"),
+                skip_reason=exp.get("skip_reason"),
+            )
+
+            severity = base_severity
+            direction = base_direction
+            scope_gap_text: Optional[str] = None
+            effort_gap_text: Optional[str] = None
+            outcome_gap_text: Optional[str] = None
+            failure_precondition: Optional[str] = None
+
+            if adapter is not None:
+                user_text = _build_unit_input(exp, unit, summary)
+                try:
+                    result = adapter.call(
+                        _GAP_SYSTEM_PROMPT,
+                        user_text,
+                        config.model if config else "claude-sonnet-4-5",
+                        _MAX_OUTPUT_TOKENS,
+                    )
+                    parsed = _parse_llm_response(result.text)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "gap_analysis LLM call failed for unit=%s: %s — "
+                        "falling back to heuristic",
+                        unit_id, exc,
+                    )
+                    parsed = None
+
+                if parsed:
+                    severity = _coerce_enum(
+                        parsed.get("severity"), SEVERITY_ENUM, base_severity
+                    )
+                    direction = _coerce_enum(
+                        parsed.get("direction"), DIRECTION_ENUM, base_direction
+                    )
+                    failure_precondition = _coerce_failure_precondition(
+                        parsed.get("failure_precondition"), severity
+                    )
+                    scope_gap_text = (
+                        parsed.get("scope_gap")
+                        if isinstance(parsed.get("scope_gap"), str)
+                        else None
+                    )
+                    effort_gap_text = (
+                        parsed.get("effort_gap")
+                        if isinstance(parsed.get("effort_gap"), str)
+                        else None
+                    )
+                    outcome_gap_text = (
+                        parsed.get("outcome_gap")
+                        if isinstance(parsed.get("outcome_gap"), str)
+                        else None
+                    )
+
+            # Offline / no-adapter / LLM-declined path: derive
+            # failure_precondition from heuristic.
+            if failure_precondition is None and severity != "none":
+                failure_precondition = _heuristic_failure_precondition(
+                    severity, direction, unit
+                )
+
+            _insert_gap_row(
+                exp_conn,
+                week_start=week_start,
+                unit_id=unit_id,
+                commitment_point=exp.get("commitment_point"),
+                scope_gap=scope_gap_text,
+                effort_gap=effort_gap_text,
+                outcome_gap=outcome_gap_text,
+                severity=severity,
+                direction=direction,
+                failure_precondition=failure_precondition,
+            )
+            written += 1
+
+        exp_conn.commit()
+
+        # Auto-confirm sweep — on every run, regardless of whether new
+        # rows were written.
+        swept = _auto_confirm_sweep(exp_conn)
+
+        logger.info(
+            "gap_analysis complete: week=%s gaps_written=%d auto_confirmed=%d",
+            week_start, written, swept,
+        )
+        return written
+    finally:
+        exp_conn.close()
+        gh_conn.close()
+
+
+def _heuristic_failure_precondition(
+    severity: str, direction: str, unit: Dict[str, Any]
+) -> str:
+    """Map a heuristic-only gap to a workflow step.
+
+    Used when no LLM is available (offline mode) or the LLM declined.
+    The mapping is intentionally coarse:
+
+    * abandoned / stalled units → ``step_3_motivation_confirmed`` (the
+      motivation evaporated after scoping revealed the true cost).
+    * ``over`` direction with high reprompts → ``step_4_plan`` (the
+      plan did not anticipate the required work).
+    * ``over`` with moderate reprompts → ``step_5_plan_confirmed`` (the
+      user accepted a plan they could not fully evaluate).
+    * everything else → ``phase_0_setup`` (the catch-all "something
+      upstream was missing" bucket).
+    """
+    status = (unit.get("status") or "").strip().lower()
+    if status in {"abandoned", "stale", "stalled", "open"}:
+        return "step_3_motivation_confirmed"
+    reprompts = unit.get("total_reprompts") or 0
+    if direction == "over" and reprompts >= 10:
+        return "step_4_plan"
+    if direction == "over":
+        return "step_5_plan_confirmed"
+    return "phase_0_setup"
+
+
+def load_gap_rows(
+    expectations_db: str,
+    week_start: str,
+    *,
+    min_severity: Optional[tuple[str, ...]] = None,
+) -> List[Dict[str, Any]]:
+    """Return gap rows for *week_start*, optionally filtered by severity.
+
+    *min_severity* is a tuple of severities to include (e.g.
+    ``("major", "critical")`` for retrospective rendering). ``None``
+    returns every row.
+    """
+    conn = sqlite3.connect(str(expectations_db))
+    try:
+        if min_severity is None:
+            rows = conn.execute(
+                "SELECT unit_id, commitment_point, scope_gap, effort_gap, "
+                "       outcome_gap, severity, direction, "
+                "       failure_precondition "
+                "FROM expectation_gaps WHERE week_start = ? "
+                "ORDER BY unit_id",
+                (week_start,),
+            ).fetchall()
+        else:
+            placeholders = ",".join("?" * len(min_severity))
+            rows = conn.execute(
+                f"SELECT unit_id, commitment_point, scope_gap, effort_gap, "
+                f"       outcome_gap, severity, direction, "
+                f"       failure_precondition "
+                f"FROM expectation_gaps "
+                f"WHERE week_start = ? AND severity IN ({placeholders}) "
+                f"ORDER BY unit_id",
+                [week_start, *min_severity],
+            ).fetchall()
+        return [
+            {
+                "unit_id": r[0],
+                "commitment_point": r[1],
+                "scope_gap": r[2],
+                "effort_gap": r[3],
+                "outcome_gap": r[4],
+                "severity": r[5],
+                "direction": r[6],
+                "failure_precondition": r[7],
+            }
+            for r in rows
+        ]
+    finally:
+        conn.close()
+
+
+__all__ = [
+    "FAILURE_PRECONDITION_ENUM",
+    "SEVERITY_ENUM",
+    "DIRECTION_ENUM",
+    "compute_severity_direction",
+    "load_gap_rows",
+    "run",
+]

--- a/synthesis/weekly.py
+++ b/synthesis/weekly.py
@@ -406,6 +406,12 @@ Required Markdown sections (exact headings, in order)
 6. `## Clarifying Questions`      — at most TWO total, numbered `1.`
    and `2.`. Each question should be answerable from the user's memory
    of the week — no research required.
+7. `## Expectation Gaps`          — units whose expected vs. actual gap
+   was `major` or `critical`. Each item names the unit, the direction
+   of the gap (`under`/`over`/`match`/`ambiguous`), and the idealized-
+   workflow step (`phase_0_setup` / `step_1_intent` / ...) that was the
+   root-cause precondition. Omit the section body when no major or
+   critical gaps exist; keep the heading.
 
 Constraints
 -----------
@@ -492,12 +498,42 @@ def _format_unit_block(
     return "\n".join(lines)
 
 
+def _render_gap_block(gap_rows: List[dict]) -> List[str]:
+    """Render the ``## Expectation Gaps`` Markdown block for the prompt.
+
+    Only major and critical rows are included — minor and none rows live
+    in ``expectation_gaps`` for X-5 calibration but do not appear in the
+    retrospective (signal density). Returns a list of lines; empty list
+    when there is nothing to render (the caller then skips adding the
+    header).
+    """
+    if not gap_rows:
+        return []
+    lines: List[str] = ["", "## Expectation Gaps (from X-2 gap analysis)", ""]
+    for row in gap_rows:
+        unit_id = row.get("unit_id")
+        severity = row.get("severity") or ""
+        direction = row.get("direction") or ""
+        fp = row.get("failure_precondition") or ""
+        lines.append(
+            f"- unit {unit_id}: severity={severity}, direction={direction}, "
+            f"failure_precondition={fp}"
+        )
+        for key in ("scope_gap", "effort_gap", "outcome_gap"):
+            val = row.get(key)
+            if val:
+                lines.append(f"    - {key}: {val}")
+    lines.append("")
+    return lines
+
+
 def _assemble_prompt(
     units: List[dict],
     unit_transcripts: dict,
     unit_timelines: dict,
     week_start: str,
     unit_attributions: Optional[dict] = None,
+    gap_rows: Optional[List[dict]] = None,
 ) -> Tuple[str, List[dict]]:
     """Return (system_prompt, user_messages) for the synthesis call.
 
@@ -536,6 +572,12 @@ def _assemble_prompt(
                 )
             body_parts.append("")
 
+    # Epic #27 — X-2 (#73): inject gap rows into the user message so the
+    # LLM can reason about them. Only major/critical are surfaced here;
+    # minor/none stay in the DB for X-5 calibration.
+    if gap_rows:
+        body_parts.extend(_render_gap_block(gap_rows))
+
     user_content = "\n".join(body_parts)
     return _STATIC_SYSTEM_PROMPT, [{"role": "user", "content": user_content}]
 
@@ -556,6 +598,7 @@ def run_synthesis(
     sessions_db: Union[str, Path],
     week_start: str,
     dry_run: bool = False,
+    expectations_db: Optional[Union[str, Path]] = None,
 ) -> Optional[Path]:
     """End-to-end weekly synthesis for *week_start*.
 
@@ -742,8 +785,49 @@ def run_synthesis(
                         gh_conn, week_start, repo_part, issue_number, session_uuids
                     )
 
+        # Epic #27 — X-2 (#73): run the gap pass before prompt assembly so
+        # gap rows are available to inject into the user message. Silent
+        # no-op when expectations_db is None (operator has not wired X-1
+        # yet) or the DB has no expectations rows for this week.
+        gap_rows: List[dict] = []
+        if expectations_db is not None:
+            from synthesis import gap_analysis
+
+            try:
+                gap_analysis.run(
+                    week_start,
+                    github_db=str(gh_path),
+                    expectations_db=str(expectations_db),
+                    config=config,
+                )
+                gap_rows = gap_analysis.load_gap_rows(
+                    str(expectations_db),
+                    week_start,
+                    min_severity=("major", "critical"),
+                )
+            except sqlite3.OperationalError as exc:
+                # Most likely: expectations.db not initialised yet (X-1
+                # hasn't been run). Log a warning and proceed without the
+                # gap section — degraded operation over a broken pipeline.
+                logger.warning(
+                    "Gap analysis skipped for week=%s: %s. Run "
+                    "'am-init-db' and 'am-extract-expectations' first.",
+                    week_start, exc,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Gap analysis failed for week=%s: %s. Retrospective "
+                    "will be written without the Expectation Gaps section.",
+                    week_start, exc,
+                )
+
         system_prompt, messages = _assemble_prompt(
-            units, unit_transcripts, unit_timelines, week_start, unit_attributions
+            units,
+            unit_transcripts,
+            unit_timelines,
+            week_start,
+            unit_attributions,
+            gap_rows=gap_rows,
         )
 
         # --- Issue #54 P-2: prompt-size guard -------------------------

--- a/tests/test_gap_analysis.py
+++ b/tests/test_gap_analysis.py
@@ -1,0 +1,546 @@
+"""Tests for ``synthesis/gap_analysis.py`` (Epic #27 — X-2, Issue #73)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from am_i_shipping.config_loader import SynthesisConfig
+from am_i_shipping.db import (
+    EXPECTED_EXPECTATIONS_TABLES,
+    assert_schema,
+    init_expectations_db,
+    init_github_db,
+)
+from synthesis import gap_analysis
+from synthesis.gap_analysis import (
+    DIRECTION_ENUM,
+    FAILURE_PRECONDITION_ENUM,
+    SEVERITY_ENUM,
+    compute_severity_direction,
+    load_gap_rows,
+)
+
+
+WEEK_START = "2026-04-14"
+
+
+def _make_config(**overrides) -> SynthesisConfig:
+    base = SynthesisConfig(
+        anthropic_api_key_env="ANTHROPIC_API_KEY",
+        model="claude-sonnet-4-5",
+        output_dir="retrospectives",
+        week_start="monday",
+        abandonment_days=14,
+        outlier_sigma=2.0,
+    )
+    if overrides:
+        return replace(base, **overrides)
+    return base
+
+
+def _init_dbs(tmp_path: Path) -> tuple[Path, Path]:
+    gh = tmp_path / "github.db"
+    exp = tmp_path / "expectations.db"
+    init_github_db(gh)
+    init_expectations_db(exp)
+    return gh, exp
+
+
+def _seed_unit(
+    gh_db: Path,
+    *,
+    unit_id: str,
+    week_start: str = WEEK_START,
+    status: str = "closed",
+    total_reprompts: int = 0,
+    review_cycles: int = 0,
+    elapsed_days: float = 1.0,
+    abandonment_flag: int = 0,
+) -> None:
+    conn = sqlite3.connect(str(gh_db))
+    try:
+        conn.execute(
+            "INSERT INTO units "
+            "(week_start, unit_id, root_node_type, root_node_id, "
+            " elapsed_days, dark_time_pct, total_reprompts, review_cycles, "
+            " status, outlier_flags, abandonment_flag) "
+            "VALUES (?, ?, 'session', ?, ?, 0.0, ?, ?, ?, '[]', ?)",
+            (
+                week_start,
+                unit_id,
+                f"n-{unit_id}",
+                elapsed_days,
+                total_reprompts,
+                review_cycles,
+                status,
+                abandonment_flag,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_expectation(
+    exp_db: Path,
+    *,
+    unit_id: str,
+    week_start: str = WEEK_START,
+    skip_reason: str | None = None,
+    expected_scope: str | None = "fix X",
+    expected_effort: str | None = "one session",
+    expected_outcome: str | None = "tests pass",
+    commitment_point: str | None = "turn 3",
+) -> None:
+    conn = sqlite3.connect(str(exp_db))
+    try:
+        conn.execute(
+            "INSERT INTO expectations "
+            "(week_start, unit_id, commitment_point, expected_scope, "
+            " expected_effort, expected_outcome, confidence, model, "
+            " input_bytes, skip_reason) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                week_start,
+                unit_id,
+                commitment_point,
+                expected_scope,
+                expected_effort,
+                expected_outcome,
+                0.8 if skip_reason is None else None,
+                "claude-sonnet-4-5",
+                100,
+                skip_reason,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _all_gap_rows(exp_db: Path, week_start: str = WEEK_START) -> list[dict]:
+    return load_gap_rows(str(exp_db), week_start)
+
+
+@pytest.fixture(autouse=True)
+def _scrub_live_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("AMIS_SYNTHESIS_LIVE", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# AS-1: schema exists with locked column names
+# ---------------------------------------------------------------------------
+
+
+class TestExpectationGapsSchema:
+    def test_init_creates_expectation_gaps_table(self, tmp_path: Path):
+        db = tmp_path / "expectations.db"
+        init_expectations_db(db)
+        assert_schema(db, EXPECTED_EXPECTATIONS_TABLES)
+
+        conn = sqlite3.connect(str(db))
+        try:
+            cols = {
+                r[1]
+                for r in conn.execute(
+                    "PRAGMA table_info(expectation_gaps)"
+                ).fetchall()
+            }
+        finally:
+            conn.close()
+
+        required = {
+            "week_start",
+            "unit_id",
+            "commitment_point",
+            "scope_gap",
+            "effort_gap",
+            "outcome_gap",
+            "severity",
+            "direction",
+            "failure_precondition",
+            "computed_at",
+            "auto_confirmed",
+        }
+        missing = required - cols
+        assert not missing, (
+            f"expectation_gaps missing required columns: {missing}"
+        )
+
+    def test_idempotent_init(self, tmp_path: Path):
+        db = tmp_path / "expectations.db"
+        init_expectations_db(db)
+        init_expectations_db(db)
+        assert_schema(db, EXPECTED_EXPECTATIONS_TABLES)
+
+
+# ---------------------------------------------------------------------------
+# Pure-function severity tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSeverityDirection:
+    def test_skip_reason_yields_none_ambiguous(self):
+        sev, direction = compute_severity_direction(
+            status="closed",
+            total_reprompts=0,
+            review_cycles=0,
+            elapsed_days=1.0,
+            expected_effort=None,
+            expected_outcome=None,
+            skip_reason="raw_content_json_empty",
+        )
+        assert sev == "none"
+        assert direction == "ambiguous"
+
+    def test_abandoned_status_yields_critical_under(self):
+        sev, direction = compute_severity_direction(
+            status="abandoned",
+            total_reprompts=0,
+            review_cycles=0,
+            elapsed_days=14.0,
+            expected_effort="one session",
+            expected_outcome="shipped",
+            skip_reason=None,
+        )
+        assert sev == "critical"
+        assert direction == "under"
+
+    def test_high_reprompts_yields_major_over(self):
+        sev, direction = compute_severity_direction(
+            status="closed",
+            total_reprompts=12,
+            review_cycles=1,
+            elapsed_days=2.0,
+            expected_effort="one session",
+            expected_outcome="shipped",
+            skip_reason=None,
+        )
+        assert sev == "major"
+        assert direction == "over"
+
+    def test_moderate_reprompts_yields_minor_over(self):
+        sev, direction = compute_severity_direction(
+            status="closed",
+            total_reprompts=5,
+            review_cycles=1,
+            elapsed_days=1.0,
+            expected_effort="one session",
+            expected_outcome="shipped",
+            skip_reason=None,
+        )
+        assert sev == "minor"
+        assert direction == "over"
+
+    def test_clean_run_yields_none_match(self):
+        sev, direction = compute_severity_direction(
+            status="closed",
+            total_reprompts=0,
+            review_cycles=0,
+            elapsed_days=0.5,
+            expected_effort="one session",
+            expected_outcome="shipped",
+            skip_reason=None,
+        )
+        assert sev == "none"
+        assert direction == "match"
+
+
+# ---------------------------------------------------------------------------
+# AS-2, AS-3, AS-4: gap pass produces one row per expectation with valid enums
+# ---------------------------------------------------------------------------
+
+
+class TestGapRunOffline:
+    def test_one_gap_row_per_expectation(self, tmp_path: Path):
+        gh, exp = _init_dbs(tmp_path)
+        _seed_unit(gh, unit_id="u1", total_reprompts=0, review_cycles=0)
+        _seed_unit(gh, unit_id="u2", status="abandoned", total_reprompts=0)
+        _seed_unit(gh, unit_id="u3_no_expectation")
+        _seed_expectation(exp, unit_id="u1")
+        _seed_expectation(exp, unit_id="u2")
+
+        written = gap_analysis.run(
+            WEEK_START,
+            github_db=str(gh),
+            expectations_db=str(exp),
+            config=_make_config(),
+        )
+
+        assert written == 2
+        rows = _all_gap_rows(exp)
+        unit_ids = {r["unit_id"] for r in rows}
+        assert unit_ids == {"u1", "u2"}
+        # u3 had a units row but no expectation row → no gap row.
+
+    def test_severity_and_direction_populated(self, tmp_path: Path):
+        gh, exp = _init_dbs(tmp_path)
+        _seed_unit(gh, unit_id="u1", status="abandoned")
+        _seed_expectation(exp, unit_id="u1")
+
+        gap_analysis.run(
+            WEEK_START,
+            github_db=str(gh),
+            expectations_db=str(exp),
+            config=_make_config(),
+        )
+        rows = _all_gap_rows(exp)
+        assert len(rows) == 1
+        assert rows[0]["severity"] in SEVERITY_ENUM
+        assert rows[0]["direction"] in DIRECTION_ENUM
+
+    def test_failure_precondition_constrained_enum(self, tmp_path: Path):
+        gh, exp = _init_dbs(tmp_path)
+        # Mix of severities.
+        _seed_unit(gh, unit_id="u_clean", total_reprompts=0)
+        _seed_unit(gh, unit_id="u_abandoned", status="abandoned")
+        _seed_unit(gh, unit_id="u_overbusy", total_reprompts=15)
+        _seed_expectation(exp, unit_id="u_clean")
+        _seed_expectation(exp, unit_id="u_abandoned")
+        _seed_expectation(exp, unit_id="u_overbusy")
+
+        gap_analysis.run(
+            WEEK_START,
+            github_db=str(gh),
+            expectations_db=str(exp),
+            config=_make_config(),
+        )
+        rows = _all_gap_rows(exp)
+        for r in rows:
+            sev = r["severity"]
+            fp = r["failure_precondition"]
+            if sev == "none":
+                assert fp is None, (
+                    f"failure_precondition must be NULL when severity=none, "
+                    f"got {fp!r}"
+                )
+            else:
+                assert fp in FAILURE_PRECONDITION_ENUM, (
+                    f"failure_precondition {fp!r} not in enum"
+                )
+
+    def test_skip_reason_yields_none_severity(self, tmp_path: Path):
+        gh, exp = _init_dbs(tmp_path)
+        _seed_unit(gh, unit_id="u1")
+        _seed_expectation(
+            exp,
+            unit_id="u1",
+            skip_reason="raw_content_json_empty",
+            expected_scope=None,
+            expected_effort=None,
+            expected_outcome=None,
+            commitment_point=None,
+        )
+        gap_analysis.run(
+            WEEK_START,
+            github_db=str(gh),
+            expectations_db=str(exp),
+            config=_make_config(),
+        )
+        rows = _all_gap_rows(exp)
+        assert len(rows) == 1
+        assert rows[0]["severity"] == "none"
+        assert rows[0]["failure_precondition"] is None
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — re-running replaces gap rows for the week
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    def test_rerun_replaces_gap_rows(self, tmp_path: Path):
+        gh, exp = _init_dbs(tmp_path)
+        _seed_unit(gh, unit_id="u1", total_reprompts=0)
+        _seed_expectation(exp, unit_id="u1")
+
+        gap_analysis.run(
+            WEEK_START, github_db=str(gh), expectations_db=str(exp),
+            config=_make_config(),
+        )
+        rows1 = _all_gap_rows(exp)
+        computed_at_1 = sqlite3.connect(str(exp)).execute(
+            "SELECT computed_at FROM expectation_gaps WHERE unit_id='u1'"
+        ).fetchone()[0]
+
+        # Sleep-free idempotency check: run again and assert the row still
+        # exists (count stable, unit_id unchanged). The computed_at string
+        # uses second-granularity so back-to-back invocations can tie; the
+        # important invariant is count + content stability, not a new
+        # timestamp.
+        gap_analysis.run(
+            WEEK_START, github_db=str(gh), expectations_db=str(exp),
+            config=_make_config(),
+        )
+        rows2 = _all_gap_rows(exp)
+        assert len(rows2) == len(rows1) == 1
+        assert rows2[0]["unit_id"] == "u1"
+
+    def test_noop_when_no_expectations(self, tmp_path: Path):
+        gh, exp = _init_dbs(tmp_path)
+        _seed_unit(gh, unit_id="u1")
+        # No expectations rows seeded.
+        written = gap_analysis.run(
+            WEEK_START, github_db=str(gh), expectations_db=str(exp),
+            config=_make_config(),
+        )
+        assert written == 0
+        assert _all_gap_rows(exp) == []
+
+
+# ---------------------------------------------------------------------------
+# AS-8: auto-confirm sweep flips rows older than 14 days
+# ---------------------------------------------------------------------------
+
+
+class TestAutoConfirmSweep:
+    def test_old_rows_flipped_young_rows_untouched(self, tmp_path: Path):
+        gh, exp = _init_dbs(tmp_path)
+        _seed_unit(gh, unit_id="u_old")
+        _seed_unit(gh, unit_id="u_young")
+        _seed_expectation(exp, unit_id="u_old")
+        _seed_expectation(exp, unit_id="u_young")
+
+        # First run: populates gap rows with ``computed_at = now``.
+        gap_analysis.run(
+            WEEK_START, github_db=str(gh), expectations_db=str(exp),
+            config=_make_config(),
+        )
+
+        # Back-date u_old's computed_at to 15 days ago.
+        old_ts = (
+            datetime.now(timezone.utc) - timedelta(days=15)
+        ).strftime("%Y-%m-%d %H:%M:%S")
+        conn = sqlite3.connect(str(exp))
+        try:
+            conn.execute(
+                "UPDATE expectation_gaps SET computed_at = ? "
+                "WHERE unit_id = 'u_old'",
+                (old_ts,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Re-run: gap pass rewrites rows for the week (so both u_old and
+        # u_young get fresh computed_at). But we specifically want to test
+        # the sweep, so call it directly on the back-dated state BEFORE
+        # re-running gap pass.
+        conn = sqlite3.connect(str(exp))
+        try:
+            swept = gap_analysis._auto_confirm_sweep(conn)
+            assert swept >= 1
+            rows = conn.execute(
+                "SELECT unit_id, auto_confirmed FROM expectation_gaps "
+                "ORDER BY unit_id"
+            ).fetchall()
+        finally:
+            conn.close()
+
+        by_uid = {r[0]: r[1] for r in rows}
+        assert by_uid["u_old"] == 1, "old row should be auto-confirmed"
+        assert by_uid["u_young"] == 0, "young row should be untouched"
+
+
+# ---------------------------------------------------------------------------
+# AS-5 / AS-7: integration with run_synthesis
+# ---------------------------------------------------------------------------
+
+
+class TestWeeklyIntegration:
+    """End-to-end: gap pass runs inside ``run_synthesis``.
+
+    The fake-adapter path returns a canned retrospective Markdown that
+    does NOT include an ``## Expectation Gaps`` section (the fake is
+    deterministic), so we verify the gap pass ran by inspecting the
+    ``expectation_gaps`` table directly.
+    """
+
+    def test_gap_pass_runs_inside_run_synthesis(self, tmp_path: Path):
+        from synthesis.weekly import run_synthesis
+        from am_i_shipping.db import init_sessions_db
+
+        gh_db = tmp_path / "github.db"
+        sess_db = tmp_path / "sessions.db"
+        exp_db = tmp_path / "expectations.db"
+        init_github_db(gh_db)
+        init_sessions_db(sess_db)
+        init_expectations_db(exp_db)
+
+        _seed_unit(gh_db, unit_id="u1", total_reprompts=12)
+        _seed_expectation(exp_db, unit_id="u1")
+
+        # unit_summaries row required (fail-loud in run_synthesis).
+        conn = sqlite3.connect(str(gh_db))
+        try:
+            conn.execute(
+                "INSERT INTO unit_summaries "
+                "(week_start, unit_id, summary_text, model, input_bytes) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (WEEK_START, "u1", "summary", "fake", 7),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        out_dir = tmp_path / "retrospectives"
+        cfg = replace(_make_config(), output_dir=str(out_dir))
+
+        result = run_synthesis(
+            cfg,
+            gh_db,
+            sess_db,
+            WEEK_START,
+            dry_run=False,
+            expectations_db=exp_db,
+        )
+        assert result is not None
+
+        rows = _all_gap_rows(exp_db)
+        assert len(rows) == 1
+        assert rows[0]["unit_id"] == "u1"
+        assert rows[0]["severity"] in SEVERITY_ENUM
+
+    def test_missing_expectations_db_is_silent_warning(
+        self, tmp_path: Path, caplog
+    ):
+        """run_synthesis must not crash when expectations_db is missing."""
+        from synthesis.weekly import run_synthesis
+        from am_i_shipping.db import init_sessions_db
+
+        gh_db = tmp_path / "github.db"
+        sess_db = tmp_path / "sessions.db"
+        # No expectations.db — pass a non-existent path. The module will
+        # try to open it, fail with OperationalError, and warn.
+        init_github_db(gh_db)
+        init_sessions_db(sess_db)
+        _seed_unit(gh_db, unit_id="u1")
+        conn = sqlite3.connect(str(gh_db))
+        try:
+            conn.execute(
+                "INSERT INTO unit_summaries "
+                "(week_start, unit_id, summary_text, model, input_bytes) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (WEEK_START, "u1", "summary", "fake", 7),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        out_dir = tmp_path / "retrospectives"
+        cfg = replace(_make_config(), output_dir=str(out_dir))
+
+        # Don't pass expectations_db — the existing (backward-compatible)
+        # code path must continue to work.
+        result = run_synthesis(
+            cfg, gh_db, sess_db, WEEK_START, dry_run=False,
+        )
+        assert result is not None


### PR DESCRIPTION
Resolves #73 (sub-issue 2/5 of epic #27). Targets the epic branch.

## Summary
- New `expectation_gaps` table in `expectations.db` with the IRREVERSIBLE column names (`commitment_point`, `scope_gap`, `effort_gap`, `outcome_gap`) locked per the epic ADR, plus `severity`, `direction`, `failure_precondition`, `computed_at`, and the `auto_confirmed` hook column for X-4.
- `synthesis/gap_analysis.py`: pure-function severity/direction heuristic + optional LLM-backed `failure_precondition` attribution constrained to an enum of idealized-workflow phase/step identifiers. Idempotent `run()` replaces gap rows for the target week. Auto-confirm sweep flips rows older than 14 days to `auto_confirmed=1`.
- `synthesis/weekly.py`: gap pass wired into `run_synthesis` via an optional `expectations_db` kwarg. Major / critical gap rows are injected into the assembled user message. `## Expectation Gaps` appended to the static system-prompt section list (contract preserved for X-3 / X-5 appends).
- `synthesis/cli.py`: resolves `expectations.db` alongside `github.db` / `sessions.db` and passes it to `run_synthesis`.
- Graceful degradation when `expectations.db` is missing or `expectation_gaps` is absent (warning + continue, per X2-OQ-3 default).

## Behavioral Question Answered
Every unit with an expectations row now produces exactly one gap row with severity (`none | minor | major | critical`), direction (`under | over | match | ambiguous`), and — when severity ≠ none — a `failure_precondition` drawn from the closed idealized-workflow enum. Major and critical gaps are surfaced in the retrospective's `## Expectation Gaps` section.

## Test Plan
- [x] `tests/test_gap_analysis.py` — 16 tests: schema assertion, severity heuristic table, one-gap-row-per-expectation, enum constraints for severity / direction / failure_precondition, skip-reason handling, idempotency, auto-confirm sweep (old flipped, young untouched), and `run_synthesis` end-to-end integration.
- [x] Full repo test suite: 556 passed, 23 skipped.

## Scope Boundaries
- X-4 correction workflow and X-5 calibration are out of scope; `auto_confirmed` is introduced here only so X-4 has a write target.
- The `## Expectation Gaps` rendered section in the final `.md` is produced by the LLM from the injected user-message block; Python never mutates a shipped retrospective (Epic #17 idempotency invariant preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)