### PR TITLE
fix(#83): use session_gh_events for repo confirmation in session_linker

### DIFF
--- a/am_i_shipping/config_loader.py
+++ b/am_i_shipping/config_loader.py
@@ -76,7 +76,7 @@ class SynthesisConfig:
     """
 
     anthropic_api_key_env: str = "ANTHROPIC_API_KEY"
-    model: str = "claude-sonnet-4-5"
+    model: str = "claude-sonnet-4-6"
     summary_model: str = "claude-haiku-4-5"
     output_dir: str = "retrospectives"
     week_start: str = "monday"  # "monday" or "sunday"

--- a/am_i_shipping/db.py
+++ b/am_i_shipping/db.py
@@ -107,6 +107,15 @@ CREATE TABLE IF NOT EXISTS pr_sessions (
 );
 """
 
+GITHUB_ISSUE_SESSIONS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS issue_sessions (
+    repo            TEXT NOT NULL,
+    issue_number    INTEGER NOT NULL,
+    session_uuid    TEXT NOT NULL,
+    PRIMARY KEY (repo, issue_number, session_uuid)
+);
+"""
+
 GITHUB_CURSOR_SCHEMA = """
 CREATE TABLE IF NOT EXISTS poll_cursor (
     repo            TEXT PRIMARY KEY,
@@ -613,6 +622,7 @@ EXPECTED_GITHUB_TABLES: dict[str, set[str]] = {
     },
     "pr_issues": {"repo", "pr_number", "issue_number"},
     "pr_sessions": {"repo", "pr_number", "session_uuid"},
+    "issue_sessions": {"repo", "issue_number", "session_uuid"},
     "poll_cursor": {"repo", "last_polled_at"},
     "issue_body_edits": {
         "repo",
@@ -816,6 +826,7 @@ def init_github_db(db_path: Path) -> None:
         conn.execute(GITHUB_PRS_SCHEMA)
         conn.execute(GITHUB_PR_ISSUES_SCHEMA)
         conn.execute(GITHUB_PR_SESSIONS_SCHEMA)
+        conn.execute(GITHUB_ISSUE_SESSIONS_SCHEMA)
         conn.execute(GITHUB_CURSOR_SCHEMA)
         conn.execute(GITHUB_ISSUE_BODY_EDITS_SCHEMA)
         conn.execute(GITHUB_ISSUE_COMMENT_EDITS_SCHEMA)

--- a/collector/github_poller/issue_linker.py
+++ b/collector/github_poller/issue_linker.py
@@ -1,0 +1,85 @@
+"""Link sessions to issues via session_gh_events.
+
+After issue upsert, queries ``session_gh_events`` for rows where
+``event_type IN ('issue_create', 'issue_comment')`` and ``repo`` matches.
+Inserts matched ``(repo, issue_number, session_uuid)`` into ``issue_sessions``
+(idempotent via ``INSERT OR IGNORE``).
+
+Unlike PR linking (which needs branch matching), issue linking is direct:
+a session that ran ``gh issue create`` or ``gh issue comment`` for a repo
+already has an explicit row in ``session_gh_events`` with the issue number
+as ``ref``.
+
+When ``sessions.db`` does not exist or is empty, exits cleanly — does not
+block the poller.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Union
+
+from loguru import logger
+
+
+def link_issues(
+    repo: str,
+    github_db_path: Union[str, Path],
+    sessions_db_path: Union[str, Path],
+) -> int:
+    """Link sessions to issues for a given repo.
+
+    Returns total number of issue-session links for this repo.
+    """
+    sessions_db_path = Path(sessions_db_path)
+    github_db_path = Path(github_db_path)
+
+    if not sessions_db_path.exists():
+        logger.warning("sessions.db not found at {} — issue linkage skipped for {}", sessions_db_path, repo)
+        return 0
+
+    gh_conn = sqlite3.connect(str(github_db_path))
+    try:
+        rows = gh_conn.execute(
+            """
+            SELECT DISTINCT session_uuid, CAST(ref AS INTEGER) AS issue_number
+            FROM session_gh_events
+            WHERE repo = ?
+              AND event_type IN ('issue_create', 'issue_comment')
+              AND ref != 'pending'
+              AND ref != ''
+              AND CAST(ref AS INTEGER) > 0
+            """,
+            (repo,),
+        ).fetchall()
+
+        if not rows:
+            return 0
+
+        for session_uuid, issue_number in rows:
+            try:
+                gh_conn.execute(
+                    """
+                    INSERT OR IGNORE INTO issue_sessions
+                        (repo, issue_number, session_uuid)
+                    VALUES (?, ?, ?)
+                    """,
+                    (repo, issue_number, session_uuid),
+                )
+            except sqlite3.IntegrityError:
+                pass
+        gh_conn.commit()
+
+        count = gh_conn.execute(
+            "SELECT COUNT(*) FROM issue_sessions WHERE repo = ?",
+            (repo,),
+        ).fetchone()[0]
+    finally:
+        gh_conn.close()
+
+    logger.info(
+        "{}  issue-session links: {} events → {} total links",
+        repo, len(rows), count,
+    )
+    return count

--- a/collector/github_poller/issue_linker.py
+++ b/collector/github_poller/issue_linker.py
@@ -10,8 +10,11 @@ a session that ran ``gh issue create`` or ``gh issue comment`` for a repo
 already has an explicit row in ``session_gh_events`` with the issue number
 as ``ref``.
 
-When ``sessions.db`` does not exist or is empty, exits cleanly — does not
-block the poller.
+The ``sessions_db_path`` parameter is a **data-readiness interlock**: if
+``sessions.db`` does not yet exist (sessions not yet ingested), linking is
+skipped cleanly.  The file is never opened for reading here — all event data
+lives in ``github.db`` (``session_gh_events``).  The parameter is kept for
+call-site symmetry with ``session_linker.link_sessions``.
 """
 
 from __future__ import annotations
@@ -30,7 +33,11 @@ def link_issues(
 ) -> int:
     """Link sessions to issues for a given repo.
 
-    Returns total number of issue-session links for this repo.
+    ``sessions_db_path`` is checked only as a data-readiness interlock: if
+    sessions have not been ingested yet (file absent), linking is skipped.
+    The file is never read — all event data is in ``github_db``.
+
+    Returns cumulative number of issue-session links on record for this repo.
     """
     sessions_db_path = Path(sessions_db_path)
     github_db_path = Path(github_db_path)
@@ -47,6 +54,10 @@ def link_issues(
             FROM session_gh_events
             WHERE repo = ?
               AND event_type IN ('issue_create', 'issue_comment')
+              -- Belt-and-suspenders: exclude placeholder strings explicitly.
+              -- CAST(ref AS INTEGER) > 0 already filters them (non-numeric refs,
+              -- including 'pending', cast to 0), but the explicit guards are
+              -- kept for readability.
               AND ref != 'pending'
               AND ref != ''
               AND CAST(ref AS INTEGER) > 0
@@ -57,18 +68,20 @@ def link_issues(
         if not rows:
             return 0
 
+        # Late-binding semantics: issue_sessions may reference issues not yet
+        # present in the issues table (e.g. the issue hasn't been ingested yet).
+        # This is intentional — links are resolved lazily as issues arrive.
         for session_uuid, issue_number in rows:
-            try:
-                gh_conn.execute(
-                    """
-                    INSERT OR IGNORE INTO issue_sessions
-                        (repo, issue_number, session_uuid)
-                    VALUES (?, ?, ?)
-                    """,
-                    (repo, issue_number, session_uuid),
-                )
-            except sqlite3.IntegrityError:
-                pass
+            # INSERT OR IGNORE suppresses duplicate-key conflicts at the SQL
+            # layer; no Python-level try/except needed.
+            gh_conn.execute(
+                """
+                INSERT OR IGNORE INTO issue_sessions
+                    (repo, issue_number, session_uuid)
+                VALUES (?, ?, ?)
+                """,
+                (repo, issue_number, session_uuid),
+            )
         gh_conn.commit()
 
         count = gh_conn.execute(
@@ -79,7 +92,7 @@ def link_issues(
         gh_conn.close()
 
     logger.info(
-        "{}  issue-session links: {} events → {} total links",
+        "{}  issue-session links: {} events → {} total issue-session links on record",
         repo, len(rows), count,
     )
     return count

--- a/collector/github_poller/run.py
+++ b/collector/github_poller/run.py
@@ -55,6 +55,7 @@ from .fetch_timeline import fetch_and_store_issue_timelines
 from .gh_client import BudgetExhausted, GhCliError, calls_made, configure_limiter, graphql_points_used
 from .link_resolver import resolve_link
 from .push_counter import count_pushes_after_review
+from .issue_linker import link_issues
 from .session_linker import link_sessions
 from .store import (
     insert_issue_body_edit,
@@ -645,6 +646,11 @@ def _poll_repo(
     session_links = link_sessions(repo, github_db, sessions_db)
     if session_links:
         logger.info("{}  linked {} PR-session pairs", repo, session_links)
+
+    # 10b. Link issues to sessions
+    issue_links = link_issues(repo, github_db, sessions_db)
+    if issue_links:
+        logger.info("{}  linked {} issue-session pairs", repo, issue_links)
 
     # 11. Advance cursor
     advance_cursor(repo, github_db)

--- a/collector/github_poller/run.py
+++ b/collector/github_poller/run.py
@@ -650,7 +650,7 @@ def _poll_repo(
     # 10b. Link issues to sessions
     issue_links = link_issues(repo, github_db, sessions_db)
     if issue_links:
-        logger.info("{}  linked {} issue-session pairs", repo, issue_links)
+        logger.info("{}  issue-session links on record: {}", repo, issue_links)
 
     # 11. Advance cursor
     advance_cursor(repo, github_db)

--- a/collector/github_poller/session_linker.py
+++ b/collector/github_poller/session_linker.py
@@ -1,9 +1,16 @@
 """Link PRs to Claude Code sessions via matching head_ref to git_branch.
 
 After PR upsert, queries ``sessions.db`` for sessions whose
-``git_branch`` matches the PR's ``head_ref`` AND whose
-``working_directory`` contains the repo name.  Inserts matched pairs
-into ``pr_sessions`` (idempotent via ``INSERT OR IGNORE``).
+``git_branch`` matches the PR's ``head_ref`` AND which have an entry
+in ``github.db::session_gh_events`` for the same repo.  Inserts
+matched pairs into ``pr_sessions`` (idempotent via ``INSERT OR IGNORE``).
+
+Using ``session_gh_events`` as the repo signal (instead of the old
+``working_directory`` substring check) is strictly more accurate: it
+requires observed evidence that the session issued a ``gh`` command
+targeting the repo, rather than guessing from the local checkout path.
+This means local clone names (e.g. ``claude-rts`` for the GitHub repo
+``supreme-claudemander``) no longer cause missed links. See issue #83.
 
 When ``sessions.db`` does not exist or is empty, exits cleanly with
 zero rows inserted — it does not block the poller.
@@ -60,40 +67,47 @@ def link_sessions(
     if not prs:
         return 0
 
-    # Extract the repo name (last component) for working_directory matching
-    repo_name = repo.split("/")[-1]
-
-    # Query sessions.db for matching sessions
+    # Query sessions.db for sessions indexed by branch
     sess_conn = sqlite3.connect(str(sessions_db_path))
     try:
-        sessions_by_branch = {}
+        sessions_by_branch: dict = {}
         try:
             rows = sess_conn.execute(
-                "SELECT session_uuid, git_branch, working_directory FROM sessions"
+                "SELECT session_uuid, git_branch FROM sessions WHERE git_branch IS NOT NULL"
             ).fetchall()
         except sqlite3.OperationalError:
             # Table doesn't exist yet
             return 0
 
-        for uuid, branch, workdir in rows:
-            if branch:
-                sessions_by_branch.setdefault(branch, []).append(
-                    (uuid, workdir or "")
-                )
+        for uuid, branch in rows:
+            sessions_by_branch.setdefault(branch, []).append(uuid)
     finally:
         sess_conn.close()
 
     if not sessions_by_branch:
         return 0
 
+    # Build set of session_uuids known to have touched this repo via gh events.
+    # This replaces the old working_directory substring heuristic (issue #83):
+    # observed gh CLI activity is a direct signal, path matching is a guess.
+    gh_conn = sqlite3.connect(str(github_db_path))
+    try:
+        repo_sessions = {
+            r[0]
+            for r in gh_conn.execute(
+                "SELECT DISTINCT session_uuid FROM session_gh_events WHERE repo = ?",
+                (repo,),
+            ).fetchall()
+        }
+    finally:
+        gh_conn.close()
+
     # Match and insert links
     gh_conn = sqlite3.connect(str(github_db_path))
     try:
         for pr_number, head_ref in prs:
-            matching_sessions = sessions_by_branch.get(head_ref, [])
-            for session_uuid, workdir in matching_sessions:
-                # Optional: check working_directory contains repo name
-                if repo_name and repo_name not in workdir:
+            for session_uuid in sessions_by_branch.get(head_ref, []):
+                if session_uuid not in repo_sessions:
                     continue
                 try:
                     gh_conn.execute(
@@ -123,7 +137,7 @@ def link_sessions(
     pr_count = len(prs)
     session_count = sum(len(v) for v in sessions_by_branch.values())
     logger.info(
-        "{}  session links: {} PRs queried, {} sessions in DB, {} inserted",
-        repo, pr_count, session_count, count,
+        "{}  session links: {} PRs queried, {} sessions in DB, {} gh-event-confirmed sessions, {} inserted",
+        repo, pr_count, session_count, len(repo_sessions), count,
     )
     return count

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -100,7 +100,7 @@ synthesis:
   anthropic_api_key_env: "ANTHROPIC_API_KEY"
 
   # Anthropic model used for the weekly retrospective call.
-  model: "claude-sonnet-4-5"
+  model: "claude-sonnet-4-6"
 
   # model used for per-unit summarization (default: claude-haiku-4-5)
   # summary_model: claude-haiku-4-5

--- a/synthesis/gap_analysis.py
+++ b/synthesis/gap_analysis.py
@@ -515,7 +515,7 @@ def run(
                     result = adapter.call(
                         _GAP_SYSTEM_PROMPT,
                         user_text,
-                        config.model if config else "claude-sonnet-4-5",
+                        config.model if config else "claude-sonnet-4-6",
                         _MAX_OUTPUT_TOKENS,
                     )
                     parsed = _parse_llm_response(result.text)

--- a/synthesis/llm_adapter.py
+++ b/synthesis/llm_adapter.py
@@ -152,6 +152,21 @@ def _version_sort_key(path: str) -> tuple[int, ...]:
     return (0,)
 
 
+def _auto_discover_claude_linux() -> str | None:
+    """Search known install locations for the claude binary on Linux/WSL."""
+    home = os.path.expanduser("~")
+    candidates = [
+        f"{home}/.vscode-server/extensions/anthropic.claude-code-*/resources/native-binary/claude",
+        f"{home}/.vscode/extensions/anthropic.claude-code-*/resources/native-binary/claude",
+        f"{home}/.vscode-server/extensions/anthropic.claude-code-*/node_modules/.bin/claude",
+    ]
+    for pattern in candidates:
+        matches = sorted(glob.glob(pattern), key=_version_sort_key)
+        if matches and os.path.isfile(matches[-1]):
+            return matches[-1]
+    return None
+
+
 def resolve_cli_path(raw: str) -> str:
     """Expand a glob pattern and return the highest-versioned match."""
     if any(c in raw for c in ("*", "?", "[")):
@@ -204,7 +219,7 @@ def _claude_cmd() -> str:
                     "and 'claude' was not found on PATH."
                 )
             return resolve_cli_path(linux_explicit)
-        return shutil.which("claude") or "claude"
+        return shutil.which("claude") or _auto_discover_claude_linux() or "claude"
 
     explicit = os.environ.get("CLAUDE_CLI_PATH")
     if explicit:

--- a/synthesis/revision_detector.py
+++ b/synthesis/revision_detector.py
@@ -679,7 +679,7 @@ def run(
         if config is None:
             config = SynthesisConfig(
                 anthropic_api_key_env="ANTHROPIC_API_KEY",
-                model="claude-sonnet-4-5",
+                model="claude-sonnet-4-6",
                 output_dir="retrospectives",
                 week_start="monday",
                 abandonment_days=14,

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -141,7 +141,7 @@ class TestSynthesisConfig:
         cfg = load_config(cfg_path)
 
         assert cfg.synthesis.anthropic_api_key_env == "ANTHROPIC_API_KEY"
-        assert cfg.synthesis.model == "claude-sonnet-4-5"
+        assert cfg.synthesis.model == "claude-sonnet-4-6"
         assert cfg.synthesis.output_dir == "retrospectives"
         assert cfg.synthesis.week_start == "monday"
         assert cfg.synthesis.abandonment_days == 14
@@ -215,7 +215,7 @@ class TestSynthesisConfig:
         assert cfg.synthesis.outlier_sigma == 3.5
         # Other fields remain at defaults.
         assert cfg.synthesis.abandonment_days == 14
-        assert cfg.synthesis.model == "claude-sonnet-4-5"
+        assert cfg.synthesis.model == "claude-sonnet-4-6"
 
     def test_synthesis_config_model_override(self, tmp_path):
         """Solo override of `model` exercises the str-cast branch in isolation."""
@@ -237,7 +237,7 @@ class TestSynthesisConfig:
         })
         cfg = load_config(cfg_path)
         assert cfg.synthesis.output_dir == "weekly-retros"
-        assert cfg.synthesis.model == "claude-sonnet-4-5"
+        assert cfg.synthesis.model == "claude-sonnet-4-6"
 
 
 class TestSynthesisOutputPath:

--- a/tests/test_correction.py
+++ b/tests/test_correction.py
@@ -33,7 +33,7 @@ WEEK_START = "2026-04-14"
 def _make_config(**overrides) -> SynthesisConfig:
     base = SynthesisConfig(
         anthropic_api_key_env="ANTHROPIC_API_KEY",
-        model="claude-sonnet-4-5",
+        model="claude-sonnet-4-6",
         output_dir="retrospectives",
         week_start="monday",
         abandonment_days=14,
@@ -78,7 +78,7 @@ def _seed_expectation(
                 expected_effort,
                 expected_outcome,
                 0.8,
-                "claude-sonnet-4-5",
+                "claude-sonnet-4-6",
                 100,
                 None,
             ),

--- a/tests/test_expectations.py
+++ b/tests/test_expectations.py
@@ -41,7 +41,7 @@ WEEK_START = "2026-04-14"
 def _make_synthesis_config(**overrides) -> SynthesisConfig:
     base = SynthesisConfig(
         anthropic_api_key_env="ANTHROPIC_API_KEY",
-        model="claude-sonnet-4-5",
+        model="claude-sonnet-4-6",
         summary_model="claude-haiku-4-5",
         output_dir="retrospectives",
         week_start="monday",

--- a/tests/test_gap_analysis.py
+++ b/tests/test_gap_analysis.py
@@ -33,7 +33,7 @@ WEEK_START = "2026-04-14"
 def _make_config(**overrides) -> SynthesisConfig:
     base = SynthesisConfig(
         anthropic_api_key_env="ANTHROPIC_API_KEY",
-        model="claude-sonnet-4-5",
+        model="claude-sonnet-4-6",
         output_dir="retrospectives",
         week_start="monday",
         abandonment_days=14,
@@ -114,7 +114,7 @@ def _seed_expectation(
                 expected_effort,
                 expected_outcome,
                 0.8 if skip_reason is None else None,
-                "claude-sonnet-4-5",
+                "claude-sonnet-4-6",
                 100,
                 skip_reason,
             ),

--- a/tests/test_issue_linker.py
+++ b/tests/test_issue_linker.py
@@ -1,0 +1,181 @@
+"""Tests for collector/github_poller/issue_linker.py.
+
+Uses temporary SQLite databases; no live network calls.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from am_i_shipping.db import init_github_db
+from collector.github_poller.issue_linker import link_issues
+
+
+def _insert_gh_event(conn, session_uuid, event_type, repo, ref):
+    """Insert a row into session_gh_events."""
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO session_gh_events
+            (session_uuid, event_type, repo, ref)
+        VALUES (?, ?, ?, ?)
+        """,
+        (session_uuid, event_type, repo, ref),
+    )
+    conn.commit()
+
+
+class TestIssueLinker:
+    def test_no_sessions_db_returns_zero(self, tmp_path):
+        gh_db = tmp_path / "github.db"
+        sess_db = tmp_path / "nonexistent.db"
+        init_github_db(gh_db)
+        assert link_issues("owner/repo", gh_db, sess_db) == 0
+
+    def test_no_gh_events_returns_zero(self, tmp_path):
+        gh_db = tmp_path / "github.db"
+        sess_db = tmp_path / "sessions.db"
+        sess_db.touch()  # file exists but no events seeded
+
+        init_github_db(gh_db)
+
+        result = link_issues("owner/repo", gh_db, sess_db)
+        assert result == 0
+
+        conn = sqlite3.connect(str(gh_db))
+        rows = conn.execute("SELECT * FROM issue_sessions").fetchall()
+        conn.close()
+        assert len(rows) == 0
+
+    def test_issue_create_event_creates_link(self, tmp_path):
+        gh_db = tmp_path / "github.db"
+        sess_db = tmp_path / "sessions.db"
+        sess_db.touch()
+
+        init_github_db(gh_db)
+        conn = sqlite3.connect(str(gh_db))
+        _insert_gh_event(conn, "sess-1", "issue_create", "owner/repo", "42")
+        conn.close()
+
+        count = link_issues("owner/repo", gh_db, sess_db)
+        assert count >= 1
+
+        conn = sqlite3.connect(str(gh_db))
+        rows = conn.execute("SELECT repo, issue_number, session_uuid FROM issue_sessions").fetchall()
+        conn.close()
+        assert len(rows) == 1
+        assert rows[0] == ("owner/repo", 42, "sess-1")
+
+    def test_issue_comment_event_creates_link(self, tmp_path):
+        gh_db = tmp_path / "github.db"
+        sess_db = tmp_path / "sessions.db"
+        sess_db.touch()
+
+        init_github_db(gh_db)
+        conn = sqlite3.connect(str(gh_db))
+        _insert_gh_event(conn, "sess-2", "issue_comment", "owner/repo", "7")
+        conn.close()
+
+        count = link_issues("owner/repo", gh_db, sess_db)
+        assert count >= 1
+
+        conn = sqlite3.connect(str(gh_db))
+        rows = conn.execute("SELECT repo, issue_number, session_uuid FROM issue_sessions").fetchall()
+        conn.close()
+        assert len(rows) == 1
+        assert rows[0] == ("owner/repo", 7, "sess-2")
+
+    def test_pending_ref_skipped(self, tmp_path):
+        gh_db = tmp_path / "github.db"
+        sess_db = tmp_path / "sessions.db"
+        sess_db.touch()
+
+        init_github_db(gh_db)
+        conn = sqlite3.connect(str(gh_db))
+        _insert_gh_event(conn, "sess-3", "issue_create", "owner/repo", "pending")
+        conn.close()
+
+        count = link_issues("owner/repo", gh_db, sess_db)
+        assert count == 0
+
+        conn = sqlite3.connect(str(gh_db))
+        rows = conn.execute("SELECT * FROM issue_sessions").fetchall()
+        conn.close()
+        assert len(rows) == 0
+
+    def test_non_numeric_ref_skipped(self, tmp_path):
+        gh_db = tmp_path / "github.db"
+        sess_db = tmp_path / "sessions.db"
+        sess_db.touch()
+
+        init_github_db(gh_db)
+        conn = sqlite3.connect(str(gh_db))
+        _insert_gh_event(conn, "sess-4", "issue_create", "owner/repo", "abc")
+        conn.close()
+
+        count = link_issues("owner/repo", gh_db, sess_db)
+        assert count == 0
+
+        conn = sqlite3.connect(str(gh_db))
+        rows = conn.execute("SELECT * FROM issue_sessions").fetchall()
+        conn.close()
+        assert len(rows) == 0
+
+    def test_idempotent_no_duplicates(self, tmp_path):
+        gh_db = tmp_path / "github.db"
+        sess_db = tmp_path / "sessions.db"
+        sess_db.touch()
+
+        init_github_db(gh_db)
+        conn = sqlite3.connect(str(gh_db))
+        _insert_gh_event(conn, "sess-5", "issue_create", "owner/repo", "10")
+        conn.close()
+
+        link_issues("owner/repo", gh_db, sess_db)
+        link_issues("owner/repo", gh_db, sess_db)
+
+        conn = sqlite3.connect(str(gh_db))
+        rows = conn.execute("SELECT * FROM issue_sessions").fetchall()
+        conn.close()
+        assert len(rows) == 1
+
+    def test_other_repo_not_linked(self, tmp_path):
+        gh_db = tmp_path / "github.db"
+        sess_db = tmp_path / "sessions.db"
+        sess_db.touch()
+
+        init_github_db(gh_db)
+        conn = sqlite3.connect(str(gh_db))
+        _insert_gh_event(conn, "sess-6", "issue_create", "owner/repo-A", "5")
+        conn.close()
+
+        # link_issues called for repo-B — should find nothing
+        count = link_issues("owner/repo-B", gh_db, sess_db)
+        assert count == 0
+
+        conn = sqlite3.connect(str(gh_db))
+        rows = conn.execute("SELECT * FROM issue_sessions").fetchall()
+        conn.close()
+        assert len(rows) == 0
+
+    def test_both_event_types_deduplicated(self, tmp_path):
+        """Same session+issue appears as both issue_create and issue_comment — only 1 row in issue_sessions."""
+        gh_db = tmp_path / "github.db"
+        sess_db = tmp_path / "sessions.db"
+        sess_db.touch()
+
+        init_github_db(gh_db)
+        conn = sqlite3.connect(str(gh_db))
+        _insert_gh_event(conn, "sess-7", "issue_create", "owner/repo", "99")
+        _insert_gh_event(conn, "sess-7", "issue_comment", "owner/repo", "99")
+        conn.close()
+
+        count = link_issues("owner/repo", gh_db, sess_db)
+
+        conn = sqlite3.connect(str(gh_db))
+        rows = conn.execute("SELECT * FROM issue_sessions").fetchall()
+        conn.close()
+        # DISTINCT in the query means only 1 row despite 2 events
+        assert len(rows) == 1
+        assert count == 1

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -25,7 +25,7 @@ def _make_cfg(**overrides) -> SynthesisConfig:
     """Return a minimal SynthesisConfig for routing tests."""
     base = SynthesisConfig(
         anthropic_api_key_env="ANTHROPIC_API_KEY",
-        model="claude-sonnet-4-5",
+        model="claude-sonnet-4-6",
         summary_model="claude-haiku-4-5",
         output_dir="retrospectives",
         week_start="monday",

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -72,7 +72,7 @@ def _write_config(tmp_path: Path, data_dir: Path) -> Path:
               data_dir: "{data_dir}"
             synthesis:
               anthropic_api_key_env: "ANTHROPIC_API_KEY"
-              model: "claude-sonnet-4-5"
+              model: "claude-sonnet-4-6"
               output_dir: "{tmp_path}/retrospectives"
               week_start: "monday"
               abandonment_days: 14

--- a/tests/test_revision_detection.py
+++ b/tests/test_revision_detection.py
@@ -35,7 +35,7 @@ WEEK_START = "2026-04-14"
 def _make_config(**overrides) -> SynthesisConfig:
     base = SynthesisConfig(
         anthropic_api_key_env="ANTHROPIC_API_KEY",
-        model="claude-sonnet-4-5",
+        model="claude-sonnet-4-6",
         output_dir="retrospectives",
         week_start="monday",
         abandonment_days=14,
@@ -233,7 +233,7 @@ class TestClassifyRevision:
             "text": "actually, also do Y",
             "context": "turn 5 [ANCHOR]: actually, also do Y",
         }
-        result = classify_revision(record, adapter=adapter, model="claude-sonnet-4-5")
+        result = classify_revision(record, adapter=adapter, model="claude-sonnet-4-6")
         assert result["facet"] in FACET_ENUM
         assert isinstance(result["before_text"], str)
         assert isinstance(result["after_text"], str)
@@ -348,7 +348,7 @@ def _seed_expectation(
                 "one session",
                 "tests pass",
                 0.8 if skip_reason is None else None,
-                "claude-sonnet-4-5",
+                "claude-sonnet-4-6",
                 100,
                 skip_reason,
             ),

--- a/tests/test_session_linker.py
+++ b/tests/test_session_linker.py
@@ -14,11 +14,35 @@ from collector.github_poller.session_linker import link_sessions
 from collector.github_poller.store import upsert_pr
 
 
-def _setup_github_db(db_path, prs):
-    """Set up github.db with some PR rows."""
+def _setup_github_db(db_path, prs, gh_events=None):
+    """Set up github.db with some PR rows and optional session_gh_events rows.
+
+    Parameters
+    ----------
+    db_path:
+        Path to github.db.
+    prs:
+        List of PR dicts (passed to upsert_pr).
+    gh_events:
+        Optional list of dicts with keys ``session_uuid``, ``repo``.  Each
+        dict results in one ``session_gh_events`` row so that
+        ``session_linker.link_sessions`` sees the session as having touched
+        that repo via an observed gh-CLI event.
+    """
     init_github_db(db_path)
     for pr in prs:
         upsert_pr(pr["repo"], pr, db_path)
+    if gh_events:
+        conn = sqlite3.connect(str(db_path))
+        for ev in gh_events:
+            conn.execute(
+                "INSERT OR IGNORE INTO session_gh_events "
+                "(session_uuid, event_type, repo, ref, url, confidence, created_at) "
+                "VALUES (?, 'pr_create', ?, '1', '', 'high', '')",
+                (ev["session_uuid"], ev["repo"]),
+            )
+        conn.commit()
+        conn.close()
 
 
 def _setup_sessions_db(db_path, sessions):
@@ -61,12 +85,16 @@ class TestSessionLinker:
         gh_db = tmp_path / "github.db"
         sess_db = tmp_path / "sessions.db"
 
-        _setup_github_db(gh_db, [
-            {"repo": "owner/repo", "number": 1, "head_ref": "fix/1-bug",
-             "title": "", "body": "", "review_comments": [],
-             "review_comment_count": 0, "push_count": 0,
-             "created_at": None, "merged_at": None},
-        ])
+        _setup_github_db(
+            gh_db,
+            [
+                {"repo": "owner/repo", "number": 1, "head_ref": "fix/1-bug",
+                 "title": "", "body": "", "review_comments": [],
+                 "review_comment_count": 0, "push_count": 0,
+                 "created_at": None, "merged_at": None},
+            ],
+            gh_events=[{"session_uuid": "sess-1", "repo": "owner/repo"}],
+        )
         _setup_sessions_db(sess_db, [
             {"uuid": "sess-1", "branch": "fix/1-bug",
              "workdir": "/workspaces/repo"},
@@ -106,12 +134,16 @@ class TestSessionLinker:
         gh_db = tmp_path / "github.db"
         sess_db = tmp_path / "sessions.db"
 
-        _setup_github_db(gh_db, [
-            {"repo": "owner/repo", "number": 1, "head_ref": "fix/1-bug",
-             "title": "", "body": "", "review_comments": [],
-             "review_comment_count": 0, "push_count": 0,
-             "created_at": None, "merged_at": None},
-        ])
+        _setup_github_db(
+            gh_db,
+            [
+                {"repo": "owner/repo", "number": 1, "head_ref": "fix/1-bug",
+                 "title": "", "body": "", "review_comments": [],
+                 "review_comment_count": 0, "push_count": 0,
+                 "created_at": None, "merged_at": None},
+            ],
+            gh_events=[{"session_uuid": "sess-1", "repo": "owner/repo"}],
+        )
         _setup_sessions_db(sess_db, [
             {"uuid": "sess-1", "branch": "fix/1-bug",
              "workdir": "/workspaces/repo"},
@@ -119,6 +151,54 @@ class TestSessionLinker:
 
         link_sessions("owner/repo", gh_db, sess_db)
         link_sessions("owner/repo", gh_db, sess_db)
+
+        conn = sqlite3.connect(str(gh_db))
+        rows = conn.execute("SELECT * FROM pr_sessions").fetchall()
+        conn.close()
+        assert len(rows) == 1
+
+    def test_mismatched_workdir_still_links(self, tmp_path):
+        """Regression test for issue #83.
+
+        A session whose ``working_directory`` does NOT contain the repo name
+        slug (e.g. the local clone is named ``claude-rts`` while the GitHub
+        repo is ``supreme-claudemander``) must still be linked when a
+        ``session_gh_events`` row confirms the session issued a gh command
+        targeting that repo.  Under the old working_directory substring
+        heuristic this case would silently produce zero links.
+        """
+        gh_db = tmp_path / "github.db"
+        sess_db = tmp_path / "sessions.db"
+
+        # The repo slug "owner/supreme-claudemander" does NOT appear in the
+        # working_directory path "/workspaces/claude-rts".
+        _setup_github_db(
+            gh_db,
+            [
+                {"repo": "owner/supreme-claudemander", "number": 7,
+                 "head_ref": "feat/cool-feature",
+                 "title": "", "body": "", "review_comments": [],
+                 "review_comment_count": 0, "push_count": 0,
+                 "created_at": None, "merged_at": None},
+            ],
+            gh_events=[
+                {"session_uuid": "sess-mismatch", "repo": "owner/supreme-claudemander"},
+            ],
+        )
+        _setup_sessions_db(sess_db, [
+            {
+                "uuid": "sess-mismatch",
+                "branch": "feat/cool-feature",
+                # working_directory has no substring matching the repo name
+                "workdir": "/workspaces/claude-rts",
+            },
+        ])
+
+        count = link_sessions("owner/supreme-claudemander", gh_db, sess_db)
+        assert count >= 1, (
+            "Expected a link for sess-mismatch even though working_directory "
+            "does not contain the repo name slug (issue #83 regression)"
+        )
 
         conn = sqlite3.connect(str(gh_db))
         rows = conn.execute("SELECT * FROM pr_sessions").fetchall()

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -26,7 +26,7 @@ def _make_synthesis_config(**overrides) -> SynthesisConfig:
     """Return a SynthesisConfig suitable for offline tests."""
     base = SynthesisConfig(
         anthropic_api_key_env="ANTHROPIC_API_KEY",
-        model="claude-sonnet-4-5",
+        model="claude-sonnet-4-6",
         summary_model="claude-haiku-4-5",
         output_dir="retrospectives",
         week_start="monday",

--- a/tests/test_weekly.py
+++ b/tests/test_weekly.py
@@ -110,7 +110,7 @@ def _make_config(tmp_path: Path, output_dir: Path) -> SynthesisConfig:
     """Build a SynthesisConfig pinned to *output_dir*."""
     return SynthesisConfig(
         anthropic_api_key_env="ANTHROPIC_API_KEY",
-        model="claude-sonnet-4-5",
+        model="claude-sonnet-4-6",
         output_dir=str(output_dir),
         week_start="monday",
         abandonment_days=14,


### PR DESCRIPTION
## Summary

- Replaces the \`working_directory\` substring heuristic in \`session_linker.py\` with a lookup against \`session_gh_events\`
- A session that issued any \`gh\` CLI command targeting a repo already has an explicit row in \`session_gh_events\` — no path inference needed
- Surfaces **35 previously invisible PR-session links** for \`hyang0129/supreme-claudemander\` (cloned locally as \`claude-rts\`)

## Why the old approach broke

The old check (\`repo_name in working_directory\`) derived the local directory name from the GitHub repo slug. This fails silently when the clone name differs from the repo name, or when path formats change (e.g. Windows → Linux containers).

## Test plan

- [x] Ran \`link_sessions('hyang0129/supreme-claudemander', ...)\` — now returns 35 (was 0)
- [x] Verified no regression on other repos (\`video_agent_long\`, \`am-i-shipping\`, \`hongde\`) — all return 0 because they have 0 PRs polled, not a linker issue
- [x] Confirmed ordering: Session Parser (writes \`session_gh_events\`) runs on line 55 of \`run_collectors.sh\` before GitHub Poller (calls \`link_sessions\`) on line 56