### PR TITLE
feat(#75): X-4 user feedback loop (epic #27)

### DIFF
--- a/am_i_shipping/db.py
+++ b/am_i_shipping/db.py
@@ -354,6 +354,43 @@ CREATE TABLE IF NOT EXISTS expectation_revisions (
 );
 """
 
+# Epic #27 — X-4 (#75): expectation_corrections schema.
+#
+# Written by ``synthesis.correction`` when the user runs
+# ``am-synthesize correct`` (interactive agentic workflow) and by the
+# auto-confirm sweep that runs on every ``am-synthesize --week``
+# invocation.
+#
+# IRREVERSIBLE column names (per the epic ADR): ``week_start``,
+# ``unit_id``, ``facet``, ``original_value``, ``corrected_value``,
+# ``correction_note``, ``corrected_by``. X-5 calibration keys off these
+# names; renaming after corrections accumulate is expensive.
+#
+# * ``facet``          — one of {``commitment_point``, ``scope``,
+#                         ``effort``, ``outcome``, ``severity``,
+#                         ``failure_precondition``}.
+# * ``corrected_by``   — one of {``user``, ``auto_confirm``}.
+# * ``original_value`` — the value that was in the ``expectation_gaps``
+#                         row at the moment the correction was written.
+#                         The gap row itself is NEVER mutated — X-5
+#                         needs the before/after delta.
+# * ``corrected_value``— equal to ``original_value`` when the user
+#                         confirmed without change; different when a
+#                         correction was supplied.
+SYNTHESIS_EXPECTATION_CORRECTIONS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS expectation_corrections (
+    week_start       TEXT NOT NULL,
+    unit_id          TEXT NOT NULL,
+    facet            TEXT NOT NULL,
+    original_value   TEXT,
+    corrected_value  TEXT,
+    correction_note  TEXT,
+    corrected_by     TEXT NOT NULL,
+    corrected_at     TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (week_start, unit_id, facet)
+);
+"""
+
 EXPECTED_EXPECTATIONS_TABLES: dict[str, set[str]] = {
     "expectations": {
         "week_start",
@@ -392,6 +429,16 @@ EXPECTED_EXPECTATIONS_TABLES: dict[str, set[str]] = {
         "after_text",
         "confidence",
         "detected_at",
+    },
+    "expectation_corrections": {
+        "week_start",
+        "unit_id",
+        "facet",
+        "original_value",
+        "corrected_value",
+        "correction_note",
+        "corrected_by",
+        "corrected_at",
     },
 }
 
@@ -780,6 +827,8 @@ def init_expectations_db(db_path: Path) -> None:
         conn.execute(SYNTHESIS_EXPECTATION_GAPS_SCHEMA)
         # Epic #27 — X-3 (#74): expectation_revisions lives in the same DB.
         conn.execute(SYNTHESIS_EXPECTATION_REVISIONS_SCHEMA)
+        # Epic #27 — X-4 (#75): expectation_corrections lives in the same DB.
+        conn.execute(SYNTHESIS_EXPECTATION_CORRECTIONS_SCHEMA)
         for migration in _EXPECTATIONS_MIGRATIONS:
             try:
                 conn.execute(migration)

--- a/synthesis/cli.py
+++ b/synthesis/cli.py
@@ -72,7 +72,36 @@ def _build_parser() -> argparse.ArgumentParser:
 
     subparsers = parser.add_subparsers(dest="subcommand")
     add_coverage_subparser(subparsers)
+    _add_correct_subparser(subparsers)
     return parser
+
+
+def _add_correct_subparser(subparsers) -> None:
+    """Register the ``am-synthesize correct`` subcommand (Epic #27 X-4)."""
+    correct = subparsers.add_parser(
+        "correct",
+        help=(
+            "Interactive agentic correction loop for the week's major/"
+            "critical expectation gaps. Persists corrections into "
+            "expectations.db; does NOT rewrite retrospective .md files."
+        ),
+    )
+    correct.add_argument(
+        "--week",
+        default=None,
+        help=(
+            "Week start date (YYYY-MM-DD). Default: most recent week that "
+            "has gap rows in expectations.db."
+        ),
+    )
+    correct.add_argument(
+        "--unit",
+        default=None,
+        help=(
+            "Restrict the correction loop to a single unit_id. Default: "
+            "iterate over every major/critical gap in the week."
+        ),
+    )
 
 
 def _run_weekly(args: argparse.Namespace) -> int:
@@ -126,6 +155,62 @@ def _run_weekly(args: argparse.Namespace) -> int:
     return 0
 
 
+def _latest_week_with_gaps(expectations_db: Path) -> Optional[str]:
+    """Return the most recent ``week_start`` that has any gap rows."""
+    import sqlite3
+
+    if not expectations_db.exists():
+        return None
+    conn = sqlite3.connect(str(expectations_db))
+    try:
+        try:
+            row = conn.execute(
+                "SELECT week_start FROM expectation_gaps "
+                "ORDER BY week_start DESC LIMIT 1"
+            ).fetchone()
+        except sqlite3.OperationalError:
+            return None
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+def _run_correct(args: argparse.Namespace) -> int:
+    """``am-synthesize correct`` — X-4 interactive correction loop."""
+    config = load_config(args.config)
+    data_dir: Path = config.data_path
+    expectations_db = data_dir / "expectations.db"
+
+    week = args.week or _latest_week_with_gaps(expectations_db)
+    if not week:
+        print(
+            "am-synthesize correct: no week specified and no gap rows found "
+            "in expectations.db. Run 'am-synthesize --week YYYY-MM-DD' first.",
+            file=sys.stderr,
+        )
+        return 2
+
+    synthesis_cfg = config.synthesis
+    output_dir = config.synthesis_output_path
+    resolved_cfg = replace(synthesis_cfg, output_dir=str(output_dir))
+
+    try:
+        from synthesis.correction import run_correction_session
+
+        written = run_correction_session(
+            week,
+            expectations_db=str(expectations_db),
+            config=resolved_cfg,
+            unit_id=args.unit,
+        )
+    except Exception:  # noqa: BLE001 — CLI is top of stack
+        logging.exception("Correction session failed")
+        return 2
+
+    print(f"Correction session complete: {written} rows written for week={week}")
+    return 0
+
+
 def _run_coverage(args: argparse.Namespace) -> int:
     config = load_config(args.config)
     data_dir: Path = config.data_path
@@ -161,6 +246,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     if args.subcommand == "coverage":
         return _run_coverage(args)
+    if args.subcommand == "correct":
+        return _run_correct(args)
     return _run_weekly(args)
 
 

--- a/synthesis/correction.py
+++ b/synthesis/correction.py
@@ -1,0 +1,613 @@
+"""Epic #27 — X-4 (#75): interactive agentic feedback loop.
+
+Drives a multi-turn LLM conversation that walks the user through the
+major/critical gap rows produced by X-2 (``expectation_gaps``) and
+persists their corrections into ``expectation_corrections``. Also owns
+the auto-confirm sweep: any gap row older than 14 days without a user
+correction gets a ``corrected_by='auto_confirm'`` row written on every
+``am-synthesize --week`` invocation (passive assent).
+
+Design priors inherited from the epic intent:
+
+* **Ship skeleton over plan to perfection.** The v1 agentic loop is
+  deliberately minimal — one facet per LLM turn, bounded by a hard
+  6-turn cap per gap. Sophistication lives in X-5's consumption of the
+  corrections, not in the UI polish here.
+* **Corrections are durable in ``expectations.db``.** The shipped
+  retrospective ``.md`` is NEVER rewritten (Epic #17 idempotency).
+  Future retrospectives read corrected values from the DB.
+* **Original value preserved.** ``expectation_gaps`` rows are not
+  mutated — ``original_value`` is a snapshot captured at correction
+  time. X-5 needs the before/after delta intact.
+* **Re-entrant.** A partial correction session can be resumed:
+  already-corrected ``(week_start, unit_id, facet)`` triples are
+  skipped.
+
+The module is intentionally I/O-parameterised (``input_fn`` /
+``output_fn``) so tests drive the loop without a real TTY, and the LLM
+adapter is the same ``_get_adapter`` abstraction the rest of synthesis
+uses. In offline mode (``AMIS_SYNTHESIS_LIVE`` unset) the fake client
+returns canned text that does not parse as a correction turn; the
+module treats unparseable agent output as "confirm, no change" so the
+offline smoke-test path still writes rows.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from am_i_shipping.config_loader import SynthesisConfig
+from synthesis.llm_adapter import _get_adapter
+
+
+logger = logging.getLogger(__name__)
+
+
+# The full facet list a correction session walks for a single gap row.
+# Order is intentional — the "what did we think would happen" facets
+# come first (commitment_point, scope, effort, outcome), then the
+# "what went wrong" facets (severity, failure_precondition).
+FACETS: Tuple[str, ...] = (
+    "commitment_point",
+    "scope",
+    "effort",
+    "outcome",
+    "severity",
+    "failure_precondition",
+)
+
+# Hard cap per gap per X4-OQ-1 default. Unbounded turns risk cost
+# overruns; the cap is applied AFTER the initial presentation turn.
+MAX_TURNS_PER_GAP = 6
+
+# Auto-confirm horizon — matches the X-2 expectation_gaps sweep window.
+AUTO_CONFIRM_DAYS = 14
+
+_MAX_OUTPUT_TOKENS = 512
+
+
+_CORRECTION_SYSTEM_PROMPT = """You are the correction agent for a \
+retrospective calibration system. The user is reviewing a gap row that \
+describes an expectation-vs-actual deviation for one software unit. Your \
+job for this turn is to propose the single most useful clarifying \
+question for the named facet, OR — if the user has already given a clear \
+answer — to emit a structured correction.
+
+You will be given:
+- The gap row's original expectation + actual outcome for context.
+- The facet under review (one of: commitment_point, scope, effort, \
+outcome, severity, failure_precondition).
+- The user's most recent reply (may be empty on the first turn).
+
+Return a single JSON object with exactly these keys:
+  action: "ask" | "confirm" | "correct"
+  question: string (non-empty when action='ask', otherwise "")
+  corrected_value: string (only meaningful when action='correct')
+  correction_note: string (short rationale; empty string when unused)
+
+Rules:
+- "ask" — you need more information; question is one short sentence.
+- "confirm" — the user has indicated the original value is correct.
+- "correct" — the user has supplied a new value; copy it into \
+corrected_value.
+- Do NOT wrap the JSON in Markdown fences. Do NOT add extra keys."""
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_agent_turn(text: str) -> Optional[Dict[str, Any]]:
+    """Parse the LLM's JSON response for a single correction turn.
+
+    Returns ``None`` on any parse failure. The caller treats ``None``
+    as "confirm no change" so the offline path still writes rows.
+    """
+    if not text:
+        return None
+    m = re.search(r"\{.*\}", text, re.DOTALL)
+    if not m:
+        return None
+    try:
+        obj = json.loads(m.group(0))
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(obj, dict):
+        return None
+    action = obj.get("action")
+    if action not in {"ask", "confirm", "correct"}:
+        return None
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_major_critical_gaps(
+    exp_conn: sqlite3.Connection,
+    week_start: str,
+    unit_id: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Return major/critical gap rows for the week (optionally one unit)."""
+    sql = (
+        "SELECT week_start, unit_id, commitment_point, scope_gap, "
+        "       effort_gap, outcome_gap, severity, direction, "
+        "       failure_precondition "
+        "FROM expectation_gaps "
+        "WHERE week_start = ? AND severity IN ('major', 'critical') "
+    )
+    params: List[Any] = [week_start]
+    if unit_id is not None:
+        sql += "AND unit_id = ? "
+        params.append(unit_id)
+    sql += "ORDER BY unit_id"
+    rows = exp_conn.execute(sql, params).fetchall()
+    return [
+        {
+            "week_start": r[0],
+            "unit_id": r[1],
+            "commitment_point": r[2],
+            "scope_gap": r[3],
+            "effort_gap": r[4],
+            "outcome_gap": r[5],
+            "severity": r[6],
+            "direction": r[7],
+            "failure_precondition": r[8],
+        }
+        for r in rows
+    ]
+
+
+def _load_expectation(
+    exp_conn: sqlite3.Connection, week_start: str, unit_id: str
+) -> Optional[Dict[str, Any]]:
+    row = exp_conn.execute(
+        "SELECT commitment_point, expected_scope, expected_effort, "
+        "       expected_outcome, confidence, skip_reason "
+        "FROM expectations WHERE week_start = ? AND unit_id = ?",
+        (week_start, unit_id),
+    ).fetchone()
+    if row is None:
+        return None
+    return {
+        "commitment_point": row[0],
+        "expected_scope": row[1],
+        "expected_effort": row[2],
+        "expected_outcome": row[3],
+        "confidence": row[4],
+        "skip_reason": row[5],
+    }
+
+
+def _existing_correction_facets(
+    exp_conn: sqlite3.Connection, week_start: str, unit_id: str
+) -> set[str]:
+    rows = exp_conn.execute(
+        "SELECT facet FROM expectation_corrections "
+        "WHERE week_start = ? AND unit_id = ?",
+        (week_start, unit_id),
+    ).fetchall()
+    return {r[0] for r in rows}
+
+
+def _insert_correction(
+    exp_conn: sqlite3.Connection,
+    *,
+    week_start: str,
+    unit_id: str,
+    facet: str,
+    original_value: Optional[str],
+    corrected_value: Optional[str],
+    correction_note: Optional[str],
+    corrected_by: str,
+) -> None:
+    """Insert a correction row. No-op on PK conflict (re-entrant safe)."""
+    exp_conn.execute(
+        "INSERT OR IGNORE INTO expectation_corrections "
+        "(week_start, unit_id, facet, original_value, corrected_value, "
+        " correction_note, corrected_by, corrected_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))",
+        (
+            week_start,
+            unit_id,
+            facet,
+            original_value,
+            corrected_value,
+            correction_note,
+            corrected_by,
+        ),
+    )
+
+
+def _mark_gap_auto_confirmed(
+    exp_conn: sqlite3.Connection,
+    week_start: str,
+    unit_id: str,
+    value: int,
+) -> None:
+    exp_conn.execute(
+        "UPDATE expectation_gaps SET auto_confirmed = ? "
+        "WHERE week_start = ? AND unit_id = ?",
+        (value, week_start, unit_id),
+    )
+
+
+def _original_value_for_facet(
+    gap: Dict[str, Any], expectation: Optional[Dict[str, Any]], facet: str
+) -> Optional[str]:
+    """Snapshot the current value for *facet* from the gap + expectation."""
+    if facet == "commitment_point":
+        return gap.get("commitment_point")
+    if facet == "severity":
+        return gap.get("severity")
+    if facet == "failure_precondition":
+        return gap.get("failure_precondition")
+    if expectation is None:
+        # Fall back to the gap-row's textual description of the deviation.
+        fallback_map = {
+            "scope": "scope_gap",
+            "effort": "effort_gap",
+            "outcome": "outcome_gap",
+        }
+        return gap.get(fallback_map.get(facet, ""))
+    if facet == "scope":
+        return expectation.get("expected_scope")
+    if facet == "effort":
+        return expectation.get("expected_effort")
+    if facet == "outcome":
+        return expectation.get("expected_outcome")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Auto-confirm sweep (AS-6)
+# ---------------------------------------------------------------------------
+
+
+def auto_confirm_sweep(
+    expectations_db: str,
+    *,
+    days: int = AUTO_CONFIRM_DAYS,
+    now: Optional[datetime] = None,
+) -> int:
+    """Write ``corrected_by='auto_confirm'`` rows for stale gaps.
+
+    For every gap row older than *days* that has no entry in
+    ``expectation_corrections``, insert one correction row per facet
+    (snapshotting the current value into ``original_value`` and
+    ``corrected_value``) and flip ``expectation_gaps.auto_confirmed``
+    to 1. Returns the number of correction rows written.
+
+    Idempotent: already-corrected facets are skipped via the PK
+    ``INSERT OR IGNORE``.
+
+    Parameters
+    ----------
+    expectations_db:
+        Path to ``expectations.db``.
+    days:
+        Age threshold in days. Default 14 (X-4 spec).
+    now:
+        Clock override for tests. Default ``datetime.now(UTC)``.
+    """
+    clock = now or datetime.now(timezone.utc)
+    cutoff = (clock - timedelta(days=days)).strftime("%Y-%m-%d %H:%M:%S")
+    conn = sqlite3.connect(str(expectations_db))
+    try:
+        try:
+            stale = conn.execute(
+                "SELECT week_start, unit_id, commitment_point, scope_gap, "
+                "       effort_gap, outcome_gap, severity, direction, "
+                "       failure_precondition "
+                "FROM expectation_gaps "
+                "WHERE computed_at IS NOT NULL AND computed_at < ?",
+                (cutoff,),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            # expectation_gaps table missing — nothing to sweep.
+            return 0
+
+        if not stale:
+            return 0
+
+        written = 0
+        for r in stale:
+            gap = {
+                "week_start": r[0],
+                "unit_id": r[1],
+                "commitment_point": r[2],
+                "scope_gap": r[3],
+                "effort_gap": r[4],
+                "outcome_gap": r[5],
+                "severity": r[6],
+                "direction": r[7],
+                "failure_precondition": r[8],
+            }
+            existing = _existing_correction_facets(
+                conn, gap["week_start"], gap["unit_id"]
+            )
+            expectation = _load_expectation(
+                conn, gap["week_start"], gap["unit_id"]
+            )
+            for facet in FACETS:
+                if facet in existing:
+                    continue
+                original = _original_value_for_facet(gap, expectation, facet)
+                _insert_correction(
+                    conn,
+                    week_start=gap["week_start"],
+                    unit_id=gap["unit_id"],
+                    facet=facet,
+                    original_value=original,
+                    corrected_value=original,
+                    correction_note="auto-confirmed after 14 days without user correction",
+                    corrected_by="auto_confirm",
+                )
+                written += 1
+            # Flip the gap row's auto_confirmed flag. The gap row's own
+            # values are NOT mutated — only the flag.
+            _mark_gap_auto_confirmed(
+                conn, gap["week_start"], gap["unit_id"], 1
+            )
+        conn.commit()
+        logger.info(
+            "auto_confirm_sweep: wrote %d correction rows for %d stale gaps",
+            written, len(stale),
+        )
+        return written
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Interactive agentic loop (AS-3, AS-4, AS-5, AS-8, AS-9)
+# ---------------------------------------------------------------------------
+
+
+def _build_gap_context(
+    gap: Dict[str, Any], expectation: Optional[Dict[str, Any]]
+) -> str:
+    parts: List[str] = []
+    parts.append(f"Unit: {gap['unit_id']}")
+    parts.append(f"Week: {gap['week_start']}")
+    parts.append(f"Severity: {gap['severity']}")
+    parts.append(f"Direction: {gap['direction']}")
+    parts.append(f"Failure precondition: {gap.get('failure_precondition')}")
+    parts.append("")
+    if expectation is not None:
+        parts.append("Expectations at commitment point:")
+        parts.append(f"  commitment_point: {expectation.get('commitment_point')}")
+        parts.append(f"  expected_scope: {expectation.get('expected_scope')}")
+        parts.append(f"  expected_effort: {expectation.get('expected_effort')}")
+        parts.append(f"  expected_outcome: {expectation.get('expected_outcome')}")
+    parts.append("")
+    parts.append("Actual deviation (from X-2):")
+    parts.append(f"  scope_gap: {gap.get('scope_gap')}")
+    parts.append(f"  effort_gap: {gap.get('effort_gap')}")
+    parts.append(f"  outcome_gap: {gap.get('outcome_gap')}")
+    return "\n".join(parts)
+
+
+def _run_facet_turn(
+    adapter: Any,
+    model: str,
+    gap_context: str,
+    facet: str,
+    original_value: Optional[str],
+    user_reply: str,
+) -> Dict[str, Any]:
+    """Ask the LLM to produce one structured correction turn.
+
+    Returns the parsed JSON (action/question/corrected_value/note) or a
+    default "confirm no change" dict when parsing fails. The "confirm on
+    parse failure" default is deliberate — in offline mode the fake
+    adapter returns non-JSON text and we still want the loop to make
+    progress.
+    """
+    user_text = (
+        f"{gap_context}\n\n"
+        f"Facet under review: {facet}\n"
+        f"Current value: {original_value!r}\n"
+        f"User reply (may be empty): {user_reply!r}\n"
+    )
+    try:
+        result = adapter.call(
+            _CORRECTION_SYSTEM_PROMPT, user_text, model, _MAX_OUTPUT_TOKENS
+        )
+    except Exception as exc:  # noqa: BLE001 — don't crash the whole loop
+        logger.warning(
+            "correction: adapter.call failed (%s); defaulting to confirm",
+            exc,
+        )
+        return {
+            "action": "confirm",
+            "question": "",
+            "corrected_value": original_value,
+            "correction_note": "",
+        }
+    parsed = _parse_agent_turn(result.text)
+    if parsed is None:
+        return {
+            "action": "confirm",
+            "question": "",
+            "corrected_value": original_value,
+            "correction_note": "",
+        }
+    return parsed
+
+
+def _process_facet(
+    adapter: Any,
+    model: str,
+    gap_context: str,
+    facet: str,
+    original_value: Optional[str],
+    input_fn: Callable[[str], str],
+    output_fn: Callable[[str], None],
+) -> Tuple[Optional[str], str]:
+    """Run the per-facet mini-loop. Returns ``(corrected_value, note)``.
+
+    The loop is bounded by :data:`MAX_TURNS_PER_GAP` per facet. On the
+    first turn ``user_reply`` is empty; subsequent turns feed the user's
+    reply from ``input_fn`` back into the LLM.
+    """
+    user_reply = ""
+    for turn in range(MAX_TURNS_PER_GAP):
+        decision = _run_facet_turn(
+            adapter, model, gap_context, facet, original_value, user_reply
+        )
+        action = decision.get("action")
+        if action == "confirm":
+            return original_value, decision.get("correction_note", "") or ""
+        if action == "correct":
+            cv = decision.get("corrected_value")
+            return (
+                cv if isinstance(cv, str) else original_value,
+                decision.get("correction_note", "") or "",
+            )
+        # action == "ask"
+        question = decision.get("question") or (
+            f"Is the current value for {facet} ({original_value!r}) correct?"
+        )
+        output_fn(f"[{facet}] {question}")
+        try:
+            user_reply = input_fn(f"{facet} > ")
+        except EOFError:
+            # Non-interactive input exhausted — confirm no change.
+            return original_value, ""
+        if not user_reply.strip():
+            # Empty reply → confirm.
+            return original_value, ""
+    # Hit the turn cap without resolution — fall back to confirm.
+    logger.warning(
+        "correction: facet=%s hit max-turn cap (%d); confirming no change",
+        facet, MAX_TURNS_PER_GAP,
+    )
+    return original_value, ""
+
+
+def run_correction_session(
+    week_start: str,
+    *,
+    expectations_db: str,
+    config: SynthesisConfig,
+    unit_id: Optional[str] = None,
+    input_fn: Callable[[str], str] = input,
+    output_fn: Callable[[str], None] = print,
+) -> int:
+    """Walk the week's major/critical gaps and persist user corrections.
+
+    Returns the number of correction rows written in this session.
+    Rows for already-corrected facets are skipped — the session is
+    re-entrant (AS-8).
+
+    When *unit_id* is provided the loop scopes to that unit only.
+    Otherwise every major/critical gap for *week_start* is iterated.
+    """
+    conn = sqlite3.connect(str(expectations_db))
+    try:
+        try:
+            gaps = _load_major_critical_gaps(conn, week_start, unit_id)
+        except sqlite3.OperationalError as exc:
+            logger.warning(
+                "run_correction_session: expectation_gaps missing (%s); "
+                "run 'am-init-db' first.",
+                exc,
+            )
+            return 0
+
+        if not gaps:
+            output_fn(
+                f"No major/critical gaps for week={week_start}"
+                + (f", unit={unit_id}" if unit_id else "")
+            )
+            return 0
+
+        adapter = _get_adapter(config)
+        model = config.model
+        total_written = 0
+
+        for gap in gaps:
+            existing = _existing_correction_facets(
+                conn, gap["week_start"], gap["unit_id"]
+            )
+            if len(existing) >= len(FACETS):
+                # Fully corrected already — skip (AS-8 re-entrancy).
+                continue
+
+            expectation = _load_expectation(
+                conn, gap["week_start"], gap["unit_id"]
+            )
+            gap_context = _build_gap_context(gap, expectation)
+            output_fn("")
+            output_fn(f"=== Gap: unit={gap['unit_id']} severity={gap['severity']} ===")
+            output_fn(gap_context)
+
+            gap_wrote_any = False
+            for facet in FACETS:
+                if facet in existing:
+                    continue
+                original = _original_value_for_facet(gap, expectation, facet)
+                corrected_value, note = _process_facet(
+                    adapter,
+                    model,
+                    gap_context,
+                    facet,
+                    original,
+                    input_fn,
+                    output_fn,
+                )
+                _insert_correction(
+                    conn,
+                    week_start=gap["week_start"],
+                    unit_id=gap["unit_id"],
+                    facet=facet,
+                    original_value=original,
+                    corrected_value=corrected_value,
+                    correction_note=note,
+                    corrected_by="user",
+                )
+                total_written += 1
+                gap_wrote_any = True
+
+            if gap_wrote_any:
+                # AS-4 — flip auto_confirmed to reflect the user's
+                # resolution. 1 when every facet was confirmed (no value
+                # change), 0 when any facet was corrected.
+                any_corrected = bool(
+                    conn.execute(
+                        "SELECT 1 FROM expectation_corrections "
+                        "WHERE week_start = ? AND unit_id = ? "
+                        "  AND corrected_by = 'user' "
+                        "  AND original_value IS NOT corrected_value "
+                        "LIMIT 1",
+                        (gap["week_start"], gap["unit_id"]),
+                    ).fetchone()
+                )
+                _mark_gap_auto_confirmed(
+                    conn,
+                    gap["week_start"],
+                    gap["unit_id"],
+                    0 if any_corrected else 1,
+                )
+            conn.commit()
+        return total_written
+    finally:
+        conn.close()
+
+
+__all__ = [
+    "AUTO_CONFIRM_DAYS",
+    "FACETS",
+    "MAX_TURNS_PER_GAP",
+    "auto_confirm_sweep",
+    "run_correction_session",
+]

--- a/synthesis/weekly.py
+++ b/synthesis/weekly.py
@@ -859,6 +859,20 @@ def run_synthesis(
                     week_start,
                     min_severity=("major", "critical"),
                 )
+                # Epic #27 — X-4 (#75): auto-confirm sweep fires on every
+                # ``am-synthesize --week`` invocation (AS-6). Any gap row
+                # older than 14 days without a user correction gets
+                # ``corrected_by='auto_confirm'`` rows written. Non-fatal
+                # if the corrections table is missing — log + proceed.
+                from synthesis.correction import auto_confirm_sweep
+
+                try:
+                    auto_confirm_sweep(str(expectations_db))
+                except sqlite3.OperationalError as exc:
+                    logger.warning(
+                        "Auto-confirm sweep skipped for week=%s: %s",
+                        week_start, exc,
+                    )
             except sqlite3.OperationalError as exc:
                 # Most likely: expectations.db not initialised yet (X-1
                 # hasn't been run). Log a warning and proceed without the

--- a/tests/test_correction.py
+++ b/tests/test_correction.py
@@ -1,0 +1,658 @@
+"""Tests for ``synthesis/correction.py`` (Epic #27 — X-4, Issue #75)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from am_i_shipping.config_loader import SynthesisConfig
+from am_i_shipping.db import (
+    EXPECTED_EXPECTATIONS_TABLES,
+    assert_schema,
+    init_expectations_db,
+    init_github_db,
+)
+from synthesis import correction
+from synthesis.correction import (
+    AUTO_CONFIRM_DAYS,
+    FACETS,
+    auto_confirm_sweep,
+    run_correction_session,
+)
+
+
+WEEK_START = "2026-04-14"
+
+
+def _make_config(**overrides) -> SynthesisConfig:
+    base = SynthesisConfig(
+        anthropic_api_key_env="ANTHROPIC_API_KEY",
+        model="claude-sonnet-4-5",
+        output_dir="retrospectives",
+        week_start="monday",
+        abandonment_days=14,
+        outlier_sigma=2.0,
+    )
+    if overrides:
+        return replace(base, **overrides)
+    return base
+
+
+def _init_dbs(tmp_path: Path) -> tuple[Path, Path]:
+    gh = tmp_path / "github.db"
+    exp = tmp_path / "expectations.db"
+    init_github_db(gh)
+    init_expectations_db(exp)
+    return gh, exp
+
+
+def _seed_expectation(
+    exp_db: Path,
+    *,
+    unit_id: str,
+    week_start: str = WEEK_START,
+    expected_scope: str = "fix X",
+    expected_effort: str = "one session",
+    expected_outcome: str = "tests pass",
+    commitment_point: str = "turn 3",
+) -> None:
+    conn = sqlite3.connect(str(exp_db))
+    try:
+        conn.execute(
+            "INSERT INTO expectations "
+            "(week_start, unit_id, commitment_point, expected_scope, "
+            " expected_effort, expected_outcome, confidence, model, "
+            " input_bytes, skip_reason) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                week_start,
+                unit_id,
+                commitment_point,
+                expected_scope,
+                expected_effort,
+                expected_outcome,
+                0.8,
+                "claude-sonnet-4-5",
+                100,
+                None,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_gap(
+    exp_db: Path,
+    *,
+    unit_id: str,
+    severity: str = "major",
+    direction: str = "over",
+    failure_precondition: str = "step_4_plan",
+    week_start: str = WEEK_START,
+    commitment_point: str = "turn 3",
+    computed_at: str | None = None,
+) -> None:
+    conn = sqlite3.connect(str(exp_db))
+    try:
+        if computed_at is None:
+            conn.execute(
+                "INSERT INTO expectation_gaps "
+                "(week_start, unit_id, commitment_point, scope_gap, "
+                " effort_gap, outcome_gap, severity, direction, "
+                " failure_precondition, auto_confirmed) "
+                "VALUES (?, ?, ?, 'scope deviated', 'effort deviated', "
+                " 'outcome deviated', ?, ?, ?, 0)",
+                (week_start, unit_id, commitment_point, severity, direction,
+                 failure_precondition),
+            )
+        else:
+            conn.execute(
+                "INSERT INTO expectation_gaps "
+                "(week_start, unit_id, commitment_point, scope_gap, "
+                " effort_gap, outcome_gap, severity, direction, "
+                " failure_precondition, computed_at, auto_confirmed) "
+                "VALUES (?, ?, ?, 'scope deviated', 'effort deviated', "
+                " 'outcome deviated', ?, ?, ?, ?, 0)",
+                (week_start, unit_id, commitment_point, severity, direction,
+                 failure_precondition, computed_at),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture(autouse=True)
+def _scrub_live_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("AMIS_SYNTHESIS_LIVE", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# AS-1: schema exists
+# ---------------------------------------------------------------------------
+
+
+class TestExpectationCorrectionsSchema:
+    def test_init_creates_expectation_corrections_table(self, tmp_path: Path):
+        db = tmp_path / "expectations.db"
+        init_expectations_db(db)
+        assert_schema(db, EXPECTED_EXPECTATIONS_TABLES)
+
+        conn = sqlite3.connect(str(db))
+        try:
+            cols = {
+                r[1]
+                for r in conn.execute(
+                    "PRAGMA table_info(expectation_corrections)"
+                ).fetchall()
+            }
+        finally:
+            conn.close()
+
+        required = {
+            "week_start",
+            "unit_id",
+            "facet",
+            "original_value",
+            "corrected_value",
+            "correction_note",
+            "corrected_by",
+            "corrected_at",
+        }
+        missing = required - cols
+        assert not missing, (
+            f"expectation_corrections missing columns: {missing}"
+        )
+
+    def test_primary_key_is_week_unit_facet(self, tmp_path: Path):
+        db = tmp_path / "expectations.db"
+        init_expectations_db(db)
+        conn = sqlite3.connect(str(db))
+        try:
+            # Insert twice on the same PK — INSERT OR IGNORE should no-op,
+            # and a bare INSERT should raise IntegrityError.
+            conn.execute(
+                "INSERT INTO expectation_corrections "
+                "(week_start, unit_id, facet, original_value, "
+                " corrected_value, correction_note, corrected_by) "
+                "VALUES ('2026-04-14', 'u1', 'scope', 'a', 'b', '', 'user')"
+            )
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO expectation_corrections "
+                    "(week_start, unit_id, facet, original_value, "
+                    " corrected_value, correction_note, corrected_by) "
+                    "VALUES ('2026-04-14', 'u1', 'scope', 'x', 'y', '', 'user')"
+                )
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# AS-2: subcommand wired
+# ---------------------------------------------------------------------------
+
+
+class TestCliSubcommand:
+    def test_correct_subcommand_help(self, capsys: pytest.CaptureFixture):
+        from synthesis.cli import _build_parser
+
+        parser = _build_parser()
+        # Help of the correct subcommand should mention --week and --unit.
+        with pytest.raises(SystemExit):
+            parser.parse_args(["correct", "--help"])
+        captured = capsys.readouterr()
+        assert "--week" in captured.out
+        assert "--unit" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# AS-3, AS-4, AS-5, AS-9: agentic loop with fake adapter
+# ---------------------------------------------------------------------------
+
+
+class _RecordingAdapter:
+    """Test adapter that returns pre-scripted JSON responses in order.
+
+    Mirrors :class:`synthesis.llm_adapter._FakeAdapter`'s call surface.
+    """
+
+    def __init__(self, responses: List[str]) -> None:
+        self._responses = list(responses)
+        self.calls: List[dict] = []
+
+    def call(self, system: str, user: str, model: str, max_tokens: int):
+        from synthesis.llm_adapter import LLMResult
+
+        self.calls.append(
+            {"system": system, "user": user, "model": model}
+        )
+        if not self._responses:
+            # Exhausted — confirm no change.
+            text = json.dumps(
+                {"action": "confirm", "question": "",
+                 "corrected_value": "", "correction_note": ""}
+            )
+        else:
+            text = self._responses.pop(0)
+        return LLMResult(text=text, cost_usd=0.0)
+
+
+def _confirm_json() -> str:
+    return json.dumps(
+        {"action": "confirm", "question": "",
+         "corrected_value": "", "correction_note": ""}
+    )
+
+
+def _correct_json(value: str, note: str = "") -> str:
+    return json.dumps(
+        {"action": "correct", "question": "",
+         "corrected_value": value, "correction_note": note}
+    )
+
+
+class TestCorrectionSession:
+    def test_confirm_path_writes_one_row_per_facet(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _, exp = _init_dbs(tmp_path)
+        _seed_expectation(exp, unit_id="u1")
+        _seed_gap(exp, unit_id="u1", severity="major")
+
+        # Every facet confirms.
+        adapter = _RecordingAdapter([_confirm_json()] * len(FACETS))
+        monkeypatch.setattr(
+            correction, "_get_adapter", lambda cfg: adapter
+        )
+
+        written = run_correction_session(
+            WEEK_START,
+            expectations_db=str(exp),
+            config=_make_config(),
+            input_fn=lambda _p: "",
+            output_fn=lambda _m: None,
+        )
+        assert written == len(FACETS)
+
+        conn = sqlite3.connect(str(exp))
+        try:
+            rows = conn.execute(
+                "SELECT facet, original_value, corrected_value, corrected_by "
+                "FROM expectation_corrections WHERE unit_id='u1' "
+                "ORDER BY facet"
+            ).fetchall()
+        finally:
+            conn.close()
+
+        assert len(rows) == len(FACETS)
+        # AS-5: confirm-no-change → original_value == corrected_value, user.
+        for facet, original, corrected, by in rows:
+            assert by == "user"
+            assert original == corrected, (
+                f"confirm should preserve value for facet={facet}"
+            )
+
+    def test_correct_path_distinct_from_original(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _, exp = _init_dbs(tmp_path)
+        _seed_expectation(exp, unit_id="u1", expected_scope="fix X")
+        _seed_gap(exp, unit_id="u1", severity="major")
+
+        # First facet is commitment_point (confirm), then scope gets
+        # corrected, rest confirm.
+        responses = [
+            _confirm_json(),                        # commitment_point
+            _correct_json("fix X and also Y", "user refined scope"),  # scope
+        ] + [_confirm_json()] * (len(FACETS) - 2)
+        adapter = _RecordingAdapter(responses)
+        monkeypatch.setattr(
+            correction, "_get_adapter", lambda cfg: adapter
+        )
+
+        run_correction_session(
+            WEEK_START,
+            expectations_db=str(exp),
+            config=_make_config(),
+            input_fn=lambda _p: "",
+            output_fn=lambda _m: None,
+        )
+        conn = sqlite3.connect(str(exp))
+        try:
+            row = conn.execute(
+                "SELECT original_value, corrected_value, correction_note "
+                "FROM expectation_corrections "
+                "WHERE unit_id='u1' AND facet='scope'"
+            ).fetchone()
+            gap_auto = conn.execute(
+                "SELECT auto_confirmed FROM expectation_gaps "
+                "WHERE unit_id='u1'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+        # AS-9: original preserved from the expectations row.
+        assert row[0] == "fix X"
+        assert row[1] == "fix X and also Y"
+        assert row[2] == "user refined scope"
+        # AS-4: at least one correction → auto_confirmed flipped to 0.
+        assert gap_auto == 0
+
+    def test_confirm_only_path_flips_auto_confirmed_to_1(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _, exp = _init_dbs(tmp_path)
+        _seed_expectation(exp, unit_id="u1")
+        _seed_gap(exp, unit_id="u1", severity="critical")
+
+        adapter = _RecordingAdapter([_confirm_json()] * len(FACETS))
+        monkeypatch.setattr(
+            correction, "_get_adapter", lambda cfg: adapter
+        )
+        run_correction_session(
+            WEEK_START,
+            expectations_db=str(exp),
+            config=_make_config(),
+            input_fn=lambda _p: "",
+            output_fn=lambda _m: None,
+        )
+        conn = sqlite3.connect(str(exp))
+        try:
+            auto = conn.execute(
+                "SELECT auto_confirmed FROM expectation_gaps "
+                "WHERE unit_id='u1'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        # Every facet confirmed with no value change → 1 (resolved).
+        assert auto == 1
+
+    def test_gap_row_not_mutated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """AS-9 — expectation_gaps row is NOT mutated by corrections."""
+        _, exp = _init_dbs(tmp_path)
+        _seed_expectation(exp, unit_id="u1")
+        _seed_gap(exp, unit_id="u1", severity="major",
+                  failure_precondition="step_4_plan")
+
+        responses = (
+            [_confirm_json()]
+            + [_correct_json("step_1_intent", "actually it was intent")]
+            + [_confirm_json()] * (len(FACETS) - 2)
+        )
+        # Put the correct_json for failure_precondition. FACETS order is
+        # commitment_point, scope, effort, outcome, severity,
+        # failure_precondition — so place it at index 5.
+        responses = [_confirm_json()] * len(FACETS)
+        responses[5] = _correct_json("step_1_intent", "root cause was intent")
+        adapter = _RecordingAdapter(responses)
+        monkeypatch.setattr(
+            correction, "_get_adapter", lambda cfg: adapter
+        )
+
+        run_correction_session(
+            WEEK_START,
+            expectations_db=str(exp),
+            config=_make_config(),
+            input_fn=lambda _p: "",
+            output_fn=lambda _m: None,
+        )
+        conn = sqlite3.connect(str(exp))
+        try:
+            gap_fp = conn.execute(
+                "SELECT failure_precondition FROM expectation_gaps "
+                "WHERE unit_id='u1'"
+            ).fetchone()[0]
+            corr = conn.execute(
+                "SELECT original_value, corrected_value "
+                "FROM expectation_corrections "
+                "WHERE unit_id='u1' AND facet='failure_precondition'"
+            ).fetchone()
+        finally:
+            conn.close()
+        # Gap row still holds the original value.
+        assert gap_fp == "step_4_plan"
+        # Correction row captures the before/after delta.
+        assert corr[0] == "step_4_plan"
+        assert corr[1] == "step_1_intent"
+
+    def test_skips_only_major_and_critical(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _, exp = _init_dbs(tmp_path)
+        _seed_expectation(exp, unit_id="u_minor")
+        _seed_expectation(exp, unit_id="u_major")
+        _seed_gap(exp, unit_id="u_minor", severity="minor")
+        _seed_gap(exp, unit_id="u_major", severity="major")
+
+        adapter = _RecordingAdapter([_confirm_json()] * 100)
+        monkeypatch.setattr(
+            correction, "_get_adapter", lambda cfg: adapter
+        )
+        run_correction_session(
+            WEEK_START,
+            expectations_db=str(exp),
+            config=_make_config(),
+            input_fn=lambda _p: "",
+            output_fn=lambda _m: None,
+        )
+        conn = sqlite3.connect(str(exp))
+        try:
+            unit_ids = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT DISTINCT unit_id FROM expectation_corrections"
+                ).fetchall()
+            }
+        finally:
+            conn.close()
+        assert unit_ids == {"u_major"}
+
+
+# ---------------------------------------------------------------------------
+# AS-8: re-entrancy — resume on remaining facets
+# ---------------------------------------------------------------------------
+
+
+class TestReentrancy:
+    def test_already_corrected_facets_are_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _, exp = _init_dbs(tmp_path)
+        _seed_expectation(exp, unit_id="u1")
+        _seed_gap(exp, unit_id="u1", severity="major")
+
+        # Pre-seed two facets as already corrected.
+        conn = sqlite3.connect(str(exp))
+        try:
+            for facet in ("commitment_point", "scope"):
+                conn.execute(
+                    "INSERT INTO expectation_corrections "
+                    "(week_start, unit_id, facet, original_value, "
+                    " corrected_value, correction_note, corrected_by) "
+                    "VALUES (?, ?, ?, 'x', 'x', '', 'user')",
+                    (WEEK_START, "u1", facet),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+        adapter = _RecordingAdapter([_confirm_json()] * 100)
+        monkeypatch.setattr(
+            correction, "_get_adapter", lambda cfg: adapter
+        )
+        written = run_correction_session(
+            WEEK_START,
+            expectations_db=str(exp),
+            config=_make_config(),
+            input_fn=lambda _p: "",
+            output_fn=lambda _m: None,
+        )
+        # Only the 4 remaining facets should have been processed.
+        assert written == len(FACETS) - 2
+
+
+# ---------------------------------------------------------------------------
+# AS-6: auto-confirm sweep after 14 days
+# ---------------------------------------------------------------------------
+
+
+class TestAutoConfirmSweep:
+    def test_stale_gap_gets_correction_rows(self, tmp_path: Path):
+        _, exp = _init_dbs(tmp_path)
+        _seed_expectation(exp, unit_id="u_old")
+        old_ts = (
+            datetime.now(timezone.utc) - timedelta(days=15)
+        ).strftime("%Y-%m-%d %H:%M:%S")
+        _seed_gap(exp, unit_id="u_old", severity="major",
+                  computed_at=old_ts)
+
+        written = auto_confirm_sweep(str(exp))
+        assert written == len(FACETS)
+
+        conn = sqlite3.connect(str(exp))
+        try:
+            rows = conn.execute(
+                "SELECT facet, corrected_by, original_value, corrected_value "
+                "FROM expectation_corrections WHERE unit_id='u_old'"
+            ).fetchall()
+            auto = conn.execute(
+                "SELECT auto_confirmed FROM expectation_gaps "
+                "WHERE unit_id='u_old'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+        assert len(rows) == len(FACETS)
+        for _facet, by, original, corrected in rows:
+            assert by == "auto_confirm"
+            assert original == corrected
+        # AS-6: gap row's auto_confirmed flag flipped to 1.
+        assert auto == 1
+
+    def test_young_gap_untouched(self, tmp_path: Path):
+        _, exp = _init_dbs(tmp_path)
+        _seed_expectation(exp, unit_id="u_young")
+        # computed_at defaults to now.
+        _seed_gap(exp, unit_id="u_young", severity="major")
+
+        written = auto_confirm_sweep(str(exp))
+        assert written == 0
+        conn = sqlite3.connect(str(exp))
+        try:
+            auto = conn.execute(
+                "SELECT auto_confirmed FROM expectation_gaps "
+                "WHERE unit_id='u_young'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert auto == 0
+
+    def test_sweep_respects_existing_user_corrections(self, tmp_path: Path):
+        """Stale gap whose facets are already user-corrected: no auto row written for those facets."""
+        _, exp = _init_dbs(tmp_path)
+        _seed_expectation(exp, unit_id="u_old")
+        old_ts = (
+            datetime.now(timezone.utc) - timedelta(days=20)
+        ).strftime("%Y-%m-%d %H:%M:%S")
+        _seed_gap(exp, unit_id="u_old", severity="major",
+                  computed_at=old_ts)
+
+        # Pre-seed a user correction on 'scope'.
+        conn = sqlite3.connect(str(exp))
+        try:
+            conn.execute(
+                "INSERT INTO expectation_corrections "
+                "(week_start, unit_id, facet, original_value, "
+                " corrected_value, correction_note, corrected_by) "
+                "VALUES (?, ?, 'scope', 'fix X', 'fix X and Y', 'note', 'user')",
+                (WEEK_START, "u_old"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        written = auto_confirm_sweep(str(exp))
+        # All facets except 'scope' (pre-existing).
+        assert written == len(FACETS) - 1
+
+        conn = sqlite3.connect(str(exp))
+        try:
+            scope_by = conn.execute(
+                "SELECT corrected_by FROM expectation_corrections "
+                "WHERE unit_id='u_old' AND facet='scope'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        # User correction preserved — sweep did NOT overwrite it.
+        assert scope_by == "user"
+
+    def test_sweep_is_idempotent(self, tmp_path: Path):
+        _, exp = _init_dbs(tmp_path)
+        _seed_expectation(exp, unit_id="u_old")
+        old_ts = (
+            datetime.now(timezone.utc) - timedelta(days=20)
+        ).strftime("%Y-%m-%d %H:%M:%S")
+        _seed_gap(exp, unit_id="u_old", severity="major",
+                  computed_at=old_ts)
+
+        first = auto_confirm_sweep(str(exp))
+        second = auto_confirm_sweep(str(exp))
+        assert first == len(FACETS)
+        assert second == 0  # PK-conflicted rows are no-ops.
+
+    def test_sweep_noop_when_expectation_gaps_missing(self, tmp_path: Path):
+        """Fresh DB, no tables at all — sweep returns 0 without crashing."""
+        empty_db = tmp_path / "empty.db"
+        # Create the file but leave it empty.
+        sqlite3.connect(str(empty_db)).close()
+        assert auto_confirm_sweep(str(empty_db)) == 0
+
+
+# ---------------------------------------------------------------------------
+# AS-7: retrospective .md is never rewritten
+# ---------------------------------------------------------------------------
+
+
+class TestRetrospectiveIdempotency:
+    def test_correction_does_not_touch_output_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _, exp = _init_dbs(tmp_path)
+        _seed_expectation(exp, unit_id="u1")
+        _seed_gap(exp, unit_id="u1", severity="major")
+
+        retro_dir = tmp_path / "retrospectives"
+        retro_dir.mkdir()
+        retro_path = retro_dir / f"{WEEK_START}.md"
+        retro_path.write_text("# existing retrospective (must not change)\n")
+        mtime_before = retro_path.stat().st_mtime_ns
+
+        adapter = _RecordingAdapter(
+            [_correct_json("new scope")] + [_confirm_json()] * (len(FACETS) - 1)
+        )
+        monkeypatch.setattr(
+            correction, "_get_adapter", lambda cfg: adapter
+        )
+        run_correction_session(
+            WEEK_START,
+            expectations_db=str(exp),
+            config=_make_config(output_dir=str(retro_dir)),
+            input_fn=lambda _p: "",
+            output_fn=lambda _m: None,
+        )
+        # .md was not modified.
+        assert retro_path.stat().st_mtime_ns == mtime_before
+        assert retro_path.read_text() == (
+            "# existing retrospective (must not change)\n"
+        )


### PR DESCRIPTION
## Summary

Implements X-4 of epic #27 — the interactive agentic correction loop and the passive auto-confirm sweep that together close the user-feedback half of the expectation calibration layer.

- Adds `expectation_corrections` table (schema locked per the epic ADR: `week_start`, `unit_id`, `facet`, `original_value`, `corrected_value`, `correction_note`, `corrected_by`, `corrected_at`) to `expectations.db`.
- New `synthesis/correction.py` module: agentic per-facet loop (6-turn cap per X4-OQ-1 default) using the same `_get_adapter` abstraction as X-2 / X-3. Re-entrant across partial sessions; never mutates the `expectation_gaps` row so X-5 preserves the before/after delta.
- New `am-synthesize correct [--week YYYY-MM-DD] [--unit <unit_id>]` subcommand. Bare `--week` weekly synthesis form is preserved verbatim.
- Auto-confirm sweep fires on every `am-synthesize --week` invocation: gaps older than 14 days without a user correction get `corrected_by='auto_confirm'` rows inserted and their `auto_confirmed` flag flipped to 1 (AS-6 passive-assent).
- Retrospective `.md` files are never rewritten — Epic #17 idempotency intact (AS-7).

Base: `epic/27-expectation-calibration` (X-1/X-2/X-3 already merged).

## Test plan

- [x] `tests/test_correction.py` — 15 cases covering AS-1 through AS-9 (schema lock, subcommand wiring, confirm-only, correct path, re-entrancy, auto-confirm sweep with stale / young / pre-corrected / idempotent / missing-table variants, and `.md` untouched).
- [x] Full suite green: `pytest tests/` → 586 passed, 23 skipped.
- [x] Regression check on X-2/X-3 adjacent modules (`test_gap_analysis.py`, `test_revision_detection.py`, `test_weekly.py`, `test_init_db.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)