### PR TITLE
feat(#74): X-3 Revision Detection — mid-unit expectation shifts

### DIFF
--- a/am_i_shipping/db.py
+++ b/am_i_shipping/db.py
@@ -319,6 +319,41 @@ _EXPECTATIONS_MIGRATIONS = [
     "ALTER TABLE expectation_gaps ADD COLUMN auto_confirmed INTEGER DEFAULT 0",
 ]
 
+# Epic #27 — X-3 (#74): expectation_revisions schema.
+#
+# Written by ``synthesis.revision_detector.run`` during ``am-synthesize``.
+# Every row is a sibling-history record of a mid-unit expectation shift
+# detected from a structural trigger (reprompt, session break >24h, or
+# scope-change turn). The committed ``expectations`` row from X-1 is
+# NEVER mutated — revisions accumulate alongside as a parallel history.
+#
+# IRREVERSIBLE column names (per the epic ADR, mirroring X-1/X-2's lock):
+# ``revision_index``, ``revision_turn``, ``revision_trigger``, ``facet``,
+# ``before_text``, ``after_text``. X-4 user corrections and X-5 calibration
+# will key off these names; renaming after X-4 ships is expensive.
+#
+# * ``revision_trigger`` — one of {``reprompt``, ``scope_change_turn``,
+#                          ``session_break``}.
+# * ``facet``            — one of {``scope``, ``effort``, ``outcome``}.
+# * ``confidence``       — LLM self-reported confidence in [0.0, 1.0].
+#                          Low-confidence rows (<0.5) are surfaced in the
+#                          retrospective with a marker, NOT dropped.
+SYNTHESIS_EXPECTATION_REVISIONS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS expectation_revisions (
+    week_start       TEXT NOT NULL,
+    unit_id          TEXT NOT NULL,
+    revision_index   INTEGER NOT NULL,
+    revision_turn    INTEGER,
+    revision_trigger TEXT,
+    facet            TEXT,
+    before_text      TEXT,
+    after_text       TEXT,
+    confidence       REAL,
+    detected_at      TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (week_start, unit_id, revision_index)
+);
+"""
+
 EXPECTED_EXPECTATIONS_TABLES: dict[str, set[str]] = {
     "expectations": {
         "week_start",
@@ -345,6 +380,18 @@ EXPECTED_EXPECTATIONS_TABLES: dict[str, set[str]] = {
         "failure_precondition",
         "computed_at",
         "auto_confirmed",
+    },
+    "expectation_revisions": {
+        "week_start",
+        "unit_id",
+        "revision_index",
+        "revision_turn",
+        "revision_trigger",
+        "facet",
+        "before_text",
+        "after_text",
+        "confidence",
+        "detected_at",
     },
 }
 
@@ -731,6 +778,8 @@ def init_expectations_db(db_path: Path) -> None:
         conn.execute(SYNTHESIS_EXPECTATIONS_SCHEMA)
         # Epic #27 — X-2 (#73): expectation_gaps lives in the same DB.
         conn.execute(SYNTHESIS_EXPECTATION_GAPS_SCHEMA)
+        # Epic #27 — X-3 (#74): expectation_revisions lives in the same DB.
+        conn.execute(SYNTHESIS_EXPECTATION_REVISIONS_SCHEMA)
         for migration in _EXPECTATIONS_MIGRATIONS:
             try:
                 conn.execute(migration)

--- a/synthesis/revision_detector.py
+++ b/synthesis/revision_detector.py
@@ -1,0 +1,819 @@
+"""Epic #27 — X-3 (#74): mid-unit expectation revision detection.
+
+Walks each unit's transcripts after the commitment point (from X-1's
+``expectations`` row) and emits one row in ``expectation_revisions`` per
+detected shift. Shifts are anchored to a specific structural trigger:
+
+* ``reprompt``          — a user reprompt turn (counted by Phase 2 into
+                          ``sessions.reprompt_count``). Revision detection
+                          locates the actual turn indices rather than just
+                          reading the aggregate count.
+* ``scope_change_turn`` — a user text turn whose content matches a coarse
+                          keyword pre-filter (``actually``, ``also``,
+                          ``wait``, ``let's instead``, ...), then is
+                          confirmed by the LLM classifier.
+* ``session_break``     — a gap > 24 h between consecutive sessions in the
+                          unit; anchored at the resumption turn.
+
+Behavioral invariants (from the refined spec):
+
+* **Zero rows is a valid result.** A unit with no structural triggers
+  produces no rows — absence is information.
+* **The committed expectation is immutable.** X-3 never mutates the
+  ``expectations`` row; revisions are a parallel sibling history.
+* **Low confidence is surfaced, not dropped.** Rows with
+  ``confidence < 0.5`` are written as-is and marked in the retrospective.
+* **Idempotent re-runs.** Upsert on ``(week_start, unit_id,
+  revision_index)`` — re-running without ``--rebuild`` does not insert
+  duplicates; existing ``detected_at`` is preserved on no-op re-runs.
+* **Offline parity.** With ``AMIS_SYNTHESIS_LIVE`` unset, the fake
+  adapter returns canned Markdown. The classifier coerces that into a
+  low-confidence revision so the pipeline still exercises the row-write
+  path end-to-end in tests.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from am_i_shipping.config_loader import SynthesisConfig
+from synthesis.expectations import _extract_turns
+from synthesis.llm_adapter import _get_adapter
+
+
+logger = logging.getLogger(__name__)
+
+
+_MAX_OUTPUT_TOKENS = 512
+
+# Session-break threshold. Hardcoded for v1 per the refined spec —
+# parameterization is deferred until X-4 corrections indicate otherwise.
+SESSION_BREAK_THRESHOLD_SECONDS = 24 * 60 * 60
+
+REVISION_TRIGGER_ENUM: tuple[str, ...] = (
+    "reprompt",
+    "scope_change_turn",
+    "session_break",
+)
+
+FACET_ENUM: tuple[str, ...] = ("scope", "effort", "outcome")
+
+# Coarse keyword pre-filter for scope-change turns. Mirrors X-1's hybrid
+# structural+LLM approach — cheap keyword filter first, LLM confirms and
+# names the facet. Any text turn matching at least one of these cues is a
+# scope-change candidate.
+_SCOPE_CHANGE_CUES: tuple[str, ...] = (
+    "actually",
+    "also",
+    "wait",
+    "let's instead",
+    "lets instead",
+    "on second thought",
+    "scratch that",
+    "instead of",
+    "forget that",
+)
+
+
+_REVISION_SYSTEM_PROMPT = """You are classifying a mid-unit expectation \
+shift for a retrospective calibration system.
+
+A "unit" is a software-development cycle. After the user accepts a plan \
+(the commitment point), they may shift expectations mid-stream: reprompt \
+with new requirements, resume after a break with a different attack, or \
+insert a scope-change turn. You will be given the trigger type, the \
+triggering turn text, and surrounding context. Classify:
+
+1. facet: one of scope | effort | outcome. Which aspect of the original \
+expectation shifted.
+2. before_text: one sentence describing the pre-shift expectation.
+3. after_text: one sentence describing the post-shift expectation.
+4. confidence: self-reported certainty in [0.0, 1.0]. Low confidence is \
+expected when the shift is ambiguous or the turn text is sparse — do \
+NOT inflate confidence. Low-confidence rows are preserved downstream.
+
+Return a single JSON object with exactly these keys:
+  facet, before_text, after_text, confidence
+
+Do NOT wrap in Markdown fences. Do NOT add extra keys."""
+
+
+# ---------------------------------------------------------------------------
+# Pure-function structural trigger detection
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso_timestamp(value: Optional[str]) -> Optional[datetime]:
+    """Parse an ISO-8601 timestamp string; return ``None`` on failure."""
+    if not value:
+        return None
+    try:
+        # Handle both ``Z`` suffix and offset-aware ISO strings.
+        v = value.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(v)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except (ValueError, TypeError):
+        return None
+
+
+def _is_reprompt_turn(turn: Dict[str, Any]) -> bool:
+    """Heuristic: a user text turn after a prior assistant action.
+
+    The structural walker uses positional context (prior assistant turn)
+    rather than this predicate alone — see :func:`detect_structural_triggers`.
+    """
+    return (
+        turn.get("role") == "user"
+        and turn.get("kind") == "text"
+        and bool((turn.get("text") or "").strip())
+    )
+
+
+def _matches_scope_change_cue(text: str) -> bool:
+    """Return True if *text* contains a scope-change keyword cue.
+
+    Case-insensitive substring match over the curated cue list. This is
+    the pre-filter — the LLM confirms and names the facet downstream.
+    """
+    if not text:
+        return False
+    low = text.lower()
+    return any(cue in low for cue in _SCOPE_CHANGE_CUES)
+
+
+def detect_structural_triggers(
+    turns: Sequence[Dict[str, Any]],
+    *,
+    commitment_turn_idx: Optional[int],
+    reprompt_count: int,
+    session_boundaries: Sequence[Tuple[int, datetime, datetime]] = (),
+) -> List[Dict[str, Any]]:
+    """Return structural trigger records for a unit's transcript.
+
+    Pure function — no DB, no LLM, no I/O. Inputs:
+
+    *turns* : flat turn list (from :func:`_extract_turns`).
+    *commitment_turn_idx* : index of X-1's commitment point (walker only
+    emits triggers at turns strictly AFTER this). ``None`` → walk from 0.
+    *reprompt_count* : aggregate from ``sessions.reprompt_count``. Used
+    to cap the number of reprompt triggers emitted.
+    *session_boundaries* : optional list of
+    ``(resumption_turn_idx, prev_session_end, this_session_start)``
+    tuples, one per session break in the unit (only breaks >
+    :data:`SESSION_BREAK_THRESHOLD_SECONDS`).
+
+    Returns a list of dicts with keys:
+      trigger, turn_idx, text, context
+
+    ``context`` is a short window of surrounding text turns for the LLM.
+    """
+    if not turns:
+        return []
+
+    start = 0 if commitment_turn_idx is None else commitment_turn_idx + 1
+
+    records: List[Dict[str, Any]] = []
+
+    # Reprompt triggers — a reprompt is a user text turn that follows a
+    # prior assistant action (text or tool_use) and is NOT the commitment
+    # turn itself. We cap at ``reprompt_count`` so attribution stays
+    # deterministic vs. Phase 2's aggregate.
+    if reprompt_count > 0:
+        emitted = 0
+        saw_assistant = False
+        for i in range(start, len(turns)):
+            t = turns[i]
+            if t.get("role") == "assistant":
+                saw_assistant = True
+                continue
+            if emitted >= reprompt_count:
+                break
+            if saw_assistant and _is_reprompt_turn(t):
+                records.append(
+                    {
+                        "trigger": "reprompt",
+                        "turn_idx": i,
+                        "text": t.get("text") or "",
+                        "context": _collect_context(turns, i, window=2),
+                    }
+                )
+                emitted += 1
+                # Require a new assistant turn before the next reprompt.
+                saw_assistant = False
+
+    # Scope-change turn triggers — user text turns matching the keyword
+    # pre-filter. These overlap with reprompts by design; the LLM can
+    # reassign facet and deduplication happens downstream via
+    # (revision_turn, trigger) uniqueness within the emitted records.
+    seen_turns = {r["turn_idx"] for r in records}
+    for i in range(start, len(turns)):
+        t = turns[i]
+        if t.get("role") != "user" or t.get("kind") != "text":
+            continue
+        text = t.get("text") or ""
+        if not _matches_scope_change_cue(text):
+            continue
+        if i in seen_turns:
+            continue
+        records.append(
+            {
+                "trigger": "scope_change_turn",
+                "turn_idx": i,
+                "text": text,
+                "context": _collect_context(turns, i, window=2),
+            }
+        )
+        seen_turns.add(i)
+
+    # Session-break triggers — anchored at each resumption turn.
+    for resume_idx, prev_end, this_start in session_boundaries:
+        if resume_idx < start:
+            continue
+        if not prev_end or not this_start:
+            continue
+        gap = (this_start - prev_end).total_seconds()
+        if gap <= SESSION_BREAK_THRESHOLD_SECONDS:
+            continue
+        if 0 <= resume_idx < len(turns):
+            text = turns[resume_idx].get("text") or ""
+        else:
+            text = ""
+        records.append(
+            {
+                "trigger": "session_break",
+                "turn_idx": resume_idx,
+                "text": text,
+                "context": _collect_context(turns, resume_idx, window=2),
+            }
+        )
+
+    # Order by turn index so revision_index is deterministic.
+    records.sort(key=lambda r: (r["turn_idx"], r["trigger"]))
+    return records
+
+
+def _collect_context(
+    turns: Sequence[Dict[str, Any]], anchor_idx: int, window: int = 2
+) -> str:
+    """Return a short text block of ±``window`` text turns around *anchor_idx*."""
+    if anchor_idx < 0 or anchor_idx >= len(turns):
+        return ""
+    text_idxs = [
+        i
+        for i, t in enumerate(turns)
+        if t.get("kind") == "text" and (t.get("text") or "").strip()
+    ]
+    if anchor_idx not in text_idxs:
+        # Anchor is not itself a text turn; surface nearest text turns.
+        # Find position of first text index >= anchor_idx, fall back to last.
+        pos = 0
+        for p, idx in enumerate(text_idxs):
+            if idx >= anchor_idx:
+                pos = p
+                break
+        else:
+            pos = max(0, len(text_idxs) - 1)
+    else:
+        pos = text_idxs.index(anchor_idx)
+    lo = max(0, pos - window)
+    hi = min(len(text_idxs), pos + window + 1)
+    lines: List[str] = []
+    for p in range(lo, hi):
+        idx = text_idxs[p]
+        marker = " [ANCHOR]" if idx == anchor_idx else ""
+        text = turns[idx].get("text") or ""
+        lines.append(f"turn {idx}{marker}: {text}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# LLM parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_llm_response(response_text: str) -> Optional[Dict[str, Any]]:
+    if not response_text:
+        return None
+    m = re.search(r"\{.*\}", response_text, re.DOTALL)
+    if not m:
+        return None
+    try:
+        obj = json.loads(m.group(0))
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(obj, dict):
+        return None
+    return obj
+
+
+def _coerce_facet(value: Any) -> str:
+    if isinstance(value, str) and value in FACET_ENUM:
+        return value
+    return "scope"
+
+
+def _coerce_confidence(value: Any) -> float:
+    try:
+        f = float(value)
+    except (ValueError, TypeError):
+        return 0.3
+    if f < 0.0:
+        return 0.0
+    if f > 1.0:
+        return 1.0
+    return f
+
+
+def classify_revision(
+    trigger_record: Dict[str, Any],
+    *,
+    adapter,
+    model: str,
+    expectation: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Call the LLM classifier for one trigger record and return a revision dict.
+
+    Returns a dict with keys ``facet``, ``before_text``, ``after_text``,
+    ``confidence`` — every key is non-NULL (the offline / declined path
+    falls back to low-confidence defaults).
+    """
+    user_parts: List[str] = []
+    user_parts.append(f"## Trigger: {trigger_record['trigger']}")
+    user_parts.append(f"## Turn index: {trigger_record['turn_idx']}")
+    if expectation:
+        user_parts.append("")
+        user_parts.append("### Original expectation (from X-1)")
+        user_parts.append(
+            f"- expected_scope: {expectation.get('expected_scope') or '(unknown)'}"
+        )
+        user_parts.append(
+            f"- expected_effort: {expectation.get('expected_effort') or '(unknown)'}"
+        )
+        user_parts.append(
+            f"- expected_outcome: {expectation.get('expected_outcome') or '(unknown)'}"
+        )
+    user_parts.append("")
+    user_parts.append("### Anchor + context")
+    user_parts.append(trigger_record.get("context") or "")
+    user_text = "\n".join(user_parts)
+
+    try:
+        result = adapter.call(
+            _REVISION_SYSTEM_PROMPT, user_text, model, _MAX_OUTPUT_TOKENS
+        )
+        parsed = _parse_llm_response(result.text)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "revision_detector LLM call failed for turn=%s: %s — "
+            "using low-confidence fallback",
+            trigger_record.get("turn_idx"),
+            exc,
+        )
+        parsed = None
+
+    if not parsed:
+        # Offline fake-adapter path returns canned Markdown, not this
+        # JSON. Fall back to a low-confidence record derived from the
+        # trigger text so the pipeline still produces a non-empty row.
+        anchor_text = (trigger_record.get("text") or "").strip() or "(no text)"
+        return {
+            "facet": "scope",
+            "before_text": "(pre-revision expectation not parsed)",
+            "after_text": anchor_text[:200],
+            "confidence": 0.3,
+        }
+
+    return {
+        "facet": _coerce_facet(parsed.get("facet")),
+        "before_text": (
+            parsed.get("before_text") if isinstance(parsed.get("before_text"), str)
+            else ""
+        ),
+        "after_text": (
+            parsed.get("after_text") if isinstance(parsed.get("after_text"), str)
+            else ""
+        ),
+        "confidence": _coerce_confidence(parsed.get("confidence")),
+    }
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_expectations(
+    exp_conn: sqlite3.Connection, week_start: str
+) -> List[Dict[str, Any]]:
+    rows = exp_conn.execute(
+        "SELECT week_start, unit_id, commitment_point, expected_scope, "
+        "       expected_effort, expected_outcome, skip_reason "
+        "FROM expectations WHERE week_start = ? ORDER BY unit_id",
+        (week_start,),
+    ).fetchall()
+    return [
+        {
+            "week_start": r[0],
+            "unit_id": r[1],
+            "commitment_point": r[2],
+            "expected_scope": r[3],
+            "expected_effort": r[4],
+            "expected_outcome": r[5],
+            "skip_reason": r[6],
+        }
+        for r in rows
+    ]
+
+
+def _load_unit_sessions(
+    gh_conn: sqlite3.Connection,
+    sessions_conn: sqlite3.Connection,
+    week_start: str,
+    unit_id: str,
+) -> List[Dict[str, Any]]:
+    """Return one dict per session in the unit, ordered by start time.
+
+    Each dict: ``session_uuid``, ``raw_content_json``, ``reprompt_count``,
+    ``session_started_at``, ``session_ended_at`` (as datetime or None).
+    """
+    # Resolve the unit's component via the same graph walk used by X-1.
+    from synthesis.weekly import _unit_nodes
+
+    row = gh_conn.execute(
+        "SELECT root_node_id FROM units WHERE week_start = ? AND unit_id = ?",
+        (week_start, unit_id),
+    ).fetchone()
+    root_node_id = row[0] if row else ""
+    component = _unit_nodes(gh_conn, week_start, root_node_id or "")
+    session_uuids = [
+        node_ref
+        for _nid, node_type, node_ref in component
+        if node_type == "session" and node_ref
+    ]
+    if not session_uuids:
+        return []
+
+    placeholders = ",".join("?" * len(session_uuids))
+    rows = sessions_conn.execute(
+        f"SELECT session_uuid, raw_content_json, reprompt_count, "
+        f"       session_started_at, session_ended_at "
+        f"FROM sessions WHERE session_uuid IN ({placeholders})",
+        session_uuids,
+    ).fetchall()
+
+    items: List[Dict[str, Any]] = []
+    for r in rows:
+        items.append(
+            {
+                "session_uuid": r[0],
+                "raw_content_json": r[1] or "",
+                "reprompt_count": r[2] or 0,
+                "session_started_at": _parse_iso_timestamp(r[3]),
+                "session_ended_at": _parse_iso_timestamp(r[4]),
+            }
+        )
+    # Order by start timestamp — None sorts last so unknown-order sessions
+    # still produce deterministic output.
+    items.sort(
+        key=lambda s: (
+            s["session_started_at"] or datetime.max.replace(tzinfo=timezone.utc),
+            s["session_uuid"],
+        )
+    )
+    return items
+
+
+def _assemble_unit_turns(
+    sessions: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], int, List[Tuple[int, datetime, datetime]]]:
+    """Concatenate turns from every session; emit session-boundary records.
+
+    Returns ``(all_turns, total_reprompt_count, boundaries)``. Each
+    boundary is ``(first_turn_idx_of_this_session, prev_session_end,
+    this_session_start)`` for the second + later sessions.
+    """
+    all_turns: List[Dict[str, Any]] = []
+    boundaries: List[Tuple[int, datetime, datetime]] = []
+    total_reprompts = 0
+
+    prev_session_end: Optional[datetime] = None
+    for s in sessions:
+        turns = _extract_turns(s["raw_content_json"])
+        if not turns:
+            prev_session_end = s.get("session_ended_at") or prev_session_end
+            total_reprompts += s.get("reprompt_count") or 0
+            continue
+        start_idx = len(all_turns)
+        all_turns.extend(turns)
+        total_reprompts += s.get("reprompt_count") or 0
+        if prev_session_end and s.get("session_started_at"):
+            boundaries.append(
+                (start_idx, prev_session_end, s["session_started_at"])
+            )
+        prev_session_end = s.get("session_ended_at") or prev_session_end
+    return all_turns, total_reprompts, boundaries
+
+
+def _parse_commitment_turn_idx(commitment_point: Optional[str]) -> Optional[int]:
+    """Extract a numeric turn index from X-1's free-text commitment_point."""
+    if not commitment_point:
+        return None
+    m = re.search(r"\d+", commitment_point)
+    if not m:
+        return None
+    try:
+        return int(m.group(0))
+    except ValueError:
+        return None
+
+
+def _existing_revision_keys(
+    exp_conn: sqlite3.Connection, week_start: str, unit_id: str
+) -> set[int]:
+    rows = exp_conn.execute(
+        "SELECT revision_index FROM expectation_revisions "
+        "WHERE week_start = ? AND unit_id = ?",
+        (week_start, unit_id),
+    ).fetchall()
+    return {r[0] for r in rows}
+
+
+def _upsert_revision(
+    exp_conn: sqlite3.Connection,
+    *,
+    week_start: str,
+    unit_id: str,
+    revision_index: int,
+    revision_turn: Optional[int],
+    revision_trigger: str,
+    facet: str,
+    before_text: Optional[str],
+    after_text: Optional[str],
+    confidence: float,
+    preserve_detected_at: bool,
+) -> None:
+    """Insert or update a revision row.
+
+    When *preserve_detected_at* is True AND a row already exists at this
+    key, the existing ``detected_at`` is kept (idempotent re-run). When
+    False, a fresh ``datetime('now')`` is written.
+    """
+    if preserve_detected_at:
+        existing = exp_conn.execute(
+            "SELECT detected_at FROM expectation_revisions "
+            "WHERE week_start = ? AND unit_id = ? AND revision_index = ?",
+            (week_start, unit_id, revision_index),
+        ).fetchone()
+        if existing:
+            # Row is already present — do not touch it. Idempotent no-op.
+            return
+    exp_conn.execute(
+        "INSERT OR REPLACE INTO expectation_revisions "
+        "(week_start, unit_id, revision_index, revision_turn, "
+        " revision_trigger, facet, before_text, after_text, "
+        " confidence, detected_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))",
+        (
+            week_start,
+            unit_id,
+            revision_index,
+            revision_turn,
+            revision_trigger,
+            facet,
+            before_text,
+            after_text,
+            confidence,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run(
+    week_start: str,
+    *,
+    github_db: str,
+    sessions_db: str,
+    expectations_db: str,
+    config: Optional[SynthesisConfig] = None,
+    rebuild: bool = False,
+) -> int:
+    """Detect expectation revisions for every unit in *week_start*.
+
+    Parameters
+    ----------
+    week_start:
+        ``YYYY-MM-DD`` anchor.
+    github_db, sessions_db, expectations_db:
+        Paths to the collector / expectation DBs. Only ``expectations_db``
+        is written to; the others are read-only.
+    config:
+        Optional :class:`SynthesisConfig`. Used to select the LLM model
+        and adapter. When ``None``, the fake adapter is still used
+        (matching gap_analysis's offline behavior).
+    rebuild:
+        When True, existing revision rows for the week are deleted before
+        the pass. Otherwise the upsert preserves existing rows
+        (idempotent default — per AS-7).
+
+    Returns
+    -------
+    Number of revision rows written for the week. ``0`` is a valid no-op
+    (no expectations, or no units have structural triggers).
+    """
+    exp_conn = sqlite3.connect(str(expectations_db))
+    gh_conn = sqlite3.connect(str(github_db))
+    sessions_conn = None
+    try:
+        # Pre-flight: ensure the table exists.
+        try:
+            exp_conn.execute(
+                "SELECT 1 FROM expectation_revisions LIMIT 1"
+            ).fetchall()
+        except sqlite3.OperationalError:
+            logger.warning(
+                "expectation_revisions table missing — caller did not run "
+                "init_expectations_db; skipping revision pass for week=%s",
+                week_start,
+            )
+            return 0
+
+        _same = sessions_db == github_db
+        try:
+            if not _same:
+                _same = os.path.samefile(github_db, sessions_db)
+        except OSError:
+            pass
+        sessions_conn = gh_conn if _same else sqlite3.connect(str(sessions_db))
+
+        expectations = _load_expectations(exp_conn, week_start)
+        if not expectations:
+            logger.info(
+                "revision_detector: no expectations for week=%s; no-op",
+                week_start,
+            )
+            return 0
+
+        if rebuild:
+            exp_conn.execute(
+                "DELETE FROM expectation_revisions WHERE week_start = ?",
+                (week_start,),
+            )
+            exp_conn.commit()
+
+        # Resolve the LLM adapter once. ``_get_adapter`` accepts None for
+        # offline mode via the AMIS_SYNTHESIS_LIVE env check, but its
+        # signature requires a SynthesisConfig — synthesize one if the
+        # caller did not provide it.
+        if config is None:
+            config = SynthesisConfig(
+                anthropic_api_key_env="ANTHROPIC_API_KEY",
+                model="claude-sonnet-4-5",
+                output_dir="retrospectives",
+                week_start="monday",
+                abandonment_days=14,
+                outlier_sigma=2.0,
+            )
+        try:
+            adapter = _get_adapter(config)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "revision_detector: adapter init failed (%s); skipping "
+                "revision pass for week=%s", exc, week_start,
+            )
+            return 0
+
+        total_written = 0
+        for exp in expectations:
+            unit_id = exp["unit_id"]
+
+            # Skip units with a skip_reason — there is no committed
+            # expectation to revise against.
+            if exp.get("skip_reason"):
+                continue
+
+            sessions = _load_unit_sessions(
+                gh_conn, sessions_conn, week_start, unit_id
+            )
+            if not sessions:
+                continue
+
+            all_turns, total_reprompts, boundaries = _assemble_unit_turns(
+                sessions
+            )
+            if not all_turns:
+                continue
+
+            commitment_idx = _parse_commitment_turn_idx(
+                exp.get("commitment_point")
+            )
+
+            triggers = detect_structural_triggers(
+                all_turns,
+                commitment_turn_idx=commitment_idx,
+                reprompt_count=total_reprompts,
+                session_boundaries=boundaries,
+            )
+            if not triggers:
+                continue
+
+            existing_keys = (
+                set() if rebuild else _existing_revision_keys(
+                    exp_conn, week_start, unit_id
+                )
+            )
+
+            for idx, trigger_record in enumerate(triggers):
+                # Idempotency: when not rebuilding and the row at this
+                # index already exists, _upsert_revision is a no-op and
+                # preserves the original detected_at.
+                preserve = (not rebuild) and (idx in existing_keys)
+
+                classification = classify_revision(
+                    trigger_record,
+                    adapter=adapter,
+                    model=config.model,
+                    expectation=exp,
+                )
+
+                _upsert_revision(
+                    exp_conn,
+                    week_start=week_start,
+                    unit_id=unit_id,
+                    revision_index=idx,
+                    revision_turn=trigger_record["turn_idx"],
+                    revision_trigger=trigger_record["trigger"],
+                    facet=classification["facet"],
+                    before_text=classification["before_text"],
+                    after_text=classification["after_text"],
+                    confidence=classification["confidence"],
+                    preserve_detected_at=preserve,
+                )
+                if not preserve:
+                    total_written += 1
+
+        exp_conn.commit()
+        logger.info(
+            "revision_detector complete: week=%s revisions_written=%d",
+            week_start, total_written,
+        )
+        return total_written
+    finally:
+        if sessions_conn is not None and sessions_conn is not gh_conn:
+            sessions_conn.close()
+        exp_conn.close()
+        gh_conn.close()
+
+
+def load_revision_rows(
+    expectations_db: str, week_start: str
+) -> List[Dict[str, Any]]:
+    """Return revision rows for *week_start*, ordered by unit + revision_index."""
+    conn = sqlite3.connect(str(expectations_db))
+    try:
+        rows = conn.execute(
+            "SELECT unit_id, revision_index, revision_turn, revision_trigger, "
+            "       facet, before_text, after_text, confidence "
+            "FROM expectation_revisions WHERE week_start = ? "
+            "ORDER BY unit_id, revision_index",
+            (week_start,),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return []
+    finally:
+        conn.close()
+    return [
+        {
+            "unit_id": r[0],
+            "revision_index": r[1],
+            "revision_turn": r[2],
+            "revision_trigger": r[3],
+            "facet": r[4],
+            "before_text": r[5],
+            "after_text": r[6],
+            "confidence": r[7],
+        }
+        for r in rows
+    ]
+
+
+__all__ = [
+    "REVISION_TRIGGER_ENUM",
+    "FACET_ENUM",
+    "SESSION_BREAK_THRESHOLD_SECONDS",
+    "detect_structural_triggers",
+    "classify_revision",
+    "run",
+    "load_revision_rows",
+]

--- a/synthesis/weekly.py
+++ b/synthesis/weekly.py
@@ -403,15 +403,22 @@ Required Markdown sections (exact headings, in order)
    Do not prescribe follow-up; surface the signal.
 5. `## Dark Time`                 — fraction of each unit's wall-clock
    span during which no session was active. Highlight the top-2.
-6. `## Clarifying Questions`      — at most TWO total, numbered `1.`
-   and `2.`. Each question should be answerable from the user's memory
-   of the week — no research required.
-7. `## Expectation Gaps`          — units whose expected vs. actual gap
+6. `## Expectation Gaps`          — units whose expected vs. actual gap
    was `major` or `critical`. Each item names the unit, the direction
    of the gap (`under`/`over`/`match`/`ambiguous`), and the idealized-
    workflow step (`phase_0_setup` / `step_1_intent` / ...) that was the
    root-cause precondition. Omit the section body when no major or
    critical gaps exist; keep the heading.
+7. `## Expectation Revisions`     — units with mid-stream expectation
+   shifts (reprompts, scope-change turns, or session breaks > 24 h
+   anchored after the commitment point). Each item names the unit, the
+   trigger type, the facet that shifted (`scope`/`effort`/`outcome`),
+   and the before/after summary. Low-confidence revisions (< 0.5) are
+   annotated as such, not omitted. Omit the section body when no
+   revisions exist; keep the heading.
+8. `## Clarifying Questions`      — at most TWO total, numbered `1.`
+   and `2.`. Each question should be answerable from the user's memory
+   of the week — no research required.
 
 Constraints
 -----------
@@ -527,6 +534,45 @@ def _render_gap_block(gap_rows: List[dict]) -> List[str]:
     return lines
 
 
+def _render_revision_block(revision_rows: List[dict]) -> List[str]:
+    """Render the ``## Expectation Revisions`` Markdown block.
+
+    Groups rows by unit, names each revision's trigger + facet, and
+    annotates low-confidence (<0.5) rows with ``[low confidence]`` so
+    they are surfaced rather than silently dropped (AS-6).
+    """
+    if not revision_rows:
+        return []
+    lines: List[str] = ["", "## Expectation Revisions (from X-3 revision detection)", ""]
+    # Group by unit, preserving the order (rows are already sorted by
+    # unit_id + revision_index upstream).
+    current_unit: Optional[str] = None
+    for row in revision_rows:
+        unit_id = row.get("unit_id")
+        if unit_id != current_unit:
+            lines.append(f"- unit {unit_id}:")
+            current_unit = unit_id
+        trigger = row.get("revision_trigger") or ""
+        facet = row.get("facet") or ""
+        confidence = row.get("confidence")
+        conf_marker = ""
+        if isinstance(confidence, (int, float)) and confidence < 0.5:
+            conf_marker = " [low confidence]"
+        turn = row.get("revision_turn")
+        lines.append(
+            f"    - revision at turn {turn}: trigger={trigger}, "
+            f"facet={facet}{conf_marker}"
+        )
+        before = row.get("before_text")
+        after = row.get("after_text")
+        if before:
+            lines.append(f"        - before: {before}")
+        if after:
+            lines.append(f"        - after: {after}")
+    lines.append("")
+    return lines
+
+
 def _assemble_prompt(
     units: List[dict],
     unit_transcripts: dict,
@@ -534,6 +580,7 @@ def _assemble_prompt(
     week_start: str,
     unit_attributions: Optional[dict] = None,
     gap_rows: Optional[List[dict]] = None,
+    revision_rows: Optional[List[dict]] = None,
 ) -> Tuple[str, List[dict]]:
     """Return (system_prompt, user_messages) for the synthesis call.
 
@@ -577,6 +624,11 @@ def _assemble_prompt(
     # minor/none stay in the DB for X-5 calibration.
     if gap_rows:
         body_parts.extend(_render_gap_block(gap_rows))
+
+    # Epic #27 — X-3 (#74): inject revision rows. All revisions are
+    # surfaced (low-confidence ones are annotated, not dropped).
+    if revision_rows:
+        body_parts.extend(_render_revision_block(revision_rows))
 
     user_content = "\n".join(body_parts)
     return _STATIC_SYSTEM_PROMPT, [{"role": "user", "content": user_content}]
@@ -785,11 +837,13 @@ def run_synthesis(
                         gh_conn, week_start, repo_part, issue_number, session_uuids
                     )
 
-        # Epic #27 — X-2 (#73): run the gap pass before prompt assembly so
-        # gap rows are available to inject into the user message. Silent
-        # no-op when expectations_db is None (operator has not wired X-1
-        # yet) or the DB has no expectations rows for this week.
+        # Epic #27 — X-2 (#73) + X-3 (#74): run the gap + revision passes
+        # before prompt assembly so their rows are available to inject
+        # into the user message. Silent no-op when expectations_db is
+        # None (operator has not wired X-1 yet) or the DB has no
+        # expectations rows for this week.
         gap_rows: List[dict] = []
+        revision_rows: List[dict] = []
         if expectations_db is not None:
             from synthesis import gap_analysis
 
@@ -821,6 +875,36 @@ def run_synthesis(
                     week_start, exc,
                 )
 
+            # X-3 revision detection — parallel to the gap pass. Each
+            # side reads X-1's ``expectations`` rows and writes its own
+            # sibling table, so the two can run in either order.
+            from synthesis import revision_detector
+
+            try:
+                revision_detector.run(
+                    week_start,
+                    github_db=str(gh_path),
+                    sessions_db=str(sess_path),
+                    expectations_db=str(expectations_db),
+                    config=config,
+                )
+                revision_rows = revision_detector.load_revision_rows(
+                    str(expectations_db), week_start
+                )
+            except sqlite3.OperationalError as exc:
+                logger.warning(
+                    "Revision detection skipped for week=%s: %s. Run "
+                    "'am-init-db' and 'am-extract-expectations' first.",
+                    week_start, exc,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Revision detection failed for week=%s: %s. "
+                    "Retrospective will be written without the "
+                    "Expectation Revisions section.",
+                    week_start, exc,
+                )
+
         system_prompt, messages = _assemble_prompt(
             units,
             unit_transcripts,
@@ -828,6 +912,7 @@ def run_synthesis(
             week_start,
             unit_attributions,
             gap_rows=gap_rows,
+            revision_rows=revision_rows,
         )
 
         # --- Issue #54 P-2: prompt-size guard -------------------------

--- a/tests/test_revision_detection.py
+++ b/tests/test_revision_detection.py
@@ -1,0 +1,618 @@
+"""Tests for ``synthesis/revision_detector.py`` (Epic #27 — X-3, Issue #74)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from am_i_shipping.config_loader import SynthesisConfig
+from am_i_shipping.db import (
+    EXPECTED_EXPECTATIONS_TABLES,
+    assert_schema,
+    init_expectations_db,
+    init_github_db,
+    init_sessions_db,
+)
+from synthesis import revision_detector
+from synthesis.revision_detector import (
+    FACET_ENUM,
+    REVISION_TRIGGER_ENUM,
+    SESSION_BREAK_THRESHOLD_SECONDS,
+    classify_revision,
+    detect_structural_triggers,
+    load_revision_rows,
+)
+
+
+WEEK_START = "2026-04-14"
+
+
+def _make_config(**overrides) -> SynthesisConfig:
+    base = SynthesisConfig(
+        anthropic_api_key_env="ANTHROPIC_API_KEY",
+        model="claude-sonnet-4-5",
+        output_dir="retrospectives",
+        week_start="monday",
+        abandonment_days=14,
+        outlier_sigma=2.0,
+    )
+    if overrides:
+        return replace(base, **overrides)
+    return base
+
+
+@pytest.fixture(autouse=True)
+def _scrub_live_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("AMIS_SYNTHESIS_LIVE", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    yield
+
+
+def _turn(role: str, kind: str, text: str = "") -> dict:
+    return {"role": role, "kind": kind, "text": text, "index": 0}
+
+
+def _raw_content_from_turns(turns: list[dict]) -> str:
+    """Build a raw_content_json that _extract_turns can parse back."""
+    messages = []
+    # Group sequential turns into messages by role.
+    for t in turns:
+        if t["kind"] == "text":
+            messages.append({"role": t["role"], "content": t["text"]})
+        elif t["kind"] == "tool_use":
+            messages.append(
+                {
+                    "role": t["role"],
+                    "content": [{"type": "tool_use", "name": "x", "input": {}}],
+                }
+            )
+    return json.dumps(messages)
+
+
+# ---------------------------------------------------------------------------
+# AS-1 — schema
+# ---------------------------------------------------------------------------
+
+
+class TestExpectationRevisionsSchema:
+    def test_init_creates_expectation_revisions_table(self, tmp_path: Path):
+        db = tmp_path / "expectations.db"
+        init_expectations_db(db)
+        assert_schema(db, EXPECTED_EXPECTATIONS_TABLES)
+
+        conn = sqlite3.connect(str(db))
+        try:
+            cols = {
+                r[1]
+                for r in conn.execute(
+                    "PRAGMA table_info(expectation_revisions)"
+                ).fetchall()
+            }
+        finally:
+            conn.close()
+
+        required = {
+            "week_start",
+            "unit_id",
+            "revision_index",
+            "revision_turn",
+            "revision_trigger",
+            "facet",
+            "before_text",
+            "after_text",
+            "confidence",
+            "detected_at",
+        }
+        missing = required - cols
+        assert not missing, f"missing columns: {missing}"
+
+    def test_idempotent_init(self, tmp_path: Path):
+        db = tmp_path / "expectations.db"
+        init_expectations_db(db)
+        init_expectations_db(db)
+        assert_schema(db, EXPECTED_EXPECTATIONS_TABLES)
+
+
+# ---------------------------------------------------------------------------
+# AS-2 / AS-3 / AS-4 — pure-function structural trigger walker
+# ---------------------------------------------------------------------------
+
+
+class TestDetectStructuralTriggers:
+    def test_no_triggers_for_clean_unit(self):
+        turns = [
+            _turn("user", "text", "please fix X"),
+            _turn("assistant", "text", "ok"),
+            _turn("assistant", "tool_use"),
+        ]
+        records = detect_structural_triggers(
+            turns, commitment_turn_idx=0, reprompt_count=0
+        )
+        assert records == []
+
+    def test_reprompt_anchored_after_assistant(self):
+        # user (commitment) -> assistant -> user (reprompt #1)
+        turns = [
+            _turn("user", "text", "plan: do X"),
+            _turn("assistant", "text", "ok, starting"),
+            _turn("user", "text", "wait, also do Y"),
+        ]
+        records = detect_structural_triggers(
+            turns, commitment_turn_idx=0, reprompt_count=1
+        )
+        # At least one reprompt trigger at turn 2.
+        reprompts = [r for r in records if r["trigger"] == "reprompt"]
+        assert len(reprompts) == 1
+        assert reprompts[0]["turn_idx"] == 2
+
+    def test_scope_change_cue_triggers(self):
+        turns = [
+            _turn("user", "text", "fix X"),
+            _turn("assistant", "text", "ok"),
+            _turn("user", "text", "actually, rewrite the whole module"),
+        ]
+        records = detect_structural_triggers(
+            turns, commitment_turn_idx=0, reprompt_count=0
+        )
+        scope_changes = [r for r in records if r["trigger"] == "scope_change_turn"]
+        assert len(scope_changes) == 1
+        assert scope_changes[0]["turn_idx"] == 2
+
+    def test_session_break_anchors_to_resumption(self):
+        turns = [
+            _turn("user", "text", "start"),
+            _turn("assistant", "text", "ok"),
+            _turn("user", "text", "resumed"),
+        ]
+        prev_end = datetime(2026, 4, 10, 10, 0, 0, tzinfo=timezone.utc)
+        this_start = prev_end + timedelta(hours=48)
+        records = detect_structural_triggers(
+            turns,
+            commitment_turn_idx=0,
+            reprompt_count=0,
+            session_boundaries=[(2, prev_end, this_start)],
+        )
+        breaks = [r for r in records if r["trigger"] == "session_break"]
+        assert len(breaks) == 1
+        assert breaks[0]["turn_idx"] == 2
+
+    def test_session_break_under_threshold_ignored(self):
+        turns = [
+            _turn("user", "text", "start"),
+            _turn("user", "text", "quick resume"),
+        ]
+        prev_end = datetime(2026, 4, 10, 10, 0, 0, tzinfo=timezone.utc)
+        this_start = prev_end + timedelta(hours=2)  # < 24h
+        records = detect_structural_triggers(
+            turns,
+            commitment_turn_idx=0,
+            reprompt_count=0,
+            session_boundaries=[(1, prev_end, this_start)],
+        )
+        breaks = [r for r in records if r["trigger"] == "session_break"]
+        assert breaks == []
+
+    def test_only_triggers_after_commitment(self):
+        # reprompt before commitment is ignored.
+        turns = [
+            _turn("user", "text", "vague idea"),
+            _turn("assistant", "text", "what exactly"),
+            _turn("user", "text", "actually this"),  # scope cue pre-commit
+            _turn("assistant", "text", "ok"),
+            _turn("user", "text", "final plan"),  # commitment
+            _turn("assistant", "text", "going"),
+            _turn("user", "text", "also handle Z"),  # post-commit
+        ]
+        records = detect_structural_triggers(
+            turns, commitment_turn_idx=4, reprompt_count=2
+        )
+        for r in records:
+            assert r["turn_idx"] > 4, (
+                f"trigger at {r['turn_idx']} is not after commitment 4"
+            )
+
+
+# ---------------------------------------------------------------------------
+# LLM classifier (fake adapter path)
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyRevision:
+    def test_fake_adapter_returns_low_confidence_record(self):
+        from synthesis.llm_adapter import _get_adapter
+
+        adapter = _get_adapter(_make_config())
+        record = {
+            "trigger": "reprompt",
+            "turn_idx": 5,
+            "text": "actually, also do Y",
+            "context": "turn 5 [ANCHOR]: actually, also do Y",
+        }
+        result = classify_revision(record, adapter=adapter, model="claude-sonnet-4-5")
+        assert result["facet"] in FACET_ENUM
+        assert isinstance(result["before_text"], str)
+        assert isinstance(result["after_text"], str)
+        assert 0.0 <= result["confidence"] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Pipeline integration (AS-2, AS-7, AS-8)
+# ---------------------------------------------------------------------------
+
+
+def _init_dbs(tmp_path: Path) -> tuple[Path, Path, Path]:
+    gh = tmp_path / "github.db"
+    sess = tmp_path / "sessions.db"
+    exp = tmp_path / "expectations.db"
+    init_github_db(gh)
+    init_sessions_db(sess)
+    init_expectations_db(exp)
+    return gh, sess, exp
+
+
+def _seed_unit_and_graph(
+    gh_db: Path,
+    *,
+    unit_id: str,
+    session_uuids: list[str],
+    week_start: str = WEEK_START,
+) -> None:
+    """Seed a units row + graph_nodes + graph_edges linking to sessions."""
+    conn = sqlite3.connect(str(gh_db))
+    try:
+        root_node_id = f"unit:{unit_id}"
+        conn.execute(
+            "INSERT INTO units "
+            "(week_start, unit_id, root_node_type, root_node_id, "
+            " elapsed_days, dark_time_pct, total_reprompts, review_cycles, "
+            " status, outlier_flags, abandonment_flag) "
+            "VALUES (?, ?, 'session', ?, 1.0, 0.0, 0, 0, 'closed', '[]', 0)",
+            (week_start, unit_id, root_node_id),
+        )
+        conn.execute(
+            "INSERT INTO graph_nodes (week_start, node_id, node_type, node_ref) "
+            "VALUES (?, ?, 'unit', ?)",
+            (week_start, root_node_id, unit_id),
+        )
+        for sid in session_uuids:
+            conn.execute(
+                "INSERT INTO graph_nodes (week_start, node_id, node_type, node_ref) "
+                "VALUES (?, ?, 'session', ?)",
+                (week_start, sid, sid),
+            )
+            conn.execute(
+                "INSERT INTO graph_edges "
+                "(week_start, src_node_id, dst_node_id, edge_type) "
+                "VALUES (?, ?, ?, 'unit_contains_session')",
+                (week_start, root_node_id, sid),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_session(
+    sess_db: Path,
+    *,
+    session_uuid: str,
+    turns: list[dict],
+    reprompt_count: int = 0,
+    started_at: str | None = None,
+    ended_at: str | None = None,
+) -> None:
+    conn = sqlite3.connect(str(sess_db))
+    try:
+        conn.execute(
+            "INSERT INTO sessions "
+            "(session_uuid, reprompt_count, raw_content_json, "
+            " session_started_at, session_ended_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                session_uuid,
+                reprompt_count,
+                _raw_content_from_turns(turns),
+                started_at,
+                ended_at,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_expectation(
+    exp_db: Path,
+    *,
+    unit_id: str,
+    commitment_point: str | None = "turn 0",
+    skip_reason: str | None = None,
+) -> None:
+    conn = sqlite3.connect(str(exp_db))
+    try:
+        conn.execute(
+            "INSERT INTO expectations "
+            "(week_start, unit_id, commitment_point, expected_scope, "
+            " expected_effort, expected_outcome, confidence, model, "
+            " input_bytes, skip_reason) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                WEEK_START,
+                unit_id,
+                commitment_point,
+                "fix X",
+                "one session",
+                "tests pass",
+                0.8 if skip_reason is None else None,
+                "claude-sonnet-4-5",
+                100,
+                skip_reason,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestPipelineRun:
+    def test_unit_with_reprompt_produces_row(self, tmp_path: Path):
+        gh, sess, exp = _init_dbs(tmp_path)
+        _seed_unit_and_graph(
+            gh, unit_id="u1", session_uuids=["s1"]
+        )
+        _seed_session(
+            sess,
+            session_uuid="s1",
+            reprompt_count=1,
+            turns=[
+                _turn("user", "text", "do X"),
+                _turn("assistant", "text", "ok"),
+                _turn("user", "text", "actually also do Y"),
+            ],
+        )
+        _seed_expectation(exp, unit_id="u1", commitment_point="turn 0")
+
+        written = revision_detector.run(
+            WEEK_START,
+            github_db=str(gh),
+            sessions_db=str(sess),
+            expectations_db=str(exp),
+            config=_make_config(),
+        )
+        assert written >= 1
+        rows = load_revision_rows(str(exp), WEEK_START)
+        assert len(rows) >= 1
+        assert rows[0]["unit_id"] == "u1"
+        assert rows[0]["revision_trigger"] in REVISION_TRIGGER_ENUM
+        assert rows[0]["facet"] in FACET_ENUM
+
+    def test_unit_without_triggers_produces_no_rows(self, tmp_path: Path):
+        gh, sess, exp = _init_dbs(tmp_path)
+        _seed_unit_and_graph(gh, unit_id="u_clean", session_uuids=["s1"])
+        _seed_session(
+            sess,
+            session_uuid="s1",
+            reprompt_count=0,
+            turns=[
+                _turn("user", "text", "plan"),
+                _turn("assistant", "text", "executing"),
+            ],
+        )
+        _seed_expectation(exp, unit_id="u_clean", commitment_point="turn 0")
+
+        written = revision_detector.run(
+            WEEK_START,
+            github_db=str(gh),
+            sessions_db=str(sess),
+            expectations_db=str(exp),
+            config=_make_config(),
+        )
+        assert written == 0
+        assert load_revision_rows(str(exp), WEEK_START) == []
+
+    def test_session_break_produces_row(self, tmp_path: Path):
+        gh, sess, exp = _init_dbs(tmp_path)
+        _seed_unit_and_graph(
+            gh, unit_id="u_break", session_uuids=["s_a", "s_b"]
+        )
+        _seed_session(
+            sess,
+            session_uuid="s_a",
+            reprompt_count=0,
+            turns=[
+                _turn("user", "text", "start"),
+                _turn("assistant", "text", "ok"),
+            ],
+            started_at="2026-04-10T10:00:00+00:00",
+            ended_at="2026-04-10T11:00:00+00:00",
+        )
+        _seed_session(
+            sess,
+            session_uuid="s_b",
+            reprompt_count=0,
+            turns=[
+                _turn("user", "text", "back now"),
+                _turn("assistant", "text", "continuing"),
+            ],
+            # 48h later → exceeds threshold
+            started_at="2026-04-12T11:00:00+00:00",
+            ended_at="2026-04-12T12:00:00+00:00",
+        )
+        _seed_expectation(exp, unit_id="u_break", commitment_point="turn 0")
+
+        revision_detector.run(
+            WEEK_START,
+            github_db=str(gh),
+            sessions_db=str(sess),
+            expectations_db=str(exp),
+            config=_make_config(),
+        )
+        rows = load_revision_rows(str(exp), WEEK_START)
+        triggers = {r["revision_trigger"] for r in rows}
+        assert "session_break" in triggers
+
+
+# ---------------------------------------------------------------------------
+# AS-7 — idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    def test_rerun_without_rebuild_preserves_rows(self, tmp_path: Path):
+        gh, sess, exp = _init_dbs(tmp_path)
+        _seed_unit_and_graph(gh, unit_id="u1", session_uuids=["s1"])
+        _seed_session(
+            sess,
+            session_uuid="s1",
+            reprompt_count=1,
+            turns=[
+                _turn("user", "text", "do X"),
+                _turn("assistant", "text", "ok"),
+                _turn("user", "text", "actually also do Y"),
+            ],
+        )
+        _seed_expectation(exp, unit_id="u1", commitment_point="turn 0")
+
+        revision_detector.run(
+            WEEK_START,
+            github_db=str(gh),
+            sessions_db=str(sess),
+            expectations_db=str(exp),
+            config=_make_config(),
+        )
+        conn = sqlite3.connect(str(exp))
+        try:
+            before = conn.execute(
+                "SELECT revision_index, detected_at FROM expectation_revisions "
+                "WHERE unit_id='u1' ORDER BY revision_index"
+            ).fetchall()
+            count_before = len(before)
+        finally:
+            conn.close()
+        assert count_before >= 1
+
+        # Re-run without rebuild — same row count, same detected_at values.
+        revision_detector.run(
+            WEEK_START,
+            github_db=str(gh),
+            sessions_db=str(sess),
+            expectations_db=str(exp),
+            config=_make_config(),
+        )
+        conn = sqlite3.connect(str(exp))
+        try:
+            after = conn.execute(
+                "SELECT revision_index, detected_at FROM expectation_revisions "
+                "WHERE unit_id='u1' ORDER BY revision_index"
+            ).fetchall()
+        finally:
+            conn.close()
+        assert len(after) == count_before
+        assert after == before, "detected_at must be preserved on idempotent re-run"
+
+
+# ---------------------------------------------------------------------------
+# AS-8 — integration into run_synthesis + AS-5/AS-6 rendering
+# ---------------------------------------------------------------------------
+
+
+class TestWeeklyIntegration:
+    def test_revision_pass_runs_inside_run_synthesis(self, tmp_path: Path):
+        from synthesis.weekly import run_synthesis
+
+        gh, sess, exp = _init_dbs(tmp_path)
+        _seed_unit_and_graph(gh, unit_id="u1", session_uuids=["s1"])
+        _seed_session(
+            sess,
+            session_uuid="s1",
+            reprompt_count=1,
+            turns=[
+                _turn("user", "text", "do X"),
+                _turn("assistant", "text", "ok"),
+                _turn("user", "text", "actually also do Y"),
+            ],
+        )
+        _seed_expectation(exp, unit_id="u1", commitment_point="turn 0")
+
+        # unit_summaries row required by run_synthesis.
+        conn = sqlite3.connect(str(gh))
+        try:
+            conn.execute(
+                "INSERT INTO unit_summaries "
+                "(week_start, unit_id, summary_text, model, input_bytes) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (WEEK_START, "u1", "summary", "fake", 7),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        out_dir = tmp_path / "retrospectives"
+        cfg = replace(_make_config(), output_dir=str(out_dir))
+
+        result = run_synthesis(
+            cfg, gh, sess, WEEK_START, dry_run=False, expectations_db=exp,
+        )
+        assert result is not None
+
+        rows = load_revision_rows(str(exp), WEEK_START)
+        assert len(rows) >= 1
+
+    def test_section_order_and_low_confidence_marker_in_prompt(
+        self, tmp_path: Path
+    ):
+        """Verify dry-run prompt contains Gaps BEFORE Revisions, with low-conf marker."""
+        from synthesis.weekly import run_synthesis
+
+        gh, sess, exp = _init_dbs(tmp_path)
+        _seed_unit_and_graph(gh, unit_id="u1", session_uuids=["s1"])
+        _seed_session(
+            sess,
+            session_uuid="s1",
+            reprompt_count=1,
+            turns=[
+                _turn("user", "text", "do X"),
+                _turn("assistant", "text", "ok"),
+                _turn("user", "text", "actually also do Y"),
+            ],
+        )
+        _seed_expectation(exp, unit_id="u1", commitment_point="turn 0")
+
+        conn = sqlite3.connect(str(gh))
+        try:
+            conn.execute(
+                "INSERT INTO unit_summaries "
+                "(week_start, unit_id, summary_text, model, input_bytes) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (WEEK_START, "u1", "summary", "fake", 7),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        out_dir = tmp_path / "retrospectives"
+        cfg = replace(_make_config(), output_dir=str(out_dir))
+
+        # dry_run writes the assembled prompt to disk — inspect it.
+        dry_path = run_synthesis(
+            cfg, gh, sess, WEEK_START, dry_run=True, expectations_db=exp,
+        )
+        assert dry_path is not None
+        text = Path(dry_path).read_text(encoding="utf-8")
+
+        # The user message must include the Revisions block heading.
+        assert "## Expectation Revisions" in text
+
+        # The system prompt must list Expectation Gaps BEFORE Expectation
+        # Revisions. Revisions must come BEFORE Clarifying Questions.
+        gaps_idx = text.index("`## Expectation Gaps`")
+        revisions_idx = text.index("`## Expectation Revisions`")
+        clarifying_idx = text.index("`## Clarifying Questions`")
+        assert gaps_idx < revisions_idx < clarifying_idx
+
+        # Low-confidence marker — the fake adapter yields confidence=0.3.
+        assert "[low confidence]" in text


### PR DESCRIPTION
## Summary

- Adds `expectation_revisions` table to `expectations.db` (schema + `EXPECTED_EXPECTATIONS_TABLES` registry in `db.py`), keyed on `(week_start, unit_id, revision_index)`.
- New `synthesis/revision_detector.py`: pure-function structural trigger walker (reprompt, scope_change_turn, session_break >24 h) + LLM classifier for facet/before/after/confidence; upserts on idempotent re-runs.
- Wired into `run_synthesis` in `synthesis/weekly.py` alongside the X-2 gap pass; adds `## Expectation Revisions` section to the static system prompt (in correct order: after Gaps, before Clarifying Questions) and to the assembled user message.
- 15 new tests in `tests/test_revision_detection.py` covering schema, pure-function walker, fake-adapter classifier, pipeline integration, idempotency, section order, and low-confidence marker.

## Test plan

- [x] `pytest tests/test_revision_detection.py` — 15 passed
- [x] `pytest tests/test_gap_analysis.py tests/test_weekly.py tests/test_init_db.py tests/test_expectations.py` — 92 passed (no regressions)
- [x] Structural trigger walker is a pure function with no I/O (unit-testable in isolation)
- [x] Idempotency: re-running without `--rebuild` preserves `detected_at` and does not insert duplicates
- [x] Low-confidence rows (confidence < 0.5) annotated with `[low confidence]` in prompt, not dropped
- [x] Section order: `## Expectation Gaps` < `## Expectation Revisions` < `## Clarifying Questions` asserted in test

Closes #74. Part of epic #27 (sub-issue 3/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)