### PR TITLE
fix(#88): add end-to-end single-repo filter to LLM pipeline stages

### DIFF
--- a/synthesis/cli.py
+++ b/synthesis/cli.py
@@ -73,13 +73,12 @@ def _build_parser() -> argparse.ArgumentParser:
         "--repo",
         default=None,
         help=(
-            "Filter LLM stages to a single repo (e.g. "
-            "'hyang0129/am-i-shipping'). Writes "
-            "retrospectives/<week>/<owner>__<repo>.md instead of "
-            "retrospectives/<week>.md so single-repo and full-weekly "
-            "runs coexist. Intended for dev-loop iteration; "
-            "unit_summaries / expectations remain partial for "
-            "non-targeted repos in the week."
+            "Filter LLM stages to a single repo (owner/name, e.g. "
+            "'hyang0129/am-i-shipping'). Writes the retrospective to "
+            "retrospectives/<week>/<owner>__<name>.md so single-repo "
+            "and full-weekly runs for the same week coexist. "
+            "Intended for dev-loop iteration; unit_summaries and "
+            "expectations remain partial for non-targeted repos."
         ),
     )
 

--- a/synthesis/cli.py
+++ b/synthesis/cli.py
@@ -69,6 +69,19 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Path to config.yaml (default: config.yaml in repo root).",
     )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help=(
+            "Filter LLM stages to a single repo (e.g. "
+            "'hyang0129/am-i-shipping'). Writes "
+            "retrospectives/<week>/<owner>__<repo>.md instead of "
+            "retrospectives/<week>.md so single-repo and full-weekly "
+            "runs coexist. Intended for dev-loop iteration; "
+            "unit_summaries / expectations remain partial for "
+            "non-targeted repos in the week."
+        ),
+    )
 
     subparsers = parser.add_subparsers(dest="subcommand")
     add_coverage_subparser(subparsers)
@@ -138,14 +151,19 @@ def _run_weekly(args: argparse.Namespace) -> int:
             args.week,
             dry_run=args.dry_run,
             expectations_db=expectations_db,
+            repo=getattr(args, "repo", None),
         )
     except Exception:  # noqa: BLE001 — CLI is the top of the stack
         logging.exception("Synthesis failed")
         return 2
 
     if result is None and not args.dry_run:
+        repo_suffix = (
+            f" for repo={args.repo!r}" if getattr(args, "repo", None) else ""
+        )
         print(
-            "No retrospective written (no units for week, or file already exists)",
+            "No retrospective written (no units for week, or file already "
+            f"exists){repo_suffix}",
             file=sys.stderr,
         )
         return 0

--- a/synthesis/expectations.py
+++ b/synthesis/expectations.py
@@ -620,9 +620,10 @@ def run_extraction(
 
         all_units = _load_week_units(gh_conn, week_start, repo=repo)
         if not all_units:
+            repo_suffix = f" repo={repo}" if repo else ""
             logger.info(
-                "No units for week_start=%s repo=%s; nothing to extract",
-                week_start, repo,
+                "No units for week_start=%s%s; nothing to extract",
+                week_start, repo_suffix,
             )
             return 0
 
@@ -838,10 +839,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--repo",
         default=None,
         help=(
-            "Filter to a single repo (e.g. 'hyang0129/am-i-shipping'). "
-            "Only units whose root_node_id belongs to this repo are "
-            "extracted. Intended for dev-loop iteration; expectations "
-            "remain partial for the week when the flag is set."
+            "Filter to a single repo (owner/name, e.g. "
+            "'hyang0129/am-i-shipping'). Only units whose root_node_id "
+            "belongs to this repo are extracted. "
+            "Intended for dev-loop iteration; expectations remain "
+            "partial for non-targeted repos."
         ),
     )
     return parser

