### PR TITLE
feat(#76): X-5 calibration learning — few-shot + per-work-type trends

### DIFF
--- a/am_i_shipping/db.py
+++ b/am_i_shipping/db.py
@@ -391,6 +391,43 @@ CREATE TABLE IF NOT EXISTS expectation_corrections (
 );
 """
 
+# Epic #27 — X-5 (#76): expectation_calibration_trends schema.
+#
+# Written by ``synthesis.calibration.run`` during ``am-synthesize`` once
+# ≥20 user corrections have accumulated in ``expectation_corrections``.
+# Each row captures the per-work-type calibration delta for a given
+# week. The shipped retrospective ``.md`` is immutable (Epic #17
+# Decision 2); this trend table is live data and may be recomputed on
+# re-runs via UPSERT semantics.
+#
+# Primary key: ``(work_type, week_start)`` — the intent document flagged
+# this choice as implementer-owned. UPSERT-by-PK keeps re-runs cheap and
+# consistent with the "trend table is live, .md is frozen" split.
+#
+# * ``work_type``            — mirror of ``github.db::issues.type_label``
+#                              or the literal ``"unknown"`` when the
+#                              issue's ``type_label`` is NULL / the unit
+#                              has no joined issue row.
+# * ``avg_*_delta``          — average over all user corrections for the
+#                              work-type where the facet actually changed
+#                              (``original_value != corrected_value``).
+#                              NULL when no user corrections for that
+#                              facet in the work-type.
+# * ``sample_count``         — number of ``corrected_by='user'`` rows
+#                              contributing to the group.
+SYNTHESIS_EXPECTATION_CALIBRATION_TRENDS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS expectation_calibration_trends (
+    work_type            TEXT NOT NULL,
+    week_start           TEXT NOT NULL,
+    avg_scope_delta      REAL,
+    avg_effort_delta     REAL,
+    avg_outcome_delta    REAL,
+    sample_count         INTEGER NOT NULL DEFAULT 0,
+    computed_at          TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (work_type, week_start)
+);
+"""
+
 EXPECTED_EXPECTATIONS_TABLES: dict[str, set[str]] = {
     "expectations": {
         "week_start",
@@ -439,6 +476,15 @@ EXPECTED_EXPECTATIONS_TABLES: dict[str, set[str]] = {
         "correction_note",
         "corrected_by",
         "corrected_at",
+    },
+    "expectation_calibration_trends": {
+        "work_type",
+        "week_start",
+        "avg_scope_delta",
+        "avg_effort_delta",
+        "avg_outcome_delta",
+        "sample_count",
+        "computed_at",
     },
 }
 
@@ -829,6 +875,9 @@ def init_expectations_db(db_path: Path) -> None:
         conn.execute(SYNTHESIS_EXPECTATION_REVISIONS_SCHEMA)
         # Epic #27 — X-4 (#75): expectation_corrections lives in the same DB.
         conn.execute(SYNTHESIS_EXPECTATION_CORRECTIONS_SCHEMA)
+        # Epic #27 — X-5 (#76): expectation_calibration_trends lives in the
+        # same DB.
+        conn.execute(SYNTHESIS_EXPECTATION_CALIBRATION_TRENDS_SCHEMA)
         for migration in _EXPECTATIONS_MIGRATIONS:
             try:
                 conn.execute(migration)

--- a/synthesis/calibration.py
+++ b/synthesis/calibration.py
@@ -1,0 +1,514 @@
+"""Epic #27 — X-5 (#76): calibration learning.
+
+Once ≥20 user corrections have accumulated in ``expectation_corrections``,
+this module performs two behaviours:
+
+1. **Few-shot injection** (see :func:`build_few_shot_block`) — exposes a
+   helper that assembles a Markdown block of the most recent user
+   corrections. :mod:`synthesis.expectations` prepends that block to the
+   classifier's user message so future extractions benefit from the
+   accumulated signal.
+2. **Calibration trends pass** (see :func:`run`) — joins
+   ``expectation_corrections`` with ``github.db::issues.type_label`` to
+   produce per-work-type averages of the user-supplied facet deltas.
+   Results UPSERT into ``expectation_calibration_trends``. Below the
+   threshold, the pass is a strict no-op.
+
+Behavioural invariants (from the refined spec):
+
+* **Gated activation.** Fewer than 20 ``corrected_by='user'`` rows means
+  ``build_few_shot_block`` returns ``""`` and :func:`run` writes nothing
+  and returns an empty dict. The pipeline behaves exactly as it did in
+  X-1..X-4 v1.
+* **User-only filter.** Auto-confirmed rows are excluded from the
+  few-shot corpus and from the trend computation. This is the guard
+  against the feared failure mode (calibrating on noise).
+* **Deterministic selection.** Few-shot rows are sorted by
+  ``corrected_at DESC, unit_id ASC`` so repeated runs pick the same
+  five examples.
+* **Idempotent writes.** Trend rows are upserted by
+  ``(work_type, week_start)``; the retrospective ``.md`` is never
+  rewritten.
+
+Architecture notes
+------------------
+* Cross-database reads use ``ATTACH DATABASE`` — the intent document
+  flagged this as implementer-owned. The calibration module owns the
+  pattern here. ``type_label`` fallback is the literal ``"unknown"``.
+* The public API is two functions: :func:`build_few_shot_block` (read-
+  only helper consumed by :mod:`synthesis.expectations`) and :func:`run`
+  (pipeline entry point invoked by :mod:`synthesis.weekly`).
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+# X5-OQ-3 resolved: module constant (not a config value). Tweak in code
+# if the first calibration pass produces noisy output.
+CALIBRATION_MIN_CORRECTIONS = 20
+
+# X5-OQ-1 resolved: five examples is 25% of the 20-row floor — large
+# enough to signal, small enough to avoid bloating every per-unit call.
+FEW_SHOT_SAMPLE_SIZE = 5
+
+# Marker string the few-shot block uses. Exposed so tests can assert on
+# it without hard-coding the exact Markdown heading.
+FEW_SHOT_BLOCK_MARKER = "## Prior Corrections"
+
+# The three calibration facets we report trends on in the retrospective.
+# ``commitment_point`` is intentionally omitted from trend averaging —
+# the value is a turn reference string, not a scalar we can average.
+# We still include ``commitment_point`` rows in the few-shot corpus for
+# calibration of the structural-detection heuristic.
+TREND_FACETS = ("scope", "effort", "outcome")
+
+
+# ---------------------------------------------------------------------------
+# Correction corpus helpers
+# ---------------------------------------------------------------------------
+
+
+def _count_user_corrections(exp_conn: sqlite3.Connection) -> int:
+    """Return the number of ``corrected_by='user'`` rows in the DB."""
+    try:
+        row = exp_conn.execute(
+            "SELECT COUNT(*) FROM expectation_corrections "
+            "WHERE corrected_by = 'user'"
+        ).fetchone()
+    except sqlite3.OperationalError:
+        # Table missing (expectations.db not initialised yet). Treat as
+        # "below threshold".
+        return 0
+    return int(row[0]) if row else 0
+
+
+def _load_recent_user_corrections(
+    exp_conn: sqlite3.Connection, limit: int = FEW_SHOT_SAMPLE_SIZE
+) -> List[Dict[str, Any]]:
+    """Return the *limit* most recent user corrections, newest first.
+
+    Stable tie-break by ``unit_id ASC`` so the selection is deterministic
+    when multiple rows share a ``corrected_at`` value (AS-5).
+    """
+    try:
+        rows = exp_conn.execute(
+            "SELECT week_start, unit_id, facet, original_value, "
+            "       corrected_value, correction_note, corrected_at "
+            "FROM expectation_corrections "
+            "WHERE corrected_by = 'user' "
+            "ORDER BY corrected_at DESC, unit_id ASC "
+            "LIMIT ?",
+            (limit,),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return []
+    keys = (
+        "week_start",
+        "unit_id",
+        "facet",
+        "original_value",
+        "corrected_value",
+        "correction_note",
+        "corrected_at",
+    )
+    return [dict(zip(keys, r)) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Few-shot block assembly (consumed by synthesis.expectations)
+# ---------------------------------------------------------------------------
+
+
+def build_few_shot_block(expectations_db: str) -> str:
+    """Return a Markdown few-shot block, or ``""`` below the threshold.
+
+    Below ``CALIBRATION_MIN_CORRECTIONS`` user corrections this is a
+    strict no-op (AS-1). At or above the threshold the block contains
+    the ``FEW_SHOT_SAMPLE_SIZE`` most recent user corrections (AS-2,
+    AS-5, AS-6).
+
+    Auto-confirmed rows are excluded — they snapshot the original value
+    unchanged and calibrating on them is the exact feared failure mode.
+    Exclusion is logged at INFO the first time the block is assembled
+    for a given run.
+    """
+    conn = sqlite3.connect(str(expectations_db))
+    try:
+        user_count = _count_user_corrections(conn)
+        if user_count < CALIBRATION_MIN_CORRECTIONS:
+            return ""
+        examples = _load_recent_user_corrections(conn)
+        if not examples:
+            return ""
+
+        # AS-6 diagnostic — count auto-confirm rows so the operator can
+        # see they were excluded from the corpus.
+        try:
+            auto_row = conn.execute(
+                "SELECT COUNT(*) FROM expectation_corrections "
+                "WHERE corrected_by = 'auto_confirm'"
+            ).fetchone()
+            auto_count = int(auto_row[0]) if auto_row else 0
+        except sqlite3.OperationalError:
+            auto_count = 0
+    finally:
+        conn.close()
+
+    logger.info(
+        "Few-shot calibration active: %d user corrections found, using "
+        "%d most recent (auto_confirm rows excluded: %d)",
+        user_count,
+        len(examples),
+        auto_count,
+    )
+
+    lines: List[str] = [FEW_SHOT_BLOCK_MARKER, ""]
+    lines.append(
+        "The following are recent user corrections to prior expectation "
+        "extractions. Use them as calibration examples for the facets "
+        "the user tends to correct — match the granularity and phrasing "
+        "of the corrected_value column when extracting new expectations."
+    )
+    lines.append("")
+    for ex in examples:
+        lines.append(f"- unit {ex['unit_id']} ({ex['week_start']}):")
+        lines.append(f"    - facet: {ex['facet']}")
+        orig = ex.get("original_value")
+        corr = ex.get("corrected_value")
+        lines.append(
+            f"    - original: {orig if orig is not None else '(none)'}"
+        )
+        lines.append(
+            f"    - corrected: {corr if corr is not None else '(none)'}"
+        )
+        note = ex.get("correction_note")
+        if note:
+            lines.append(f"    - note: {note}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Trend computation
+# ---------------------------------------------------------------------------
+
+
+def _joined_user_corrections(
+    exp_conn: sqlite3.Connection, github_db: str
+) -> List[Dict[str, Any]]:
+    """Return user-correction rows joined with ``issues.type_label``.
+
+    Uses ``ATTACH DATABASE`` to reach into ``github.db`` for the
+    ``type_label``. ``unit_id`` encodes the root node; for issue-rooted
+    units the format is ``issue:<repo>#<number>``. For units rooted at
+    other node types (PR, session) the join falls through and the row
+    is grouped under ``"unknown"`` (fallback).
+    """
+    # Attach github.db under a fixed alias. We detach in a finally to
+    # leave the connection clean for further queries.
+    exp_conn.execute("ATTACH DATABASE ? AS gh", (str(github_db),))
+    try:
+        # Join ``units`` on the expectations side's (week_start, unit_id)
+        # to pick up the ``root_node_id``, then parse the repo/number out
+        # of it and join ``gh.issues`` on that. Doing the parsing in SQL
+        # is fiddly — easier to do the join in Python after a single
+        # bulk fetch.
+        rows = exp_conn.execute(
+            "SELECT ec.week_start, ec.unit_id, ec.facet, "
+            "       ec.original_value, ec.corrected_value, "
+            "       ec.corrected_at, u.root_node_type, u.root_node_id "
+            "FROM expectation_corrections ec "
+            "LEFT JOIN gh.units u "
+            "  ON u.week_start = ec.week_start "
+            " AND u.unit_id = ec.unit_id "
+            "WHERE ec.corrected_by = 'user'"
+        ).fetchall()
+        # Pre-fetch issues for a cheap in-memory lookup. A full week's
+        # corrections hit at most a few tens of distinct issues.
+        issue_rows = exp_conn.execute(
+            "SELECT repo, issue_number, type_label FROM gh.issues"
+        ).fetchall()
+    finally:
+        try:
+            exp_conn.execute("DETACH DATABASE gh")
+        except sqlite3.OperationalError:
+            pass
+
+    issue_type: Dict[tuple[str, int], Optional[str]] = {
+        (r[0], int(r[1])): r[2] for r in issue_rows
+    }
+
+    out: List[Dict[str, Any]] = []
+    for row in rows:
+        (
+            week_start,
+            unit_id,
+            facet,
+            original_value,
+            corrected_value,
+            corrected_at,
+            root_node_type,
+            root_node_id,
+        ) = row
+        work_type: Optional[str] = None
+        if root_node_type == "issue" and isinstance(root_node_id, str):
+            # root_node_id format: "issue:<repo>#<number>"
+            try:
+                without_prefix = root_node_id[len("issue:"):]
+                repo_part, issue_part = without_prefix.rsplit("#", 1)
+                issue_number = int(issue_part)
+                work_type = issue_type.get((repo_part, issue_number))
+            except (ValueError, IndexError):
+                work_type = None
+        out.append(
+            {
+                "week_start": week_start,
+                "unit_id": unit_id,
+                "facet": facet,
+                "original_value": original_value,
+                "corrected_value": corrected_value,
+                "corrected_at": corrected_at,
+                "work_type": work_type or "unknown",
+            }
+        )
+    return out
+
+
+def _delta_signal(original: Optional[str], corrected: Optional[str]) -> Optional[float]:
+    """Return a scalar signal for the user's correction on this facet.
+
+    The stored values are free-text (scope/effort/outcome are strings in
+    ``expectations``), so we cannot compute a numeric delta. We report
+    a *change indicator*: ``+1.0`` when the user changed the value and
+    ``0.0`` when they confirmed without change. The sign is by
+    convention positive — direction would require parsing the text,
+    which is out of scope for v1.
+
+    Returns ``None`` when both sides are NULL — no signal at all.
+    """
+    if original is None and corrected is None:
+        return None
+    if (original or "").strip() == (corrected or "").strip():
+        return 0.0
+    return 1.0
+
+
+def _compute_group_deltas(
+    rows: List[Dict[str, Any]],
+) -> Dict[str, Dict[str, Any]]:
+    """Aggregate joined rows into ``{work_type: {avg_*_delta, sample_count}}``.
+
+    ``avg_*_delta`` is the mean of the per-row change indicator for that
+    facet across all corrections in the work-type group. ``sample_count``
+    is the total number of user-correction rows contributing to the
+    group (across all facets).
+    """
+    grouped: Dict[str, Dict[str, List[float]]] = {}
+    sample_counts: Dict[str, int] = {}
+    for row in rows:
+        wt = row["work_type"]
+        grouped.setdefault(wt, {f: [] for f in TREND_FACETS})
+        sample_counts[wt] = sample_counts.get(wt, 0) + 1
+        facet = row["facet"]
+        if facet not in TREND_FACETS:
+            continue
+        signal = _delta_signal(row["original_value"], row["corrected_value"])
+        if signal is None:
+            continue
+        grouped[wt][facet].append(signal)
+
+    out: Dict[str, Dict[str, Any]] = {}
+    for wt, facet_map in grouped.items():
+        entry: Dict[str, Any] = {"sample_count": sample_counts.get(wt, 0)}
+        for facet in TREND_FACETS:
+            values = facet_map[facet]
+            entry[f"avg_{facet}_delta"] = (
+                sum(values) / len(values) if values else None
+            )
+        out[wt] = entry
+    return out
+
+
+def _upsert_trends(
+    exp_conn: sqlite3.Connection,
+    week_start: str,
+    trends: Dict[str, Dict[str, Any]],
+    *,
+    computed_at: Optional[str] = None,
+) -> None:
+    """UPSERT per-work-type trend rows for *week_start*."""
+    ts = computed_at or datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    for work_type, entry in trends.items():
+        exp_conn.execute(
+            "INSERT INTO expectation_calibration_trends "
+            "(work_type, week_start, avg_scope_delta, avg_effort_delta, "
+            " avg_outcome_delta, sample_count, computed_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(work_type, week_start) DO UPDATE SET "
+            "  avg_scope_delta = excluded.avg_scope_delta, "
+            "  avg_effort_delta = excluded.avg_effort_delta, "
+            "  avg_outcome_delta = excluded.avg_outcome_delta, "
+            "  sample_count = excluded.sample_count, "
+            "  computed_at = excluded.computed_at",
+            (
+                work_type,
+                week_start,
+                entry.get("avg_scope_delta"),
+                entry.get("avg_effort_delta"),
+                entry.get("avg_outcome_delta"),
+                entry.get("sample_count", 0),
+                ts,
+            ),
+        )
+    exp_conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+def run(
+    week_start: str,
+    *,
+    github_db: str,
+    expectations_db: str,
+) -> Dict[str, Dict[str, Any]]:
+    """Run the calibration trends pass for *week_start*.
+
+    Returns the per-work-type trend dict. Below the correction threshold
+    this is a strict no-op: returns ``{}`` without writing to
+    ``expectation_calibration_trends`` (AS-1 / below-threshold scenario).
+    At or above the threshold the trend rows are UPSERTed and the same
+    dict is returned for downstream Markdown rendering.
+    """
+    conn = sqlite3.connect(str(expectations_db))
+    try:
+        user_count = _count_user_corrections(conn)
+        if user_count < CALIBRATION_MIN_CORRECTIONS:
+            logger.info(
+                "Calibration pass skipped for week=%s: %d user corrections "
+                "< threshold=%d",
+                week_start,
+                user_count,
+                CALIBRATION_MIN_CORRECTIONS,
+            )
+            return {}
+        joined = _joined_user_corrections(conn, github_db)
+        trends = _compute_group_deltas(joined)
+        if not trends:
+            logger.info(
+                "Calibration pass for week=%s produced no trend groups "
+                "(no user corrections joined to a work type).",
+                week_start,
+            )
+            return {}
+        _upsert_trends(conn, week_start, trends)
+        logger.info(
+            "Calibration pass wrote %d trend rows for week=%s "
+            "(user_corrections=%d)",
+            len(trends),
+            week_start,
+            user_count,
+        )
+        return trends
+    finally:
+        conn.close()
+
+
+def load_trends(
+    expectations_db: str, week_start: str
+) -> Dict[str, Dict[str, Any]]:
+    """Load previously computed trend rows for *week_start*.
+
+    Returns ``{work_type: {avg_scope_delta, avg_effort_delta,
+    avg_outcome_delta, sample_count}}``. Empty dict when nothing has
+    been written for the week.
+    """
+    conn = sqlite3.connect(str(expectations_db))
+    try:
+        try:
+            rows = conn.execute(
+                "SELECT work_type, avg_scope_delta, avg_effort_delta, "
+                "       avg_outcome_delta, sample_count "
+                "FROM expectation_calibration_trends "
+                "WHERE week_start = ? "
+                "ORDER BY sample_count DESC, work_type ASC",
+                (week_start,),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return {}
+    finally:
+        conn.close()
+    out: Dict[str, Dict[str, Any]] = {}
+    for r in rows:
+        out[r[0]] = {
+            "avg_scope_delta": r[1],
+            "avg_effort_delta": r[2],
+            "avg_outcome_delta": r[3],
+            "sample_count": r[4],
+        }
+    return out
+
+
+def render_calibration_block(
+    trends: Dict[str, Dict[str, Any]], *, top_n: int = 3
+) -> List[str]:
+    """Render the ``## Calibration Trends`` Markdown block.
+
+    Returns a list of lines; empty list when ``trends`` is empty (caller
+    omits the section entirely — AS-1 / below-threshold scenario).
+    """
+    if not trends:
+        return []
+    # Rank by the most pronounced correction rate across scope/effort/
+    # outcome — higher average means the user changed the value more
+    # often in that work-type.
+    def _pronounced(entry: Dict[str, Any]) -> float:
+        vals = [
+            entry.get(f"avg_{f}_delta")
+            for f in TREND_FACETS
+        ]
+        vals_f = [v for v in vals if isinstance(v, (int, float))]
+        return max(vals_f) if vals_f else 0.0
+
+    ranked = sorted(
+        trends.items(),
+        key=lambda kv: (_pronounced(kv[1]), kv[1].get("sample_count", 0)),
+        reverse=True,
+    )[: max(1, top_n)]
+
+    lines: List[str] = ["", "## Calibration Trends (from X-5 calibration)", ""]
+    for work_type, entry in ranked:
+        sample = entry.get("sample_count", 0)
+        parts: List[str] = []
+        for facet in TREND_FACETS:
+            v = entry.get(f"avg_{facet}_delta")
+            if isinstance(v, (int, float)):
+                parts.append(f"{facet}_correction_rate={v:.2f}")
+        detail = ", ".join(parts) if parts else "no facet signal"
+        lines.append(
+            f"- {work_type}: {detail} (sample={sample})"
+        )
+    lines.append("")
+    return lines
+
+
+__all__ = [
+    "CALIBRATION_MIN_CORRECTIONS",
+    "FEW_SHOT_SAMPLE_SIZE",
+    "FEW_SHOT_BLOCK_MARKER",
+    "TREND_FACETS",
+    "build_few_shot_block",
+    "run",
+    "load_trends",
+    "render_calibration_block",
+]

--- a/synthesis/expectations.py
+++ b/synthesis/expectations.py
@@ -469,6 +469,22 @@ def run_extraction(
 
     adapter = _get_adapter(config)
 
+    # Epic #27 — X-5 (#76): few-shot calibration block. Assembled once
+    # per run and prepended to every classifier user message when the
+    # ≥20 user-correction threshold is crossed. Below threshold this is
+    # an empty string (no-op — identical to X-1..X-4 baseline).
+    from synthesis.calibration import build_few_shot_block
+
+    try:
+        few_shot_block = build_few_shot_block(expectations_db)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Few-shot calibration block assembly failed (%s); "
+            "proceeding without calibration examples.",
+            exc,
+        )
+        few_shot_block = ""
+
     gh_conn = sqlite3.connect(github_db)
     exp_conn = sqlite3.connect(expectations_db)
     sessions_conn = None
@@ -539,10 +555,15 @@ def run_extraction(
 
             # Live call — we have a structural candidate and non-empty input.
             structural_count += 1
+            # X-5: prepend few-shot calibration block when active. Empty
+            # string below threshold means no-op string concatenation.
+            classifier_input = (
+                f"{few_shot_block}\n{unit_input}" if few_shot_block else unit_input
+            )
             try:
                 result = adapter.call(
                     _EXPECTATIONS_SYSTEM_PROMPT,
-                    unit_input,
+                    classifier_input,
                     config.model,
                     _MAX_OUTPUT_TOKENS,
                 )

--- a/synthesis/weekly.py
+++ b/synthesis/weekly.py
@@ -416,7 +416,15 @@ Required Markdown sections (exact headings, in order)
    and the before/after summary. Low-confidence revisions (< 0.5) are
    annotated as such, not omitted. Omit the section body when no
    revisions exist; keep the heading.
-8. `## Clarifying Questions`      — at most TWO total, numbered `1.`
+8. `## Calibration Trends`        — *conditional; present only when
+   ≥20 user corrections have accumulated in `expectation_corrections`
+   (Epic #27 X-5).* Per-work-type calibration deltas grouped by
+   `type_label`. Each bullet names the work type, the correction rate
+   per facet (`scope`/`effort`/`outcome`), and the sample count.
+   The LLM must preserve the supplied bullets verbatim — do not invent
+   new work types or rephrase the numeric deltas. Omit the section
+   entirely when the calibration pass produced no rows.
+9. `## Clarifying Questions`      — at most TWO total, numbered `1.`
    and `2.`. Each question should be answerable from the user's memory
    of the week — no research required.
 
@@ -581,6 +589,7 @@ def _assemble_prompt(
     unit_attributions: Optional[dict] = None,
     gap_rows: Optional[List[dict]] = None,
     revision_rows: Optional[List[dict]] = None,
+    calibration_trends: Optional[dict] = None,
 ) -> Tuple[str, List[dict]]:
     """Return (system_prompt, user_messages) for the synthesis call.
 
@@ -629,6 +638,13 @@ def _assemble_prompt(
     # surfaced (low-confidence ones are annotated, not dropped).
     if revision_rows:
         body_parts.extend(_render_revision_block(revision_rows))
+
+    # Epic #27 — X-5 (#76): calibration trends. Empty dict below the
+    # ≥20-correction threshold — block is omitted entirely.
+    if calibration_trends:
+        from synthesis.calibration import render_calibration_block
+
+        body_parts.extend(render_calibration_block(calibration_trends))
 
     user_content = "\n".join(body_parts)
     return _STATIC_SYSTEM_PROMPT, [{"role": "user", "content": user_content}]
@@ -919,6 +935,35 @@ def run_synthesis(
                     week_start, exc,
                 )
 
+        # Epic #27 — X-5 (#76): calibration trends pass. Runs AFTER the
+        # X-4 auto-confirm sweep (which populates additional correction
+        # rows) so the threshold count reflects the freshest state. Below
+        # the ≥20 user-correction threshold this is a strict no-op and
+        # returns an empty dict — the retrospective omits the section.
+        calibration_trends: dict = {}
+        if expectations_db is not None:
+            from synthesis import calibration
+
+            try:
+                calibration_trends = calibration.run(
+                    week_start,
+                    github_db=str(gh_path),
+                    expectations_db=str(expectations_db),
+                )
+            except sqlite3.OperationalError as exc:
+                logger.warning(
+                    "Calibration pass skipped for week=%s: %s. Run "
+                    "'am-init-db' and 'am-extract-expectations' first.",
+                    week_start, exc,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Calibration pass failed for week=%s: %s. "
+                    "Retrospective will be written without the "
+                    "Calibration Trends section.",
+                    week_start, exc,
+                )
+
         system_prompt, messages = _assemble_prompt(
             units,
             unit_transcripts,
@@ -927,6 +972,7 @@ def run_synthesis(
             unit_attributions,
             gap_rows=gap_rows,
             revision_rows=revision_rows,
+            calibration_trends=calibration_trends,
         )
 
         # --- Issue #54 P-2: prompt-size guard -------------------------

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,517 @@
+"""Tests for ``synthesis/calibration.py`` (Epic #27 — X-5, Issue #76)."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+import pytest
+
+from am_i_shipping.db import (
+    EXPECTED_EXPECTATIONS_TABLES,
+    assert_schema,
+    init_expectations_db,
+    init_github_db,
+)
+from synthesis import calibration
+from synthesis.calibration import (
+    CALIBRATION_MIN_CORRECTIONS,
+    FEW_SHOT_BLOCK_MARKER,
+    FEW_SHOT_SAMPLE_SIZE,
+    build_few_shot_block,
+    load_trends,
+    render_calibration_block,
+)
+
+
+WEEK_START = "2026-04-14"
+
+
+def _init_dbs(tmp_path: Path) -> tuple[Path, Path]:
+    gh = tmp_path / "github.db"
+    exp = tmp_path / "expectations.db"
+    init_github_db(gh)
+    init_expectations_db(exp)
+    return gh, exp
+
+
+def _seed_issue(
+    gh_db: Path, *, repo: str, issue_number: int, type_label: Optional[str]
+) -> None:
+    conn = sqlite3.connect(str(gh_db))
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO issues "
+            "(repo, issue_number, title, type_label, state) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (repo, issue_number, f"issue #{issue_number}", type_label, "open"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_unit(
+    gh_db: Path,
+    *,
+    unit_id: str,
+    week_start: str = WEEK_START,
+    root_node_type: str = "issue",
+    root_node_id: Optional[str] = None,
+) -> None:
+    conn = sqlite3.connect(str(gh_db))
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO units "
+            "(week_start, unit_id, root_node_type, root_node_id, "
+            " elapsed_days, dark_time_pct, total_reprompts, review_cycles, status) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                week_start,
+                unit_id,
+                root_node_type,
+                root_node_id or unit_id,
+                1.0,
+                0.0,
+                0,
+                0,
+                "complete",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_correction(
+    exp_db: Path,
+    *,
+    unit_id: str,
+    facet: str,
+    original_value: Optional[str],
+    corrected_value: Optional[str],
+    corrected_by: str = "user",
+    corrected_at: Optional[str] = None,
+    week_start: str = WEEK_START,
+) -> None:
+    conn = sqlite3.connect(str(exp_db))
+    try:
+        if corrected_at is None:
+            conn.execute(
+                "INSERT OR REPLACE INTO expectation_corrections "
+                "(week_start, unit_id, facet, original_value, corrected_value, "
+                " correction_note, corrected_by) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    week_start,
+                    unit_id,
+                    facet,
+                    original_value,
+                    corrected_value,
+                    None,
+                    corrected_by,
+                ),
+            )
+        else:
+            conn.execute(
+                "INSERT OR REPLACE INTO expectation_corrections "
+                "(week_start, unit_id, facet, original_value, corrected_value, "
+                " correction_note, corrected_by, corrected_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    week_start,
+                    unit_id,
+                    facet,
+                    original_value,
+                    corrected_value,
+                    None,
+                    corrected_by,
+                    corrected_at,
+                ),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_n_user_corrections(
+    exp_db: Path,
+    gh_db: Path,
+    *,
+    n: int,
+    type_label: str = "bug",
+    facet_cycle: Iterable[str] = ("scope", "effort", "outcome"),
+    starting_at: Optional[datetime] = None,
+) -> None:
+    """Helper: seed *n* user corrections backed by issue-rooted units."""
+    facets = list(facet_cycle)
+    clock = starting_at or datetime(2026, 4, 10, 10, 0, 0, tzinfo=timezone.utc)
+    for i in range(n):
+        issue_number = 1000 + i
+        repo = "acme/svc"
+        root = f"issue:{repo}#{issue_number}"
+        _seed_issue(gh_db, repo=repo, issue_number=issue_number, type_label=type_label)
+        _seed_unit(
+            gh_db,
+            unit_id=root,
+            root_node_type="issue",
+            root_node_id=root,
+        )
+        facet = facets[i % len(facets)]
+        ts = (clock + timedelta(minutes=i)).strftime("%Y-%m-%d %H:%M:%S")
+        _seed_correction(
+            exp_db,
+            unit_id=root,
+            facet=facet,
+            original_value=f"old-{i}",
+            corrected_value=f"new-{i}" if i % 2 == 0 else f"old-{i}",
+            corrected_by="user",
+            corrected_at=ts,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+class TestCalibrationTrendsSchema:
+    """AS-7: expectation_calibration_trends is registered and created."""
+
+    def test_table_created(self, tmp_path):
+        exp = tmp_path / "expectations.db"
+        init_expectations_db(exp)
+        conn = sqlite3.connect(str(exp))
+        try:
+            tables = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+        finally:
+            conn.close()
+        assert "expectation_calibration_trends" in tables
+
+    def test_table_has_expected_columns(self, tmp_path):
+        exp = tmp_path / "expectations.db"
+        init_expectations_db(exp)
+        conn = sqlite3.connect(str(exp))
+        try:
+            columns = {
+                r[1]
+                for r in conn.execute(
+                    "PRAGMA table_info(expectation_calibration_trends)"
+                ).fetchall()
+            }
+        finally:
+            conn.close()
+        expected = {
+            "work_type",
+            "week_start",
+            "avg_scope_delta",
+            "avg_effort_delta",
+            "avg_outcome_delta",
+            "sample_count",
+            "computed_at",
+        }
+        assert expected.issubset(columns)
+
+    def test_registered_in_expected_tables(self, tmp_path):
+        exp = tmp_path / "expectations.db"
+        init_expectations_db(exp)
+        # assert_schema verifies the table is in the global registry
+        assert_schema(exp, EXPECTED_EXPECTATIONS_TABLES)
+        assert "expectation_calibration_trends" in EXPECTED_EXPECTATIONS_TABLES
+
+
+# ---------------------------------------------------------------------------
+# Few-shot injection — gating
+# ---------------------------------------------------------------------------
+
+
+class TestFewShotGating:
+    """AS-1 / AS-2: few-shot block is gated on ≥20 user corrections."""
+
+    def test_below_threshold_returns_empty(self, tmp_path):
+        _, exp = _init_dbs(tmp_path)
+        gh = tmp_path / "github.db"
+        _seed_n_user_corrections(exp, gh, n=CALIBRATION_MIN_CORRECTIONS - 1)
+        result = build_few_shot_block(str(exp))
+        assert result == ""
+        assert FEW_SHOT_BLOCK_MARKER not in result
+
+    def test_at_threshold_injects_block(self, tmp_path):
+        _, exp = _init_dbs(tmp_path)
+        gh = tmp_path / "github.db"
+        _seed_n_user_corrections(exp, gh, n=CALIBRATION_MIN_CORRECTIONS)
+        result = build_few_shot_block(str(exp))
+        assert result != ""
+        assert FEW_SHOT_BLOCK_MARKER in result
+
+    def test_block_contains_five_entries_at_threshold(self, tmp_path):
+        _, exp = _init_dbs(tmp_path)
+        gh = tmp_path / "github.db"
+        _seed_n_user_corrections(exp, gh, n=CALIBRATION_MIN_CORRECTIONS)
+        result = build_few_shot_block(str(exp))
+        # Count unit bullets — one per example.
+        unit_bullets = [
+            ln for ln in result.splitlines() if ln.startswith("- unit ")
+        ]
+        assert len(unit_bullets) == FEW_SHOT_SAMPLE_SIZE
+
+    def test_auto_confirm_rows_excluded(self, tmp_path):
+        _, exp = _init_dbs(tmp_path)
+        gh = tmp_path / "github.db"
+        _seed_n_user_corrections(exp, gh, n=CALIBRATION_MIN_CORRECTIONS)
+        # Add some auto_confirm rows with distinctive values.
+        _seed_issue(gh, repo="acme/svc", issue_number=9999, type_label="bug")
+        _seed_unit(
+            gh,
+            unit_id="issue:acme/svc#9999",
+            root_node_id="issue:acme/svc#9999",
+        )
+        _seed_correction(
+            exp,
+            unit_id="issue:acme/svc#9999",
+            facet="scope",
+            original_value="AUTO-CONFIRM-SENTINEL",
+            corrected_value="AUTO-CONFIRM-SENTINEL",
+            corrected_by="auto_confirm",
+            corrected_at="2029-01-01 00:00:00",  # Most recent — would win if not filtered
+        )
+        result = build_few_shot_block(str(exp))
+        assert "AUTO-CONFIRM-SENTINEL" not in result
+
+    def test_selection_deterministic(self, tmp_path):
+        """AS-5: identical inputs produce identical few-shot selection."""
+        _, exp = _init_dbs(tmp_path)
+        gh = tmp_path / "github.db"
+        # Seed rows with identical timestamps to force the tie-break.
+        same_ts = "2026-04-10 10:00:00"
+        for i in range(CALIBRATION_MIN_CORRECTIONS):
+            issue_number = 2000 + i
+            repo = "acme/svc"
+            root = f"issue:{repo}#{issue_number}"
+            _seed_issue(
+                gh, repo=repo, issue_number=issue_number, type_label="bug"
+            )
+            _seed_unit(gh, unit_id=root, root_node_id=root)
+            _seed_correction(
+                exp,
+                unit_id=root,
+                facet="scope",
+                original_value=f"v-{i}",
+                corrected_value=f"w-{i}",
+                corrected_by="user",
+                corrected_at=same_ts,
+            )
+        first = build_few_shot_block(str(exp))
+        second = build_few_shot_block(str(exp))
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Trend computation
+# ---------------------------------------------------------------------------
+
+
+class TestTrendComputation:
+    """AS-3 / AS-7: per-work-type deltas land in calibration trends table."""
+
+    def test_below_threshold_noop(self, tmp_path):
+        gh, exp = _init_dbs(tmp_path)
+        _seed_n_user_corrections(exp, gh, n=CALIBRATION_MIN_CORRECTIONS - 1)
+        result = calibration.run(
+            WEEK_START,
+            github_db=str(gh),
+            expectations_db=str(exp),
+        )
+        assert result == {}
+        # Table must be empty.
+        conn = sqlite3.connect(str(exp))
+        try:
+            rows = conn.execute(
+                "SELECT * FROM expectation_calibration_trends"
+            ).fetchall()
+        finally:
+            conn.close()
+        assert rows == []
+
+    def test_at_threshold_writes_rows(self, tmp_path):
+        gh, exp = _init_dbs(tmp_path)
+        _seed_n_user_corrections(
+            exp, gh, n=CALIBRATION_MIN_CORRECTIONS, type_label="bug"
+        )
+        result = calibration.run(
+            WEEK_START,
+            github_db=str(gh),
+            expectations_db=str(exp),
+        )
+        assert "bug" in result
+        entry = result["bug"]
+        assert entry["sample_count"] == CALIBRATION_MIN_CORRECTIONS
+        # At least one facet has a numeric delta.
+        numeric = [
+            entry.get(f"avg_{f}_delta") for f in ("scope", "effort", "outcome")
+        ]
+        assert any(isinstance(v, float) for v in numeric)
+
+    def test_work_type_grouping(self, tmp_path):
+        """AS-3: multiple type_labels produce multiple trend rows."""
+        gh, exp = _init_dbs(tmp_path)
+        # 15 bug corrections + 10 refactor = 25 total, above threshold.
+        _seed_n_user_corrections(exp, gh, n=15, type_label="bug")
+        # Continue numbering to avoid PK collisions.
+        clock = datetime(2026, 4, 11, 10, 0, 0, tzinfo=timezone.utc)
+        for i in range(10):
+            issue_number = 3000 + i
+            repo = "acme/svc"
+            root = f"issue:{repo}#{issue_number}"
+            _seed_issue(
+                gh, repo=repo, issue_number=issue_number, type_label="refactor"
+            )
+            _seed_unit(gh, unit_id=root, root_node_id=root)
+            ts = (clock + timedelta(minutes=i)).strftime("%Y-%m-%d %H:%M:%S")
+            _seed_correction(
+                exp,
+                unit_id=root,
+                facet="effort",
+                original_value="small",
+                corrected_value="large",
+                corrected_by="user",
+                corrected_at=ts,
+            )
+        result = calibration.run(
+            WEEK_START,
+            github_db=str(gh),
+            expectations_db=str(exp),
+        )
+        assert set(result.keys()) >= {"bug", "refactor"}
+        assert result["refactor"]["sample_count"] == 10
+
+    def test_unknown_work_type_fallback(self, tmp_path):
+        """Units with NULL type_label fall under 'unknown'."""
+        gh, exp = _init_dbs(tmp_path)
+        _seed_n_user_corrections(
+            exp, gh, n=CALIBRATION_MIN_CORRECTIONS, type_label=None
+        )
+        result = calibration.run(
+            WEEK_START,
+            github_db=str(gh),
+            expectations_db=str(exp),
+        )
+        assert "unknown" in result
+
+    def test_upsert_idempotent_on_rerun(self, tmp_path):
+        """Re-running updates the trend row rather than duplicating."""
+        gh, exp = _init_dbs(tmp_path)
+        _seed_n_user_corrections(
+            exp, gh, n=CALIBRATION_MIN_CORRECTIONS, type_label="bug"
+        )
+        calibration.run(
+            WEEK_START, github_db=str(gh), expectations_db=str(exp)
+        )
+        calibration.run(
+            WEEK_START, github_db=str(gh), expectations_db=str(exp)
+        )
+        conn = sqlite3.connect(str(exp))
+        try:
+            rows = conn.execute(
+                "SELECT work_type, week_start FROM expectation_calibration_trends"
+            ).fetchall()
+        finally:
+            conn.close()
+        # No duplicates per (work_type, week_start).
+        assert len(rows) == len(set(rows))
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+class TestRendering:
+    """AS-4: render_calibration_block produces the retrospective section."""
+
+    def test_empty_trends_returns_empty_list(self):
+        assert render_calibration_block({}) == []
+
+    def test_section_header_present(self):
+        trends = {
+            "bug": {
+                "avg_scope_delta": 0.5,
+                "avg_effort_delta": 0.75,
+                "avg_outcome_delta": None,
+                "sample_count": 20,
+            }
+        }
+        lines = render_calibration_block(trends)
+        assert any("## Calibration Trends" in ln for ln in lines)
+        assert any("bug" in ln for ln in lines)
+
+    def test_top_n_limits_rendered_entries(self):
+        trends = {
+            f"type{i}": {
+                "avg_scope_delta": i * 0.1,
+                "avg_effort_delta": None,
+                "avg_outcome_delta": None,
+                "sample_count": 5,
+            }
+            for i in range(10)
+        }
+        lines = render_calibration_block(trends, top_n=3)
+        bullets = [ln for ln in lines if ln.startswith("- ")]
+        assert len(bullets) == 3
+
+
+# ---------------------------------------------------------------------------
+# load_trends
+# ---------------------------------------------------------------------------
+
+
+class TestLoadTrends:
+    def test_load_trends_empty_when_missing(self, tmp_path):
+        _, exp = _init_dbs(tmp_path)
+        assert load_trends(str(exp), WEEK_START) == {}
+
+    def test_load_trends_round_trip(self, tmp_path):
+        gh, exp = _init_dbs(tmp_path)
+        _seed_n_user_corrections(
+            exp, gh, n=CALIBRATION_MIN_CORRECTIONS, type_label="bug"
+        )
+        calibration.run(
+            WEEK_START, github_db=str(gh), expectations_db=str(exp)
+        )
+        loaded = load_trends(str(exp), WEEK_START)
+        assert "bug" in loaded
+        assert loaded["bug"]["sample_count"] == CALIBRATION_MIN_CORRECTIONS
+
+
+# ---------------------------------------------------------------------------
+# Weekly pipeline integration (idempotency of the .md)
+# ---------------------------------------------------------------------------
+
+
+class TestWeeklyIntegration:
+    """AS-8: retrospective .md is not overwritten on re-run."""
+
+    def test_md_idempotency(self, tmp_path):
+        """Pre-existing retrospective .md is preserved on re-run."""
+        from synthesis.output_writer import write_retrospective
+
+        output_dir = tmp_path / "retrospectives"
+        output_dir.mkdir()
+        md_path = output_dir / f"{WEEK_START}.md"
+        md_path.write_text("ORIGINAL CONTENT\n", encoding="utf-8")
+        mtime_before = md_path.stat().st_mtime
+
+        # Attempt to overwrite — writer must refuse.
+        result = write_retrospective(
+            "NEW CONTENT\n", output_dir, WEEK_START
+        )
+        assert result is None
+        assert md_path.read_text(encoding="utf-8") == "ORIGINAL CONTENT\n"
+        assert md_path.stat().st_mtime == mtime_before


### PR DESCRIPTION
## Summary
- Adds `synthesis/calibration.py` — gated on ≥20 `corrected_by='user'` corrections. Below threshold X-5 is a strict no-op (identical behaviour to X-1..X-4 baseline).
- Few-shot block of 5 most-recent user corrections is prepended to the X-1 classifier user message (deterministic selection by `corrected_at DESC, unit_id ASC`). Auto-confirm rows are excluded and the exclusion is logged at INFO — this is the guard against the epic's feared failure mode (calibrating on noise).
- New `expectation_calibration_trends` table stores per-work-type deltas keyed on `(work_type, week_start)` with UPSERT semantics. Cross-db join to `github.db::issues.type_label` via `ATTACH DATABASE`; missing labels fall under `"unknown"`.
- Weekly retrospective gains a conditional `## Calibration Trends` section positioned between `## Expectation Revisions` and `## Clarifying Questions`. Shipped `.md` remains immutable per Epic #17 Decision 2.

Resolves #76.

## Acceptance scenarios
- **AS-1 / below-threshold no-op**: verified by `TestFewShotGating::test_below_threshold_returns_empty` and `TestTrendComputation::test_below_threshold_noop`.
- **AS-2 / activation at threshold**: `test_at_threshold_injects_block`, `test_block_contains_five_entries_at_threshold`.
- **AS-3 / work-type grouping**: `test_work_type_grouping`, `test_unknown_work_type_fallback`.
- **AS-4 / retrospective section renders**: `TestRendering::test_section_header_present`; section ordering updated in `_STATIC_SYSTEM_PROMPT`.
- **AS-5 / deterministic selection**: `test_selection_deterministic`.
- **AS-6 / auto-confirm exclusion**: `test_auto_confirm_rows_excluded`.
- **AS-7 / trend table persisted**: `TestCalibrationTrendsSchema::*` + `test_at_threshold_writes_rows` + `TestLoadTrends::test_load_trends_round_trip`.
- **AS-8 / idempotency of `.md`**: `TestWeeklyIntegration::test_md_idempotency` + `test_upsert_idempotent_on_rerun`.

## Open-question resolutions (documented in module docstring)
- **Trend table PK**: `(work_type, week_start)` with `ON CONFLICT DO UPDATE`. Simpler than a `run_id` composite and consistent with the "trend table is live data, `.md` is frozen" split.
- **Cross-db join**: `ATTACH DATABASE gh`; detach in `finally`. X-5 establishes the pattern for this codebase.
- **Section in `_STATIC_SYSTEM_PROMPT`**: added as a *conditional* required section; the section is omitted from the assembled user message entirely when the calibration dict is empty, so the LLM never renders an empty block.
- **`--dry-run` exposure**: no new flag needed — the existing `am-extract-expectations --dry-run` path writes the assembled classifier input, and the few-shot block is now part of that input (visible via the extended prompt file).

## Test plan
- [x] Full repo test suite: `605 passed, 23 skipped in 384.23s`
- [x] `tests/test_calibration.py` (19 cases): schema, few-shot gating, determinism, auto-confirm exclusion, trend grouping, upsert idempotency, rendering, load-trends round-trip, `.md` idempotency
- [x] `tests/test_init_db.py`, `test_expectations.py`, `test_correction.py`, `test_gap_analysis.py`, `test_revision_detection.py` all still pass (108 passed in 13.92s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)