--- a/synthesis/expectations.py
+++ b/synthesis/expectations.py
@@ -465,12 +465,25 @@ def _load_extracted_unit_ids(
 
 
 def _load_week_units(
-    gh_conn: sqlite3.Connection, week_start: str
+    gh_conn: sqlite3.Connection, week_start: str,
+    repo: Optional[str] = None,
 ) -> List[str]:
-    """Return all ``unit_id`` values in ``units`` for *week_start*, sorted."""
+    """Return all ``unit_id`` values in ``units`` for *week_start*, sorted.
+
+    When *repo* is set (issue #88), filter to units scoped to that repo
+    via :func:`synthesis.weekly._repo_filter_sql`. Without it the query
+    is byte-identical to the pre-#88 baseline.
+    """
+    from synthesis.weekly import _repo_filter_sql, _repo_filter_bind
+
+    fragment, _ = _repo_filter_sql(repo)
+    params: List = [week_start]
+    if fragment:
+        params.extend(_repo_filter_bind(repo, week_start))
     rows = gh_conn.execute(
-        "SELECT unit_id FROM units WHERE week_start = ? ORDER BY unit_id",
-        (week_start,),
+        f"SELECT unit_id FROM units WHERE week_start = ?{fragment} "
+        "ORDER BY unit_id",
+        params,
     ).fetchall()
     return [r[0] for r in rows]
 
@@ -525,6 +538,7 @@ def run_extraction(
     expectations_db: str,
     week_start: str,
     rebuild: bool = False,
+    repo: Optional[str] = None,
 ) -> int:
     """Extract expectations for every unit in *week_start*.
 
@@ -582,15 +596,31 @@ def run_extraction(
         sessions_conn = gh_conn if _same else sqlite3.connect(sessions_db)
 
         if rebuild:
-            exp_conn.execute(
-                "DELETE FROM expectations WHERE week_start = ?", (week_start,)
-            )
+            # When rebuild is combined with --repo, clear only the targeted
+            # repo's expectations rows. Sub-select against units in github.db
+            # via ATTACH is clumsy across two SQLite connections, so we
+            # compute the unit_id set in Python and issue a bounded DELETE.
+            if repo:
+                targeted = _load_week_units(gh_conn, week_start, repo=repo)
+                if targeted:
+                    placeholders = ",".join("?" * len(targeted))
+                    exp_conn.execute(
+                        "DELETE FROM expectations WHERE week_start = ? "
+                        f"AND unit_id IN ({placeholders})",
+                        [week_start] + targeted,
+                    )
+            else:
+                exp_conn.execute(
+                    "DELETE FROM expectations WHERE week_start = ?",
+                    (week_start,),
+                )
             exp_conn.commit()
 
-        all_units = _load_week_units(gh_conn, week_start)
+        all_units = _load_week_units(gh_conn, week_start, repo=repo)
         if not all_units:
             logger.info(
-                "No units for week_start=%s; nothing to extract", week_start
+                "No units for week_start=%s repo=%s; nothing to extract",
+                week_start, repo,
             )
             return 0
 
@@ -802,6 +832,16 @@ def _build_parser() -> argparse.ArgumentParser:
         default="config.yaml",
         help="Path to config.yaml (default: config.yaml in repo root).",
     )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help=(
+            "Filter to a single repo (e.g. 'hyang0129/am-i-shipping'). "
+            "Only units whose root_node_id belongs to this repo are "
+            "extracted. Intended for dev-loop iteration; expectations "
+            "remain partial for the week when the flag is set."
+        ),
+    )
     return parser
 
 
@@ -827,6 +867,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         expectations_db=expectations_db,
         week_start=args.week,
         rebuild=args.rebuild,
+        repo=getattr(args, "repo", None),
     )
     sys.exit(result)
 

--- a/synthesis/expectations.py
+++ b/synthesis/expectations.py
@@ -56,7 +56,13 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 from am_i_shipping.config_loader import SynthesisConfig, load_config
 from am_i_shipping.db import init_expectations_db, init_github_db
 from synthesis.llm_adapter import _get_adapter
-from synthesis.weekly import _load_session_transcripts, _resolve_unit_sessions, _unit_nodes
+from synthesis.weekly import (
+    _load_session_transcripts,
+    _load_units,
+    _repo_filter_sql,
+    _resolve_unit_sessions,
+    _unit_nodes,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -474,12 +480,8 @@ def _load_week_units(
     via :func:`synthesis.weekly._repo_filter_sql`. Without it the query
     is byte-identical to the pre-#88 baseline.
     """
-    from synthesis.weekly import _repo_filter_sql, _repo_filter_bind
-
-    fragment, _ = _repo_filter_sql(repo)
-    params: List = [week_start]
-    if fragment:
-        params.extend(_repo_filter_bind(repo, week_start))
+    fragment, repo_params = _repo_filter_sql(repo, week_start)
+    params: List = [week_start, *repo_params]
     rows = gh_conn.execute(
         f"SELECT unit_id FROM units WHERE week_start = ?{fragment} "
         "ORDER BY unit_id",

--- a/synthesis/gap_analysis.py
+++ b/synthesis/gap_analysis.py
@@ -447,6 +447,7 @@ def run(
     github_db: str,
     expectations_db: str,
     config: Optional[SynthesisConfig] = None,
+    repo: Optional[str] = None,
 ) -> int:
     """Compute gap rows for every unit with an expectations row in *week_start*.
 
@@ -493,6 +494,24 @@ def run(
 
     try:
         expectations = _load_expectations(exp_conn, week_start)
+
+        # Issue #88: restrict to the targeted repo's unit set.
+        # When *repo* is None the set is None (meaning "no filter").
+        # Otherwise we resolve the unit_id set once via weekly's filter
+        # helper (which knows how to apply the session resolver) and
+        # drop every expectation row whose unit_id is not in the set.
+        # This is simpler than rewriting the expectations SELECT to
+        # cross-join units, and cheap because expectations-per-week is
+        # O(units-per-week).
+        if repo:
+            from synthesis.weekly import _load_units
+            targeted_units = {
+                u["unit_id"] for u in _load_units(gh_conn, week_start, repo=repo)
+            }
+            expectations = [
+                e for e in expectations if e["unit_id"] in targeted_units
+            ]
+
         if not expectations:
             logger.info(
                 "No expectations rows for week=%s; gap pass is a no-op",
@@ -835,12 +854,21 @@ def load_gap_rows(
     week_start: str,
     *,
     min_severity: Optional[tuple[str, ...]] = None,
+    repo: Optional[str] = None,
+    github_db: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Return gap rows for *week_start*, optionally filtered by severity.
 
     *min_severity* is a tuple of severities to include (e.g.
     ``("major", "critical")`` for retrospective rendering). ``None``
     returns every row.
+
+    When *repo* is set (issue #88), an additional Python-side filter
+    restricts rows to unit_ids that belong to that repo. Because
+    ``expectations.db`` does not carry the repo column, the caller must
+    also supply *github_db* so the helper can resolve the unit set via
+    :func:`synthesis.weekly._load_units`. If *github_db* is missing, the
+    repo filter is silently ignored (degraded rather than misleading).
     """
     conn = sqlite3.connect(str(expectations_db))
     try:
@@ -864,7 +892,7 @@ def load_gap_rows(
                 f"ORDER BY unit_id",
                 [week_start, *min_severity],
             ).fetchall()
-        return [
+        results = [
             {
                 "unit_id": r[0],
                 "commitment_point": r[1],
@@ -880,6 +908,20 @@ def load_gap_rows(
         ]
     finally:
         conn.close()
+
+    if repo and github_db:
+        from synthesis.weekly import _load_units
+
+        gh_conn = sqlite3.connect(str(github_db))
+        try:
+            targeted = {
+                u["unit_id"]
+                for u in _load_units(gh_conn, week_start, repo=repo)
+            }
+        finally:
+            gh_conn.close()
+        results = [r for r in results if r["unit_id"] in targeted]
+    return results
 
 
 __all__ = [

--- a/synthesis/gap_analysis.py
+++ b/synthesis/gap_analysis.py
@@ -42,7 +42,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from am_i_shipping.config_loader import SynthesisConfig
 from synthesis.llm_adapter import _get_adapter
-from synthesis.weekly import _resolve_unit_sessions
+from synthesis.weekly import _load_units, _resolve_unit_sessions
 
 
 logger = logging.getLogger(__name__)
@@ -504,7 +504,6 @@ def run(
         # cross-join units, and cheap because expectations-per-week is
         # O(units-per-week).
         if repo:
-            from synthesis.weekly import _load_units
             targeted_units = {
                 u["unit_id"] for u in _load_units(gh_conn, week_start, repo=repo)
             }
@@ -867,9 +866,17 @@ def load_gap_rows(
     restricts rows to unit_ids that belong to that repo. Because
     ``expectations.db`` does not carry the repo column, the caller must
     also supply *github_db* so the helper can resolve the unit set via
-    :func:`synthesis.weekly._load_units`. If *github_db* is missing, the
-    repo filter is silently ignored (degraded rather than misleading).
+    :func:`synthesis.weekly._load_units`. If *repo* is set without
+    *github_db*, this function raises ``ValueError`` — a silent degrade
+    would return cross-repo rows under a contract that implies
+    repo-scoping, so we fail loudly instead (F-2 cycle-1 fix).
     """
+    if repo and not github_db:
+        raise ValueError(
+            "load_gap_rows: repo filter requires github_db to resolve "
+            "the targeted unit set (expectations.db does not carry the "
+            "repo column)"
+        )
     conn = sqlite3.connect(str(expectations_db))
     try:
         if min_severity is None:
@@ -910,8 +917,6 @@ def load_gap_rows(
         conn.close()
 
     if repo and github_db:
-        from synthesis.weekly import _load_units
-
         gh_conn = sqlite3.connect(str(github_db))
         try:
             targeted = {

--- a/synthesis/output_writer.py
+++ b/synthesis/output_writer.py
@@ -33,8 +33,9 @@ def write_retrospective(
     content: str,
     output_dir: Union[str, Path],
     week_start: str,
+    repo: Optional[str] = None,
 ) -> Optional[Path]:
-    """Atomically write *content* to ``<output_dir>/<week_start>.md``.
+    """Atomically write *content* to the retrospective output path.
 
     Parameters
     ----------
@@ -44,7 +45,16 @@ def write_retrospective(
     output_dir:
         Directory to write into. Created (with parents) if missing.
     week_start:
-        ``YYYY-MM-DD`` anchor. Used verbatim as the filename stem.
+        ``YYYY-MM-DD`` anchor. Used verbatim as the filename stem for the
+        full-weekly path.
+    repo:
+        Optional ``"owner/name"`` slug. When set (issue #88) the output
+        lands at ``<output_dir>/<week_start>/<owner>__<name>.md``
+        instead of ``<output_dir>/<week_start>.md`` so single-repo and
+        full-weekly runs coexist. The ``/`` in the slug is transliterated
+        to ``__`` so the filename is path-safe on every filesystem. The
+        refuse-to-overwrite guard naturally keys on ``(week, repo)``
+        because each combination maps to a distinct path.
 
     Returns
     -------
@@ -58,7 +68,10 @@ def write_retrospective(
     touching ``output_dir`` in any way. This matches ADR Decision 2:
     the synthesis call is downstream of this check in
     :func:`synthesis.weekly.run_synthesis`, so "file exists" also skips
-    the API call.
+    the API call. With the issue-#88 *repo* parameter, the guard
+    implicitly keys on ``(week, repo)`` — a single-repo run and a
+    full-weekly run for the same week do not block each other because
+    they target different filenames.
 
     Atomicity
     ---------
@@ -70,7 +83,15 @@ def write_retrospective(
     unlinked so a later run is not confused by stray ``.tmp`` droppings.
     """
     out_dir = Path(output_dir)
-    output_path = out_dir / f"{week_start}.md"
+    if repo:
+        # Issue #88: repo-scoped path. Owner/name segments are combined
+        # with ``__`` rather than keeping the ``/`` so the filename stays
+        # within a single directory level — simplifies mkdir + atomic
+        # rename (no nested mkdir after the week directory).
+        safe_slug = repo.replace("/", "__")
+        output_path = out_dir / week_start / f"{safe_slug}.md"
+    else:
+        output_path = out_dir / f"{week_start}.md"
 
     # --- Decision 2: refuse to overwrite -------------------------------
     if output_path.exists():
@@ -83,7 +104,10 @@ def write_retrospective(
     # --- ensure the output directory exists ----------------------------
     # We do this AFTER the exists check so a pre-existing file under an
     # already-existing directory is the cheap path (no mkdir syscall).
-    out_dir.mkdir(parents=True, exist_ok=True)
+    # For the repo-scoped path (issue #88) the parent is
+    # ``<output_dir>/<week>/``; for the bare-week path it is
+    # ``<output_dir>/``. ``parents=True`` handles both.
+    output_path.parent.mkdir(parents=True, exist_ok=True)
 
     # --- atomic write via .tmp + rename --------------------------------
     tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")

--- a/synthesis/revision_detector.py
+++ b/synthesis/revision_detector.py
@@ -678,9 +678,10 @@ def run(
             ]
 
         if not expectations:
+            repo_suffix = f" repo={repo}" if repo else ""
             logger.info(
-                "revision_detector: no expectations for week=%s repo=%s; no-op",
-                week_start, repo,
+                "revision_detector: no expectations for week=%s%s; no-op",
+                week_start, repo_suffix,
             )
             return 0
 

--- a/synthesis/revision_detector.py
+++ b/synthesis/revision_detector.py
@@ -45,6 +45,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 from am_i_shipping.config_loader import SynthesisConfig
 from synthesis.expectations import _extract_turns
 from synthesis.llm_adapter import _get_adapter
+from synthesis.weekly import _load_units
 
 
 logger = logging.getLogger(__name__)
@@ -669,7 +670,6 @@ def run(
         # strategy as gap_analysis.run — compute the unit set once via
         # weekly's filter helper and drop expectation rows outside it.
         if repo:
-            from synthesis.weekly import _load_units
             targeted_units = {
                 u["unit_id"] for u in _load_units(gh_conn, week_start, repo=repo)
             }
@@ -798,10 +798,18 @@ def load_revision_rows(
     """Return revision rows for *week_start*, ordered by unit + revision_index.
 
     When *repo* is set (issue #88), rows are additionally filtered to
-    the targeted repo's unit set via :func:`synthesis.weekly._load_units`,
-    provided *github_db* is also passed. When *github_db* is missing the
-    repo filter silently degrades to no-op.
+    the targeted repo's unit set via :func:`synthesis.weekly._load_units`.
+    The caller must also pass *github_db* so the unit set can be
+    resolved — if *repo* is set without *github_db* this function raises
+    ``ValueError`` rather than silently returning cross-repo rows (F-2
+    cycle-1 fix).
     """
+    if repo and not github_db:
+        raise ValueError(
+            "load_revision_rows: repo filter requires github_db to resolve "
+            "the targeted unit set (expectations.db does not carry the "
+            "repo column)"
+        )
     conn = sqlite3.connect(str(expectations_db))
     try:
         rows = conn.execute(
@@ -830,8 +838,6 @@ def load_revision_rows(
     ]
 
     if repo and github_db:
-        from synthesis.weekly import _load_units
-
         gh_conn = sqlite3.connect(str(github_db))
         try:
             targeted = {

--- a/synthesis/revision_detector.py
+++ b/synthesis/revision_detector.py
@@ -613,6 +613,7 @@ def run(
     expectations_db: str,
     config: Optional[SynthesisConfig] = None,
     rebuild: bool = False,
+    repo: Optional[str] = None,
 ) -> int:
     """Detect expectation revisions for every unit in *week_start*.
 
@@ -663,10 +664,23 @@ def run(
         sessions_conn = gh_conn if _same else sqlite3.connect(str(sessions_db))
 
         expectations = _load_expectations(exp_conn, week_start)
+
+        # Issue #88: restrict to the targeted repo's unit set. Same
+        # strategy as gap_analysis.run — compute the unit set once via
+        # weekly's filter helper and drop expectation rows outside it.
+        if repo:
+            from synthesis.weekly import _load_units
+            targeted_units = {
+                u["unit_id"] for u in _load_units(gh_conn, week_start, repo=repo)
+            }
+            expectations = [
+                e for e in expectations if e["unit_id"] in targeted_units
+            ]
+
         if not expectations:
             logger.info(
-                "revision_detector: no expectations for week=%s; no-op",
-                week_start,
+                "revision_detector: no expectations for week=%s repo=%s; no-op",
+                week_start, repo,
             )
             return 0
 
@@ -775,9 +789,19 @@ def run(
 
 
 def load_revision_rows(
-    expectations_db: str, week_start: str
+    expectations_db: str,
+    week_start: str,
+    *,
+    repo: Optional[str] = None,
+    github_db: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
-    """Return revision rows for *week_start*, ordered by unit + revision_index."""
+    """Return revision rows for *week_start*, ordered by unit + revision_index.
+
+    When *repo* is set (issue #88), rows are additionally filtered to
+    the targeted repo's unit set via :func:`synthesis.weekly._load_units`,
+    provided *github_db* is also passed. When *github_db* is missing the
+    repo filter silently degrades to no-op.
+    """
     conn = sqlite3.connect(str(expectations_db))
     try:
         rows = conn.execute(
@@ -791,7 +815,7 @@ def load_revision_rows(
         return []
     finally:
         conn.close()
-    return [
+    results = [
         {
             "unit_id": r[0],
             "revision_index": r[1],
@@ -804,6 +828,20 @@ def load_revision_rows(
         }
         for r in rows
     ]
+
+    if repo and github_db:
+        from synthesis.weekly import _load_units
+
+        gh_conn = sqlite3.connect(str(github_db))
+        try:
+            targeted = {
+                u["unit_id"]
+                for u in _load_units(gh_conn, week_start, repo=repo)
+            }
+        finally:
+            gh_conn.close()
+        results = [r for r in results if r["unit_id"] in targeted]
+    return results
 
 
 __all__ = [

--- a/synthesis/summarize.py
+++ b/synthesis/summarize.py
@@ -69,26 +69,58 @@ def _load_unsummarized_units(
     gh_conn: sqlite3.Connection,
     week_start: str,
     rebuild: bool = False,
+    repo: Optional[str] = None,
 ) -> List[dict]:
     """Return units for *week_start* that do not yet have a summary row.
 
     If *rebuild* is True, existing ``unit_summaries`` rows for the week
     are deleted before the query so every unit is treated as unsummarized.
+    When *rebuild* is combined with *repo*, only the targeted repo's
+    summary rows are deleted so a partial rebuild is possible.
+
+    When *repo* (``"owner/name"``) is set — issue #88 — the SELECT is
+    filtered via :func:`synthesis.weekly._repo_filter_sql` so only the
+    targeted repo's units are summarised. Without *repo*, the query is
+    byte-identical to the pre-#88 baseline.
     """
+    from synthesis.weekly import _repo_filter_sql, _repo_filter_bind
+
     if rebuild:
-        gh_conn.execute(
-            "DELETE FROM unit_summaries WHERE week_start = ?",
-            (week_start,),
-        )
+        # For a repo-scoped rebuild we still only want to clear rows
+        # belonging to that repo — otherwise a dev iteration would
+        # silently blow away every other repo's summaries for the week.
+        if repo:
+            fragment, _placeholders = _repo_filter_sql(repo, units_alias="u")
+            params: List = [week_start]
+            params.extend(_repo_filter_bind(repo, week_start))
+            gh_conn.execute(
+                # Delete using an EXISTS filter against ``units u`` so the
+                # repo predicate can be applied alongside the week key.
+                "DELETE FROM unit_summaries WHERE week_start = ? "
+                "AND unit_id IN ("
+                f"  SELECT u.unit_id FROM units u WHERE u.week_start = ?{fragment}"
+                ")",
+                [week_start] + params,
+            )
+        else:
+            gh_conn.execute(
+                "DELETE FROM unit_summaries WHERE week_start = ?",
+                (week_start,),
+            )
         gh_conn.commit()
+
+    fragment, _placeholders = _repo_filter_sql(repo, units_alias="u")
+    params: List = [week_start]
+    if fragment:
+        params.extend(_repo_filter_bind(repo, week_start))
 
     rows = gh_conn.execute(
         "SELECT u.unit_id FROM units u "
         "LEFT JOIN unit_summaries s "
         "  ON u.week_start = s.week_start AND u.unit_id = s.unit_id "
-        "WHERE u.week_start = ? AND s.unit_id IS NULL "
+        f"WHERE u.week_start = ? AND s.unit_id IS NULL{fragment} "
         "ORDER BY u.unit_id",
-        (week_start,),
+        params,
     ).fetchall()
     return [{"unit_id": r[0]} for r in rows]
 
@@ -299,6 +331,7 @@ def run_summarization(
     sessions_db: str,
     week_start: str,
     rebuild: bool = False,
+    repo: Optional[str] = None,
 ) -> int:
     """Summarize all unsummarized units for *week_start*.
 
@@ -337,12 +370,15 @@ def run_summarization(
         sessions_conn = gh_conn if _same else sqlite3.connect(sessions_db)
 
         try:
-            units = _load_unsummarized_units(gh_conn, week_start, rebuild=rebuild)
+            units = _load_unsummarized_units(
+                gh_conn, week_start, rebuild=rebuild, repo=repo
+            )
 
             if not units:
                 logger.info(
-                    "No unsummarized units for week_start=%s; nothing to do",
-                    week_start,
+                    "No unsummarized units for week_start=%s repo=%s; "
+                    "nothing to do",
+                    week_start, repo,
                 )
                 return 0
 
@@ -437,6 +473,16 @@ def _build_parser() -> argparse.ArgumentParser:
         default="config.yaml",
         help="Path to config.yaml (default: config.yaml in repo root).",
     )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help=(
+            "Filter to a single repo (e.g. 'hyang0129/am-i-shipping'). "
+            "Only units whose root_node_id belongs to this repo are "
+            "summarised. Intended for dev-loop iteration; unit_summaries "
+            "remain partial for the week when the flag is set."
+        ),
+    )
     return parser
 
 
@@ -460,6 +506,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         sessions_db=sessions_db,
         week_start=args.week,
         rebuild=args.rebuild_summaries,
+        repo=getattr(args, "repo", None),
     )
     sys.exit(result)
 

--- a/synthesis/summarize.py
+++ b/synthesis/summarize.py
@@ -375,10 +375,11 @@ def run_summarization(
             )
 
             if not units:
+                repo_suffix = f" repo={repo}" if repo else ""
                 logger.info(
-                    "No unsummarized units for week_start=%s repo=%s; "
+                    "No unsummarized units for week_start=%s%s; "
                     "nothing to do",
-                    week_start, repo,
+                    week_start, repo_suffix,
                 )
                 return 0
 
@@ -477,10 +478,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--repo",
         default=None,
         help=(
-            "Filter to a single repo (e.g. 'hyang0129/am-i-shipping'). "
-            "Only units whose root_node_id belongs to this repo are "
-            "summarised. Intended for dev-loop iteration; unit_summaries "
-            "remain partial for the week when the flag is set."
+            "Filter to a single repo (owner/name, e.g. "
+            "'hyang0129/am-i-shipping'). Only units whose root_node_id "
+            "belongs to this repo are summarised. "
+            "Intended for dev-loop iteration; unit_summaries remain "
+            "partial for non-targeted repos."
         ),
     )
     return parser

--- a/synthesis/summarize.py
+++ b/synthesis/summarize.py
@@ -36,7 +36,11 @@ from typing import List, Optional, Sequence, Tuple
 from am_i_shipping.config_loader import SynthesisConfig, load_config
 from am_i_shipping.db import init_github_db
 from synthesis.llm_adapter import _get_adapter
-from synthesis.weekly import _load_session_transcripts, _unit_nodes
+from synthesis.weekly import (
+    _load_session_transcripts,
+    _repo_filter_sql,
+    _unit_nodes,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -83,24 +87,22 @@ def _load_unsummarized_units(
     targeted repo's units are summarised. Without *repo*, the query is
     byte-identical to the pre-#88 baseline.
     """
-    from synthesis.weekly import _repo_filter_sql, _repo_filter_bind
-
     if rebuild:
         # For a repo-scoped rebuild we still only want to clear rows
         # belonging to that repo — otherwise a dev iteration would
         # silently blow away every other repo's summaries for the week.
         if repo:
-            fragment, _placeholders = _repo_filter_sql(repo, units_alias="u")
-            params: List = [week_start]
-            params.extend(_repo_filter_bind(repo, week_start))
+            fragment, repo_params = _repo_filter_sql(
+                repo, week_start, units_alias="u"
+            )
             gh_conn.execute(
-                # Delete using an EXISTS filter against ``units u`` so the
+                # Delete using a sub-select against ``units u`` so the
                 # repo predicate can be applied alongside the week key.
                 "DELETE FROM unit_summaries WHERE week_start = ? "
                 "AND unit_id IN ("
                 f"  SELECT u.unit_id FROM units u WHERE u.week_start = ?{fragment}"
                 ")",
-                [week_start] + params,
+                [week_start, week_start, *repo_params],
             )
         else:
             gh_conn.execute(
@@ -109,10 +111,8 @@ def _load_unsummarized_units(
             )
         gh_conn.commit()
 
-    fragment, _placeholders = _repo_filter_sql(repo, units_alias="u")
-    params: List = [week_start]
-    if fragment:
-        params.extend(_repo_filter_bind(repo, week_start))
+    fragment, repo_params = _repo_filter_sql(repo, week_start, units_alias="u")
+    params: List = [week_start, *repo_params]
 
     rows = gh_conn.execute(
         "SELECT u.unit_id FROM units u "

--- a/synthesis/weekly.py
+++ b/synthesis/weekly.py
@@ -213,22 +213,131 @@ def water_fill_truncate(
 # ---------------------------------------------------------------------------
 
 
+def _repo_filter_sql(
+    repo: Optional[str],
+    *,
+    units_alias: str = "",
+) -> Tuple[str, List[str]]:
+    """Return ``(sql_fragment, params)`` for filtering ``units`` by repo.
+
+    Issue #88 — single-repo filter for the LLM pipeline stages.
+
+    When *repo* is ``None`` or empty, returns ``("", [])`` so callers can
+    concatenate the fragment unconditionally and leave the baseline
+    no-flag SQL byte-identical.
+
+    When *repo* is a ``"owner/name"`` slug, the fragment is an ``AND ...``
+    clause (parenthesised) matching:
+
+    * issue-rooted units whose ``root_node_id`` is literally
+      ``issue:<repo>#<N>``,
+    * PR-rooted units whose ``root_node_id`` is literally
+      ``pr:<repo>#<N>``, and
+    * session-rooted units whose ``session:<uuid>`` is attributed to the
+      target repo via ``session_issue_attribution``.
+
+    The session branch covers the defensive path: today's
+    ``unit_identifier`` drops session-only graph components so
+    ``root_node_type='session'`` is effectively empty in practice, but the
+    spec (refined issue #88) calls for the resolver because a future
+    change upstream could start emitting them. Sessions attributed only
+    to a PR (not an issue) would be missed — documented limitation,
+    acceptable for a dev-loop feature.
+
+    ``units_alias`` lets callers reference a joined/aliased ``units`` table
+    (e.g. ``"u"`` in the ``LEFT JOIN unit_summaries`` query). Pass ``""``
+    when the SELECT is a bare ``FROM units``.
+
+    The trailing ``#%`` boundary on each LIKE pattern prevents
+    ``hyang0129/am-i-shipping`` from matching
+    ``hyang0129/am-i-shipping-sibling``.
+    """
+    if not repo:
+        return "", []
+
+    prefix = f"{units_alias}." if units_alias else ""
+    issue_pat = f"issue:{repo}#%"
+    pr_pat = f"pr:{repo}#%"
+
+    # Inner subquery resolves session-rooted units via
+    # session_issue_attribution. We substr the root_node_id past the
+    # literal "session:" prefix to recover the uuid, then join against
+    # the attribution table on (week_start, session_uuid, repo).
+    #
+    # The subquery is intentionally scoped by the *outer* week_start
+    # (via a correlated column). Callers always filter on week_start in
+    # the outer WHERE, so the subquery's ``u2.week_start = ?`` is fed
+    # the same value — we keep the binding explicit rather than
+    # correlating to avoid a dependency on the outer alias naming.
+    #
+    # Tied to :data:`synthesis.weekly._repo_filter_sql` — any change to
+    # the shape here must match the callers in gap_analysis / expectations /
+    # summarize / weekly at once.
+    session_subquery = (
+        "SELECT u2.unit_id FROM units u2 "
+        "JOIN session_issue_attribution sia "
+        "  ON sia.week_start = u2.week_start "
+        " AND sia.session_uuid = substr(u2.root_node_id, length('session:') + 1) "
+        "WHERE u2.week_start = ? "
+        "  AND u2.root_node_type = 'session' "
+        "  AND sia.repo = ?"
+    )
+
+    fragment = (
+        f" AND ({prefix}root_node_id LIKE ? "
+        f"     OR {prefix}root_node_id LIKE ? "
+        f"     OR (({prefix}root_node_type = 'session') "
+        f"         AND {prefix}unit_id IN ({session_subquery})))"
+    )
+    # Param order matches the ?s above: issue LIKE, pr LIKE, session
+    # subquery's week_start, session subquery's repo.
+    # NOTE — the caller is responsible for binding its own ``week_start``
+    # placeholder earlier in the query; this helper contributes the
+    # four placeholders above in order.
+    # session_week_start is duplicated from the outer bind by the caller
+    # via the ``session_week_start`` helper below. Keep them in lock-step.
+    return fragment, [issue_pat, pr_pat, "__SESSION_WEEK_PLACEHOLDER__", repo]
+
+
+def _repo_filter_bind(
+    repo: Optional[str],
+    week_start: str,
+) -> List[str]:
+    """Return the concrete parameter list for :func:`_repo_filter_sql`.
+
+    Handles the ``session_week_start`` substitution so callers do not
+    have to remember the placeholder convention.
+    """
+    _, params = _repo_filter_sql(repo)
+    return [week_start if p == "__SESSION_WEEK_PLACEHOLDER__" else p for p in params]
+
+
 def _load_units(
     github_conn: sqlite3.Connection,
     week_start: str,
+    repo: Optional[str] = None,
 ) -> List[dict]:
     """Return one dict per ``units`` row for *week_start*.
 
     Includes ``outlier_flags`` (JSON string or NULL) and
     ``abandonment_flag`` (0/1 or NULL) from the cross-unit pass.
+
+    When *repo* is set, filter to units whose ``root_node_id`` is
+    scoped to that repo (issue:/pr: LIKE + session resolver). When
+    ``None`` (default), the query is byte-identical to the pre-#88
+    baseline.
     """
+    fragment, _params_placeholder = _repo_filter_sql(repo)
+    params: List = [week_start]
+    if fragment:
+        params.extend(_repo_filter_bind(repo, week_start))
     rows = github_conn.execute(
         "SELECT unit_id, root_node_type, root_node_id, "
         "       elapsed_days, dark_time_pct, total_reprompts, "
         "       review_cycles, status, outlier_flags, abandonment_flag "
-        "FROM units WHERE week_start = ? "
+        f"FROM units WHERE week_start = ?{fragment} "
         "ORDER BY unit_id",
-        (week_start,),
+        params,
     ).fetchall()
     return [
         {
@@ -735,6 +844,7 @@ def run_synthesis(
     week_start: str,
     dry_run: bool = False,
     expectations_db: Optional[Union[str, Path]] = None,
+    repo: Optional[str] = None,
 ) -> Optional[Path]:
     """End-to-end weekly synthesis for *week_start*.
 
@@ -784,10 +894,11 @@ def run_synthesis(
     sess_conn = gh_conn if _same else sqlite3.connect(str(sess_path))
 
     try:
-        units = _load_units(gh_conn, week_start)
+        units = _load_units(gh_conn, week_start, repo=repo)
         if not units:
             logger.info(
-                "No units found for week_start=%s; skipping synthesis", week_start
+                "No units found for week_start=%s repo=%s; skipping synthesis",
+                week_start, repo,
             )
             return None
 
@@ -937,11 +1048,13 @@ def run_synthesis(
                     github_db=str(gh_path),
                     expectations_db=str(expectations_db),
                     config=config,
+                    repo=repo,
                 )
                 gap_rows = gap_analysis.load_gap_rows(
                     str(expectations_db),
                     week_start,
                     min_severity=("major", "critical"),
+                    repo=repo,
                 )
                 # Epic #27 — X-4 (#75): auto-confirm sweep fires on every
                 # ``am-synthesize --week`` invocation (AS-6). Any gap row
@@ -985,9 +1098,11 @@ def run_synthesis(
                     sessions_db=str(sess_path),
                     expectations_db=str(expectations_db),
                     config=config,
+                    repo=repo,
                 )
                 revision_rows = revision_detector.load_revision_rows(
-                    str(expectations_db), week_start
+                    str(expectations_db), week_start, repo=repo,
+                    github_db=str(gh_path),
                 )
             except sqlite3.OperationalError as exc:
                 logger.warning(
@@ -1122,7 +1237,9 @@ def run_synthesis(
         user_content = messages[0]["content"]
         markdown = _get_adapter(config).call(system_prompt, user_content, config.model, _MAX_OUTPUT_TOKENS).text
 
-        result = write_retrospective(markdown, config.output_dir, week_start)
+        result = write_retrospective(
+            markdown, config.output_dir, week_start, repo=repo
+        )
 
         # Record a successful synthesis run in health.json ONLY when the
         # retrospective was actually written this invocation. Refuse-to-
@@ -1146,6 +1263,8 @@ __all__ = [
     "run_synthesis",
     "water_fill_truncate",
     "_resolve_unit_sessions",
+    "_repo_filter_sql",
+    "_repo_filter_bind",
     "TRANSCRIPT_BUDGET_BYTES",
     "MAX_UNITS_PER_PROMPT",
     "MAX_PROMPT_SOFT_WARN_BYTES",

--- a/synthesis/weekly.py
+++ b/synthesis/weekly.py
@@ -896,9 +896,10 @@ def run_synthesis(
     try:
         units = _load_units(gh_conn, week_start, repo=repo)
         if not units:
+            repo_suffix = f" repo={repo}" if repo else ""
             logger.info(
-                "No units found for week_start=%s repo=%s; skipping synthesis",
-                week_start, repo,
+                "No units found for week_start=%s%s; skipping synthesis",
+                week_start, repo_suffix,
             )
             return None
 

--- a/synthesis/weekly.py
+++ b/synthesis/weekly.py
@@ -215,6 +215,7 @@ def water_fill_truncate(
 
 def _repo_filter_sql(
     repo: Optional[str],
+    week_start: Optional[str] = None,
     *,
     units_alias: str = "",
 ) -> Tuple[str, List[str]]:
@@ -248,31 +249,48 @@ def _repo_filter_sql(
     (e.g. ``"u"`` in the ``LEFT JOIN unit_summaries`` query). Pass ``""``
     when the SELECT is a bare ``FROM units``.
 
+    ``week_start`` must be provided whenever ``repo`` is truthy — the
+    session-attribution subquery correlates on ``week_start`` and the
+    helper binds it directly so the caller does not have to remember a
+    placeholder convention. (F-1 collapse: previously a two-function API
+    that returned a sentinel string; now a single function that returns
+    a ready-to-bind param list.)
+
     The trailing ``#%`` boundary on each LIKE pattern prevents
     ``hyang0129/am-i-shipping`` from matching
-    ``hyang0129/am-i-shipping-sibling``.
+    ``hyang0129/am-i-shipping-sibling``. The slug is also LIKE-escaped
+    (``%``, ``_``, backslash) with an explicit ``ESCAPE '\\'`` clause
+    so a repo whose name legitimately contains ``_`` — e.g.
+    ``owner/my_repo`` — cannot be confused with ``owner/myXrepo``.
     """
     if not repo:
         return "", []
+    if week_start is None:
+        raise ValueError(
+            "_repo_filter_sql: week_start is required when repo is set "
+            "(the session-attribution subquery correlates on week_start)"
+        )
 
     prefix = f"{units_alias}." if units_alias else ""
-    issue_pat = f"issue:{repo}#%"
-    pr_pat = f"pr:{repo}#%"
+
+    # LIKE-escape the slug so %, _, or \\ inside an owner/name cannot
+    # turn into SQL LIKE metacharacters. ``ESCAPE '\\'`` below tells
+    # SQLite to treat our backslash as the literal-escape sentinel.
+    esc_repo = (
+        repo.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    )
+    issue_pat = f"issue:{esc_repo}#%"
+    pr_pat = f"pr:{esc_repo}#%"
 
     # Inner subquery resolves session-rooted units via
     # session_issue_attribution. We substr the root_node_id past the
     # literal "session:" prefix to recover the uuid, then join against
     # the attribution table on (week_start, session_uuid, repo).
     #
-    # The subquery is intentionally scoped by the *outer* week_start
-    # (via a correlated column). Callers always filter on week_start in
-    # the outer WHERE, so the subquery's ``u2.week_start = ?`` is fed
-    # the same value — we keep the binding explicit rather than
-    # correlating to avoid a dependency on the outer alias naming.
-    #
-    # Tied to :data:`synthesis.weekly._repo_filter_sql` — any change to
-    # the shape here must match the callers in gap_analysis / expectations /
-    # summarize / weekly at once.
+    # The subquery's ``u2.week_start = ?`` is bound to the *same*
+    # week_start the caller filters the outer query on. Binding it
+    # directly here (rather than correlating to an outer alias) keeps
+    # the helper independent of the caller's alias naming.
     session_subquery = (
         "SELECT u2.unit_id FROM units u2 "
         "JOIN session_issue_attribution sia "
@@ -284,32 +302,16 @@ def _repo_filter_sql(
     )
 
     fragment = (
-        f" AND ({prefix}root_node_id LIKE ? "
-        f"     OR {prefix}root_node_id LIKE ? "
+        f" AND ({prefix}root_node_id LIKE ? ESCAPE '\\' "
+        f"     OR {prefix}root_node_id LIKE ? ESCAPE '\\' "
         f"     OR (({prefix}root_node_type = 'session') "
         f"         AND {prefix}unit_id IN ({session_subquery})))"
     )
     # Param order matches the ?s above: issue LIKE, pr LIKE, session
-    # subquery's week_start, session subquery's repo.
-    # NOTE — the caller is responsible for binding its own ``week_start``
-    # placeholder earlier in the query; this helper contributes the
-    # four placeholders above in order.
-    # session_week_start is duplicated from the outer bind by the caller
-    # via the ``session_week_start`` helper below. Keep them in lock-step.
-    return fragment, [issue_pat, pr_pat, "__SESSION_WEEK_PLACEHOLDER__", repo]
-
-
-def _repo_filter_bind(
-    repo: Optional[str],
-    week_start: str,
-) -> List[str]:
-    """Return the concrete parameter list for :func:`_repo_filter_sql`.
-
-    Handles the ``session_week_start`` substitution so callers do not
-    have to remember the placeholder convention.
-    """
-    _, params = _repo_filter_sql(repo)
-    return [week_start if p == "__SESSION_WEEK_PLACEHOLDER__" else p for p in params]
+    # subquery's week_start, session subquery's repo. ``repo`` in the
+    # session branch is compared directly against ``session_issue_attribution.repo``
+    # — no LIKE, no escape needed.
+    return fragment, [issue_pat, pr_pat, week_start, repo]
 
 
 def _load_units(
@@ -327,10 +329,8 @@ def _load_units(
     ``None`` (default), the query is byte-identical to the pre-#88
     baseline.
     """
-    fragment, _params_placeholder = _repo_filter_sql(repo)
-    params: List = [week_start]
-    if fragment:
-        params.extend(_repo_filter_bind(repo, week_start))
+    fragment, repo_params = _repo_filter_sql(repo, week_start)
+    params: List = [week_start, *repo_params]
     rows = github_conn.execute(
         "SELECT unit_id, root_node_type, root_node_id, "
         "       elapsed_days, dark_time_pct, total_reprompts, "
@@ -1055,6 +1055,7 @@ def run_synthesis(
                     week_start,
                     min_severity=("major", "critical"),
                     repo=repo,
+                    github_db=str(gh_path),
                 )
                 # Epic #27 — X-4 (#75): auto-confirm sweep fires on every
                 # ``am-synthesize --week`` invocation (AS-6). Any gap row
@@ -1264,7 +1265,6 @@ __all__ = [
     "water_fill_truncate",
     "_resolve_unit_sessions",
     "_repo_filter_sql",
-    "_repo_filter_bind",
     "TRANSCRIPT_BUDGET_BYTES",
     "MAX_UNITS_PER_PROMPT",
     "MAX_PROMPT_SOFT_WARN_BYTES",

--- a/tests/test_single_repo_filter.py
+++ b/tests/test_single_repo_filter.py
@@ -186,11 +186,40 @@ def test_repo_filter_sql_is_noop_without_repo() -> None:
 
 
 def test_repo_filter_sql_pins_slug_boundary() -> None:
-    _, params = _repo_filter_sql(REPO_A)
+    _, params = _repo_filter_sql(REPO_A, WEEK)
     # Param patterns must end in ``#%`` so a sibling repo slug cannot match.
     like_params = [p for p in params if p.startswith(("issue:", "pr:"))]
     assert len(like_params) == 2
     assert all(p.endswith("#%") for p in like_params)
+
+
+def test_repo_filter_sql_requires_week_start_when_repo_set() -> None:
+    """F-1 cycle 1: helper must fail loudly if caller forgets week_start.
+
+    The old two-function API used a sentinel string that silently
+    surfaced as a bad bind if the caller skipped ``_repo_filter_bind``.
+    The collapsed API makes week_start a required positional whenever
+    repo is truthy.
+    """
+    with pytest.raises(ValueError, match="week_start is required"):
+        _repo_filter_sql(REPO_A)
+
+
+def test_repo_filter_sql_escapes_like_metachars() -> None:
+    """F-3 cycle 1: underscore / percent in a repo name must not leak as
+    LIKE wildcards. A repo called ``owner/my_repo`` must not match a
+    unit id ``issue:owner/myXrepo#1``."""
+    from synthesis.weekly import _repo_filter_sql as _filter
+
+    _, params = _filter("owner/my_repo", WEEK)
+    like_params = [p for p in params if p.startswith(("issue:", "pr:"))]
+    # The ``_`` was escaped to ``\_`` (so the LIKE treats it literally).
+    assert all("\\_" in p for p in like_params)
+
+    # A literal ``%`` in the slug is also escaped.
+    _, pct_params = _filter("owner/50%repo", WEEK)
+    pct_like = [p for p in pct_params if p.startswith(("issue:", "pr:"))]
+    assert all("\\%" in p for p in pct_like)
 
 
 def test_load_units_filters_by_repo(two_repo_fixture: dict) -> None:

--- a/tests/test_single_repo_filter.py
+++ b/tests/test_single_repo_filter.py
@@ -24,7 +24,6 @@ reachable, but the resolver SQL must still hold.
 from __future__ import annotations
 
 import sqlite3
-from dataclasses import replace
 from pathlib import Path
 
 import pytest

--- a/tests/test_single_repo_filter.py
+++ b/tests/test_single_repo_filter.py
@@ -416,3 +416,147 @@ def test_run_synthesis_no_flag_writes_bare_week_path(
     # Flat path (no week directory) — unchanged from pre-#88 behavior.
     assert result.name == f"{WEEK}.md"
     assert result.parent.name == "retrospectives"
+
+
+# ---------------------------------------------------------------------------
+# F-4 cycle 1 — rebuild-preservation negative assertions
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_rebuild_with_repo_preserves_other_repos_rows(
+    two_repo_fixture: dict,
+) -> None:
+    """Negative invariant: ``--repo A --rebuild-summaries`` must NOT
+    delete repo B's summary rows for the same week (F-4)."""
+    cfg = _make_config(two_repo_fixture["tmp_path"])
+
+    # Seed a summary row for every unit in the fixture (both repos).
+    for uid in ("u-a-issue", "u-a-pr", "u-b-issue", "u-b-pr", "u-lookalike"):
+        _seed_unit_summary(two_repo_fixture["gh_db"], uid)
+
+    rc = run_summarization(
+        cfg,
+        github_db=str(two_repo_fixture["gh_db"]),
+        sessions_db=str(two_repo_fixture["sess_db"]),
+        week_start=WEEK,
+        rebuild=True,
+        repo=REPO_A,
+    )
+    assert rc == 0
+
+    conn = sqlite3.connect(str(two_repo_fixture["gh_db"]))
+    try:
+        rows = conn.execute(
+            "SELECT unit_id FROM unit_summaries WHERE week_start = ?",
+            (WEEK,),
+        ).fetchall()
+    finally:
+        conn.close()
+    ids = {r[0] for r in rows}
+    # Repo B's summaries (and the look-alike) must still be present.
+    assert "u-b-issue" in ids
+    assert "u-b-pr" in ids
+    assert "u-lookalike" in ids
+    # Repo A's rows are rewritten (either present after re-summarisation
+    # or not — what we assert here is that the *other* repos survived).
+
+
+def test_extract_expectations_rebuild_with_repo_preserves_other_repos_rows(
+    two_repo_fixture: dict,
+) -> None:
+    """Negative invariant for run_extraction (F-4). Seed expectations for
+    both repos, run rebuild scoped to repo A, confirm repo B survives."""
+    cfg = _make_config(two_repo_fixture["tmp_path"])
+
+    # Seed expectations rows directly — one per unit in both repos.
+    conn = sqlite3.connect(str(two_repo_fixture["exp_db"]))
+    try:
+        for uid in ("u-a-issue", "u-a-pr", "u-b-issue", "u-b-pr"):
+            conn.execute(
+                "INSERT INTO expectations "
+                "(week_start, unit_id, commitment_point, expected_scope, "
+                " expected_effort, expected_outcome, confidence, model, "
+                " input_bytes, skip_reason) "
+                "VALUES (?, ?, NULL, NULL, NULL, NULL, NULL, 'test', 0, NULL)",
+                (WEEK, uid),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    rc = run_extraction(
+        cfg,
+        github_db=str(two_repo_fixture["gh_db"]),
+        sessions_db=str(two_repo_fixture["sess_db"]),
+        expectations_db=str(two_repo_fixture["exp_db"]),
+        week_start=WEEK,
+        rebuild=True,
+        repo=REPO_A,
+    )
+    assert rc == 0
+
+    conn = sqlite3.connect(str(two_repo_fixture["exp_db"]))
+    try:
+        rows = conn.execute(
+            "SELECT DISTINCT unit_id FROM expectations WHERE week_start = ?",
+            (WEEK,),
+        ).fetchall()
+    finally:
+        conn.close()
+    ids = {r[0] for r in rows}
+    # Repo B's pre-existing rows must still be present after the
+    # repo-scoped rebuild — otherwise a dev iteration would silently
+    # wipe other repos' work.
+    assert "u-b-issue" in ids
+    assert "u-b-pr" in ids
+
+
+# ---------------------------------------------------------------------------
+# F-8 cycle 1 — alias-aware session resolver test (units_alias="u")
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_respects_repo_filter_for_session_rooted_unit(
+    two_repo_fixture: dict,
+) -> None:
+    """Exercise the ``units_alias='u'`` branch of the session resolver.
+
+    `_load_unsummarized_units` joins ``units u`` against ``unit_summaries``
+    and passes ``units_alias='u'``. The session subquery inside the
+    helper is written against its own alias (``u2``) and must remain
+    correct when the outer query uses a non-empty alias. Verified by
+    seeding a session-rooted unit + attribution row and confirming
+    ``run_summarization(..., repo=REPO_A)`` picks it up."""
+    gh_db = two_repo_fixture["gh_db"]
+    _seed_unit(
+        gh_db,
+        unit_id="u-a-session",
+        root_node_type="session",
+        root_node_id="session:xyz-789",
+    )
+    _seed_session_attribution(gh_db, session_uuid="xyz-789", repo=REPO_A, issue_number=1)
+
+    cfg = _make_config(two_repo_fixture["tmp_path"])
+    rc = run_summarization(
+        cfg,
+        github_db=str(gh_db),
+        sessions_db=str(two_repo_fixture["sess_db"]),
+        week_start=WEEK,
+        repo=REPO_A,
+    )
+    assert rc == 0
+
+    conn = sqlite3.connect(str(gh_db))
+    try:
+        rows = conn.execute(
+            "SELECT unit_id FROM unit_summaries WHERE week_start = ?",
+            (WEEK,),
+        ).fetchall()
+    finally:
+        conn.close()
+    ids = {r[0] for r in rows}
+    # Session-rooted unit must be present (resolver works under alias="u").
+    assert "u-a-session" in ids
+    # Repo B's units are not summarised.
+    assert "u-b-issue" not in ids
+    assert "u-b-pr" not in ids

--- a/tests/test_single_repo_filter.py
+++ b/tests/test_single_repo_filter.py
@@ -1,0 +1,389 @@
+"""Tests for the single-repo filter threaded through the LLM pipeline stages
+(issue #88).
+
+Covers the acceptance scenarios from the refined spec:
+
+* Entry Point 1 — ``run_synthesis`` with ``repo`` writes a repo-scoped
+  retrospective and leaves only targeted-repo units in the assembled prompt.
+* Entry Point 2 — ``run_summarization`` with ``repo`` touches only the
+  targeted repo's units.
+* Entry Point 3 — ``run_extraction`` with ``repo`` writes only the targeted
+  repo's expectations rows.
+* Entry Point 5 — the output path is keyed on ``(week, repo)`` so single-repo
+  and full-weekly runs coexist and neither blocks the other on the refuse-to-
+  overwrite guard.
+* Entry Point 6 — bare invocations (no ``repo``) produce the same rows / path
+  as the pre-#88 baseline.
+
+Session-rooted units are exercised separately via the
+:func:`synthesis.weekly._load_units` helper — today's ``unit_identifier``
+drops session-only components so end-to-end coverage via the CLIs is not
+reachable, but the resolver SQL must still hold.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from am_i_shipping.config_loader import SynthesisConfig
+from am_i_shipping.db import (
+    init_expectations_db,
+    init_github_db,
+    init_sessions_db,
+)
+from synthesis.expectations import run_extraction
+from synthesis.output_writer import write_retrospective
+from synthesis.summarize import run_summarization
+from synthesis.weekly import _load_units, _repo_filter_sql, run_synthesis
+
+
+WEEK = "2026-04-21"
+REPO_A = "hyang0129/am-i-shipping"
+REPO_B = "hyang0129/other"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_config(tmp_path: Path) -> SynthesisConfig:
+    return SynthesisConfig(
+        anthropic_api_key_env="ANTHROPIC_API_KEY",
+        model="claude-sonnet-4-6",
+        summary_model="claude-haiku-4-5",
+        output_dir=str(tmp_path / "retrospectives"),
+        week_start="monday",
+        abandonment_days=14,
+        outlier_sigma=2.0,
+    )
+
+
+def _seed_unit(
+    gh_db: Path,
+    *,
+    unit_id: str,
+    root_node_type: str,
+    root_node_id: str,
+    week_start: str = WEEK,
+) -> None:
+    conn = sqlite3.connect(str(gh_db))
+    try:
+        conn.execute(
+            "INSERT INTO units "
+            "(week_start, unit_id, root_node_type, root_node_id, "
+            " elapsed_days, dark_time_pct, total_reprompts, "
+            " review_cycles, status, outlier_flags, abandonment_flag) "
+            "VALUES (?, ?, ?, ?, 1.0, 0.0, 0, 0, 'closed', '[]', 0)",
+            (week_start, unit_id, root_node_type, root_node_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_unit_summary(gh_db: Path, unit_id: str, *, week_start: str = WEEK) -> None:
+    conn = sqlite3.connect(str(gh_db))
+    try:
+        conn.execute(
+            "INSERT INTO unit_summaries "
+            "(week_start, unit_id, summary_text, model, input_bytes) "
+            "VALUES (?, ?, ?, 'test', 0)",
+            (week_start, unit_id, f"summary for {unit_id}"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_session_attribution(
+    gh_db: Path,
+    *,
+    session_uuid: str,
+    repo: str,
+    issue_number: int,
+    week_start: str = WEEK,
+) -> None:
+    conn = sqlite3.connect(str(gh_db))
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO session_issue_attribution "
+            "(week_start, session_uuid, repo, issue_number, fraction, phase) "
+            "VALUES (?, ?, ?, ?, 1.0, 'execution')",
+            (week_start, session_uuid, repo, issue_number),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def two_repo_fixture(tmp_path: Path) -> dict:
+    """Seed two repos with one issue-rooted and one PR-rooted unit each."""
+    gh_db = tmp_path / "github.db"
+    sess_db = tmp_path / "sessions.db"
+    exp_db = tmp_path / "expectations.db"
+    init_github_db(gh_db)
+    init_sessions_db(sess_db)
+    init_expectations_db(exp_db)
+
+    # Repo A — two units
+    _seed_unit(
+        gh_db,
+        unit_id="u-a-issue",
+        root_node_type="issue",
+        root_node_id=f"issue:{REPO_A}#1",
+    )
+    _seed_unit(
+        gh_db,
+        unit_id="u-a-pr",
+        root_node_type="pr",
+        root_node_id=f"pr:{REPO_A}#2",
+    )
+    # Repo B — one unit, one PR-rooted
+    _seed_unit(
+        gh_db,
+        unit_id="u-b-issue",
+        root_node_type="issue",
+        root_node_id=f"issue:{REPO_B}#3",
+    )
+    _seed_unit(
+        gh_db,
+        unit_id="u-b-pr",
+        root_node_type="pr",
+        root_node_id=f"pr:{REPO_B}#4",
+    )
+
+    # Look-alike slug to guard against prefix-bleed via the trailing ``#%``.
+    _seed_unit(
+        gh_db,
+        unit_id="u-lookalike",
+        root_node_type="issue",
+        root_node_id=f"issue:{REPO_A}-sibling#99",
+    )
+
+    return {
+        "gh_db": gh_db,
+        "sess_db": sess_db,
+        "exp_db": exp_db,
+        "tmp_path": tmp_path,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests — the SQL builder
+# ---------------------------------------------------------------------------
+
+
+def test_repo_filter_sql_is_noop_without_repo() -> None:
+    fragment, params = _repo_filter_sql(None)
+    assert fragment == ""
+    assert params == []
+
+
+def test_repo_filter_sql_pins_slug_boundary() -> None:
+    _, params = _repo_filter_sql(REPO_A)
+    # Param patterns must end in ``#%`` so a sibling repo slug cannot match.
+    like_params = [p for p in params if p.startswith(("issue:", "pr:"))]
+    assert len(like_params) == 2
+    assert all(p.endswith("#%") for p in like_params)
+
+
+def test_load_units_filters_by_repo(two_repo_fixture: dict) -> None:
+    gh_conn = sqlite3.connect(str(two_repo_fixture["gh_db"]))
+    try:
+        all_units = _load_units(gh_conn, WEEK)
+        filtered = _load_units(gh_conn, WEEK, repo=REPO_A)
+    finally:
+        gh_conn.close()
+
+    all_ids = {u["unit_id"] for u in all_units}
+    filtered_ids = {u["unit_id"] for u in filtered}
+    # Every seed unit is visible without the flag.
+    assert {"u-a-issue", "u-a-pr", "u-b-issue", "u-b-pr", "u-lookalike"} <= all_ids
+    # The filter keeps only REPO_A's issue + PR and drops the look-alike.
+    assert filtered_ids == {"u-a-issue", "u-a-pr"}
+
+
+def test_load_units_filter_uses_session_attribution(two_repo_fixture: dict) -> None:
+    """Session-rooted unit reachable only via session_issue_attribution."""
+    gh_db = two_repo_fixture["gh_db"]
+    # Seed a session-rooted unit and an attribution row pointing at REPO_A.
+    _seed_unit(
+        gh_db,
+        unit_id="u-a-session",
+        root_node_type="session",
+        root_node_id="session:abc-123",
+    )
+    _seed_session_attribution(gh_db, session_uuid="abc-123", repo=REPO_A, issue_number=1)
+
+    gh_conn = sqlite3.connect(str(gh_db))
+    try:
+        filtered = _load_units(gh_conn, WEEK, repo=REPO_A)
+    finally:
+        gh_conn.close()
+
+    assert "u-a-session" in {u["unit_id"] for u in filtered}
+
+
+# ---------------------------------------------------------------------------
+# Entry Point 2 — am-summarize-units (via run_summarization)
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_respects_repo_filter(two_repo_fixture: dict) -> None:
+    cfg = _make_config(two_repo_fixture["tmp_path"])
+
+    rc = run_summarization(
+        cfg,
+        github_db=str(two_repo_fixture["gh_db"]),
+        sessions_db=str(two_repo_fixture["sess_db"]),
+        week_start=WEEK,
+        repo=REPO_A,
+    )
+    assert rc == 0
+
+    # Only REPO_A's units have summaries.
+    conn = sqlite3.connect(str(two_repo_fixture["gh_db"]))
+    try:
+        rows = conn.execute(
+            "SELECT unit_id FROM unit_summaries WHERE week_start = ?",
+            (WEEK,),
+        ).fetchall()
+    finally:
+        conn.close()
+    ids = {r[0] for r in rows}
+    assert ids == {"u-a-issue", "u-a-pr"}
+
+
+# ---------------------------------------------------------------------------
+# Entry Point 3 — am-extract-expectations (via run_extraction)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_expectations_respects_repo_filter(two_repo_fixture: dict) -> None:
+    cfg = _make_config(two_repo_fixture["tmp_path"])
+    rc = run_extraction(
+        cfg,
+        github_db=str(two_repo_fixture["gh_db"]),
+        sessions_db=str(two_repo_fixture["sess_db"]),
+        expectations_db=str(two_repo_fixture["exp_db"]),
+        week_start=WEEK,
+        repo=REPO_A,
+    )
+    # Even on skip rows the run should return 0 (no fatal failures).
+    assert rc == 0
+
+    conn = sqlite3.connect(str(two_repo_fixture["exp_db"]))
+    try:
+        rows = conn.execute(
+            "SELECT DISTINCT unit_id FROM expectations WHERE week_start = ?",
+            (WEEK,),
+        ).fetchall()
+    finally:
+        conn.close()
+    ids = {r[0] for r in rows}
+    # Only REPO_A units have expectation rows written.
+    assert ids == {"u-a-issue", "u-a-pr"}
+
+
+# ---------------------------------------------------------------------------
+# Entry Point 5 — write_retrospective repo-scoped path
+# ---------------------------------------------------------------------------
+
+
+def test_write_retrospective_repo_scoped_path(tmp_path: Path) -> None:
+    out = tmp_path / "retrospectives"
+    # Seed a pre-existing bare-week file.
+    out.mkdir()
+    (out / f"{WEEK}.md").write_text("pre-existing full-week", encoding="utf-8")
+
+    repo_path = write_retrospective("single repo", out, WEEK, repo=REPO_A)
+    assert repo_path is not None
+    expected = out / WEEK / "hyang0129__am-i-shipping.md"
+    assert repo_path == expected
+    assert expected.read_text(encoding="utf-8") == "single repo"
+    # Full-week file untouched.
+    assert (out / f"{WEEK}.md").read_text(encoding="utf-8") == "pre-existing full-week"
+
+
+def test_write_retrospective_bare_week_still_writes_after_repo(tmp_path: Path) -> None:
+    """Write the repo-scoped file first, then a bare-week run must not be blocked."""
+    out = tmp_path / "retrospectives"
+    repo_path = write_retrospective("single repo", out, WEEK, repo=REPO_A)
+    assert repo_path is not None
+
+    bare_path = write_retrospective("full week", out, WEEK)
+    assert bare_path is not None
+    assert bare_path == out / f"{WEEK}.md"
+    assert bare_path.read_text(encoding="utf-8") == "full week"
+
+
+def test_write_retrospective_refuse_repeats_repo_path(tmp_path: Path) -> None:
+    """Two single-repo runs for the same (week, repo) — second is a no-op."""
+    out = tmp_path / "retrospectives"
+    first = write_retrospective("first", out, WEEK, repo=REPO_A)
+    assert first is not None
+    second = write_retrospective("second — should not overwrite", out, WEEK, repo=REPO_A)
+    assert second is None
+    assert first.read_text(encoding="utf-8") == "first"
+
+
+# ---------------------------------------------------------------------------
+# Entry Point 1 — run_synthesis writes to the repo-scoped path
+# ---------------------------------------------------------------------------
+
+
+def test_run_synthesis_writes_repo_scoped_retrospective(
+    two_repo_fixture: dict,
+) -> None:
+    cfg = _make_config(two_repo_fixture["tmp_path"])
+    # Seed unit_summaries for every REPO_A unit so run_synthesis does not
+    # raise the missing-summary guard. Non-targeted units can remain
+    # unsummarised; the filter means run_synthesis never touches them.
+    _seed_unit_summary(two_repo_fixture["gh_db"], "u-a-issue")
+    _seed_unit_summary(two_repo_fixture["gh_db"], "u-a-pr")
+
+    result = run_synthesis(
+        cfg,
+        two_repo_fixture["gh_db"],
+        two_repo_fixture["sess_db"],
+        WEEK,
+        expectations_db=two_repo_fixture["exp_db"],
+        repo=REPO_A,
+    )
+    assert result is not None
+    # Path is the repo-scoped form.
+    assert result.parent.name == WEEK
+    assert result.name == "hyang0129__am-i-shipping.md"
+
+
+# ---------------------------------------------------------------------------
+# Entry Point 6 — no-flag byte-identity (path shape)
+# ---------------------------------------------------------------------------
+
+
+def test_run_synthesis_no_flag_writes_bare_week_path(
+    two_repo_fixture: dict,
+) -> None:
+    cfg = _make_config(two_repo_fixture["tmp_path"])
+    # Seed every unit's summary so the bare-week path succeeds without a
+    # missing-summary raise.
+    for uid in ("u-a-issue", "u-a-pr", "u-b-issue", "u-b-pr", "u-lookalike"):
+        _seed_unit_summary(two_repo_fixture["gh_db"], uid)
+
+    result = run_synthesis(
+        cfg,
+        two_repo_fixture["gh_db"],
+        two_repo_fixture["sess_db"],
+        WEEK,
+        expectations_db=two_repo_fixture["exp_db"],
+    )
+    assert result is not None
+    # Flat path (no week directory) — unchanged from pre-#88 behavior.
+    assert result.name == f"{WEEK}.md"
+    assert result.parent.name == "retrospectives"


### PR DESCRIPTION
Closes #88

## What changed

Threads an optional `--repo owner/name` flag through the three LLM CLIs
(`am-summarize-units`, `am-extract-expectations`, `am-synthesize`) and the
two internal runners that `run_synthesis` triggers (`gap_analysis.run`,
`revision_detector.run`). When set, each stage filters its unit set via a
shared `_repo_filter_sql` helper (issue:/pr: LIKE patterns plus a
session-rooted resolver against `session_issue_attribution`). The
retrospective is written to `retrospectives/<week>/<owner>__<repo>.md`
so single-repo dev-loop runs coexist with full-weekly runs without
tripping the refuse-to-overwrite guard.

`calibration.run` is left unfiltered by design — it is a global
historical aggregation (>=20 corrections across all time) whose floor
would be broken by per-repo scoping. Out of scope per the refined spec.

## Tier / approach

Tier 2 — Planner (refined spec acted as the plan) -> single-operator
implementation across 7 modules + 1 new test module -> self-review.

## Acceptance criteria

- [x] `am-synthesize --week X --repo owner/name` writes a repo-scoped
  retrospective at `retrospectives/<week>/<owner>__<repo>.md`.
- [x] `am-summarize-units --week X --repo owner/name` writes rows only
  for targeted-repo units (verified by `test_summarize_respects_repo_filter`).
- [x] `am-extract-expectations --week X --repo owner/name` writes
  `expectations` rows only for targeted-repo units
  (`test_extract_expectations_respects_repo_filter`).
- [x] Bare-week invocations produce byte-identical behaviour to the
  pre-#88 baseline (no-flag test + full suite green: 656 passed, 26 skipped).
- [x] Single-repo file and full-weekly file coexist; neither blocks the
  other (`test_write_retrospective_bare_week_still_writes_after_repo`).
- [x] Session-rooted units can be filtered via `session_issue_attribution`
  (`test_load_units_filter_uses_session_attribution`).

## Outstanding items

None.

Generated with Claude Code