### PR TITLE
refactor(#95): synth LLM adapter defaults to live, tests opt into offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ prescribe recommendations; that is a separate layer.
   and `data/sessions.db`
 - Apportions a 512 KB transcript budget across the week's sessions (see
   `synthesis/weekly.py::water_fill_truncate`)
-- Calls the Anthropic API (or an offline fake when `AMIS_SYNTHESIS_LIVE`
-  is unset) to render the retrospective
+- Calls the Anthropic API (or an offline fake when `AMIS_SYNTHESIS_OFFLINE=1`
+  is set) to render the retrospective
 - Writes `retrospectives/YYYY-MM-DD.md` atomically; refuses to overwrite
   an existing file so your hand-written answers under "Clarifying
   Questions" survive a re-run
@@ -144,7 +144,8 @@ am-synthesize --week YYYY-MM-DD --dry-run
 
 | Variable | Purpose |
 |----------|---------|
-| `AMIS_SYNTHESIS_LIVE=1` | Use the real Anthropic API instead of the offline fake client. Requires `ANTHROPIC_API_KEY` (or whichever name `config.synthesis.anthropic_api_key_env` resolves to). |
+| `AMIS_SYNTHESIS_OFFLINE=1` | Force the offline fake client instead of the real Anthropic API. Default is live. Tests opt into this via the `tests/conftest.py` autouse fixture so they never hit the network. |
+| `LLM_PROVIDER` | `claude-cli` (default) shells out to the authenticated `claude` CLI; `anthropic` calls the SDK directly and requires `ANTHROPIC_API_KEY` (or whichever name `config.synthesis.anthropic_api_key_env` resolves to). |
 | `AMIS_FORCE_SYNTHESIS=1` | Run `am-synthesize` inside `run_collectors.sh` / `.ps1` even when today is not Sunday. Useful for ad-hoc re-runs or catching up after a missed Sunday. |
 
 ### Where output goes

--- a/run_collectors.sh
+++ b/run_collectors.sh
@@ -72,7 +72,7 @@ run_collector "GitHub Poller"  -m collector.github_poller.run
 # WARNING and does NOT increment FAIL_COUNT. The overall scheduler's
 # exit code should reflect the daily collectors' health; synthesis is a
 # once-a-week add-on that may legitimately skip (missing API key,
-# AMIS_SYNTHESIS_LIVE=1 without credentials, empty DB, etc.). Only
+# live mode without credentials, empty DB, etc.). Only
 # daily-collector failures should flip the scheduler red. See F-5 in the
 # PR-48 review-fix cycle.
 if [ "$(date +%u)" = "7" ] || [ "${AMIS_FORCE_SYNTHESIS:-0}" = "1" ]; then

--- a/synthesis/cli.py
+++ b/synthesis/cli.py
@@ -18,9 +18,9 @@ Coverage diagnostic (Issue #70 — pre-synthesis health check)::
 The bare ``--week`` form is preserved verbatim so scripts and cron entries
 that predate the coverage subcommand continue to work — no breaking change.
 
-When ``AMIS_SYNTHESIS_LIVE`` is unset, weekly runs use the offline
+When ``AMIS_SYNTHESIS_OFFLINE=1`` is set, weekly runs use the offline
 :class:`synthesis.fake_client.FakeAnthropicClient` and do not require an API
-key.
+key. The default is live.
 """
 
 from __future__ import annotations

--- a/synthesis/correction.py
+++ b/synthesis/correction.py
@@ -26,7 +26,7 @@ Design priors inherited from the epic intent:
 The module is intentionally I/O-parameterised (``input_fn`` /
 ``output_fn``) so tests drive the loop without a real TTY, and the LLM
 adapter is the same ``_get_adapter`` abstraction the rest of synthesis
-uses. In offline mode (``AMIS_SYNTHESIS_LIVE`` unset) the fake client
+uses. In offline mode (``AMIS_SYNTHESIS_OFFLINE=1``) the fake client
 returns canned text that does not parse as a correction turn; the
 module treats unparseable agent output as "confirm, no change" so the
 offline smoke-test path still writes rows.

--- a/synthesis/expectations.py
+++ b/synthesis/expectations.py
@@ -38,8 +38,9 @@ Architecture notes
   the graph-walk + session-lookup helpers the rest of the synthesis
   pipeline shares.
 * Reuses :func:`synthesis.llm_adapter._get_adapter` for offline/live
-  client selection. ``AMIS_SYNTHESIS_LIVE`` unset (the default in tests)
-  routes to :class:`FakeAnthropicClient`.
+  client selection. ``AMIS_SYNTHESIS_OFFLINE=1`` (the default in tests
+  via the conftest autouse fixture) routes to
+  :class:`FakeAnthropicClient`. Production defaults to live.
 """
 
 from __future__ import annotations

--- a/synthesis/fake_client.py
+++ b/synthesis/fake_client.py
@@ -7,17 +7,17 @@ without a network call or an API key.
 Why in-tree instead of monkeypatching the real SDK
 ---------------------------------------------------
 The weekly runner picks between the live SDK and this fake based on the
-``AMIS_SYNTHESIS_LIVE`` env var. Co-locating the fake next to the
-production call site means:
+``AMIS_SYNTHESIS_OFFLINE`` env var (default live; ``=1`` opts into the
+fake). Co-locating the fake next to the production call site means:
 
 * The fake's return shape is type-compatible with
   :class:`anthropic.types.Message` at the narrow surface
-  :mod:`synthesis.weekly` consumes (``.content[0].text``) — so swapping
-  ``AMIS_SYNTHESIS_LIVE=1`` on flips to the real SDK without any
+  :mod:`synthesis.weekly` consumes (``.content[0].text``) — so unsetting
+  ``AMIS_SYNTHESIS_OFFLINE`` flips to the real SDK without any
   branching in callers beyond the client selection itself.
 * The deterministic payload is the anchor for the golden snapshot test
   in ``tests/fixtures/synthesis/expected_retrospective.md``: re-running
-  against ``AMIS_SYNTHESIS_LIVE`` unset must produce byte-identical
+  against ``AMIS_SYNTHESIS_OFFLINE=1`` must produce byte-identical
   output.
 
 The Markdown returned below conforms to the epic template:

--- a/synthesis/gap_analysis.py
+++ b/synthesis/gap_analysis.py
@@ -25,7 +25,7 @@ Behavioral invariants (from the refined spec):
 * **Auto-confirm sweep.** Gap rows with ``computed_at`` older than 14
   days and ``auto_confirmed=0`` are flipped to 1 on every run. X-4 will
   read / override this column later.
-* **Offline parity.** When ``AMIS_SYNTHESIS_LIVE`` is unset the
+* **Offline parity.** When ``AMIS_SYNTHESIS_OFFLINE=1`` is set the
   :class:`FakeAnthropicClient` path returns a deterministic canned
   JSON; severity computation is a pure function and does not require an
   API call.

--- a/synthesis/llm_adapter.py
+++ b/synthesis/llm_adapter.py
@@ -3,20 +3,21 @@
 Ported from ``video_agent_long/tools/llm_adapter.py``. Routes synthesis
 LLM calls through one of three backends selected at runtime:
 
-* **offline** (``AMIS_SYNTHESIS_LIVE`` unset / falsy) →
-  :class:`_FakeAdapter` — wraps :class:`FakeAnthropicClient`; no API
-  calls, deterministic output, no credentials required.
+* **claude-cli** (default; ``LLM_PROVIDER`` unset or ``claude-cli``) →
+  :class:`ClaudeCliAdapter` — shells out to the ``claude`` CLI via
+  ``subprocess``. Uses the authenticated session inside the running
+  Claude Code instance; does NOT require ``ANTHROPIC_API_KEY`` in the
+  subprocess environment (the key is stripped to prevent leakage).
 
-* **claude-cli** (``AMIS_SYNTHESIS_LIVE=1``, ``LLM_PROVIDER=claude-cli``,
-  the default when live) → :class:`ClaudeCliAdapter` — shells out to the
-  ``claude`` CLI via ``subprocess``. Uses the authenticated session inside
-  the running Claude Code instance; does NOT require ``ANTHROPIC_API_KEY``
-  in the subprocess environment (the key is stripped to prevent leakage).
+* **anthropic** (``LLM_PROVIDER=anthropic``) → :class:`AnthropicAdapter`
+  — calls the Anthropic SDK directly. The system prompt is wrapped in a
+  ``cache_control: ephemeral`` block so repeated weekly synthesis runs
+  pay a cache-read price on the static context.
 
-* **anthropic** (``AMIS_SYNTHESIS_LIVE=1``, ``LLM_PROVIDER=anthropic``) →
-  :class:`AnthropicAdapter` — calls the Anthropic SDK directly. The system
-  prompt is wrapped in a ``cache_control: ephemeral`` block so repeated
-  weekly synthesis runs pay a cache-read price on the static context.
+* **offline** (``AMIS_SYNTHESIS_OFFLINE=1``) → :class:`_FakeAdapter` —
+  wraps :class:`FakeAnthropicClient`; no API calls, deterministic
+  output, no credentials required. Tests opt into this; production
+  defaults to live.
 
 Call-site interface is uniform across all three backends::
 
@@ -26,8 +27,11 @@ Call-site interface is uniform across all three backends::
 
 Environment variables
 ---------------------
-``AMIS_SYNTHESIS_LIVE``
-    Any truthy string enables live mode. Unset or empty → offline.
+``AMIS_SYNTHESIS_OFFLINE``
+    Any truthy string forces the offline ``_FakeAdapter``. Unset or
+    empty → live mode (the default). Tests set this to avoid hitting
+    the network; the suite-level autouse fixture in ``tests/conftest.py``
+    sets it for every test by default.
 ``LLM_PROVIDER``
     ``claude-cli`` (default) or ``anthropic``. Only read in live mode.
 ``LINUX_CLAUDE_CLI_PATH``
@@ -350,16 +354,16 @@ class _FakeAdapter:
 
 
 def _get_adapter(config: "SynthesisConfig") -> LLMAdapter:
-    """Return the appropriate adapter based on ``AMIS_SYNTHESIS_LIVE`` and ``LLM_PROVIDER``.
+    """Return the appropriate adapter based on ``AMIS_SYNTHESIS_OFFLINE`` and ``LLM_PROVIDER``.
 
-    Offline (``AMIS_SYNTHESIS_LIVE`` unset / falsy):
+    Offline (``AMIS_SYNTHESIS_OFFLINE=1``):
         Returns :class:`_FakeAdapter` regardless of ``LLM_PROVIDER``.
 
-    Live (``AMIS_SYNTHESIS_LIVE=1``):
+    Live (``AMIS_SYNTHESIS_OFFLINE`` unset / falsy — the default):
         ``LLM_PROVIDER=claude-cli`` (default) → :class:`ClaudeCliAdapter`
         ``LLM_PROVIDER=anthropic``            → :class:`AnthropicAdapter`
     """
-    if not os.environ.get("AMIS_SYNTHESIS_LIVE"):
+    if os.environ.get("AMIS_SYNTHESIS_OFFLINE"):
         return _FakeAdapter()
 
     provider = os.environ.get("LLM_PROVIDER", "claude-cli")
@@ -371,7 +375,7 @@ def _get_adapter(config: "SynthesisConfig") -> LLMAdapter:
         api_key = os.environ.get(config.anthropic_api_key_env)
         if not api_key:
             raise RuntimeError(
-                f"AMIS_SYNTHESIS_LIVE is set but {config.anthropic_api_key_env} "
+                f"LLM_PROVIDER=anthropic but {config.anthropic_api_key_env} "
                 "is empty — cannot call the Anthropic API"
             )
         return AnthropicAdapter(api_key=api_key)

--- a/synthesis/revision_detector.py
+++ b/synthesis/revision_detector.py
@@ -26,7 +26,7 @@ Behavioral invariants (from the refined spec):
 * **Idempotent re-runs.** Upsert on ``(week_start, unit_id,
   revision_index)`` — re-running without ``--rebuild`` does not insert
   duplicates; existing ``detected_at`` is preserved on no-op re-runs.
-* **Offline parity.** With ``AMIS_SYNTHESIS_LIVE`` unset, the fake
+* **Offline parity.** With ``AMIS_SYNTHESIS_OFFLINE=1``, the fake
   adapter returns canned Markdown. The classifier coerces that into a
   low-confidence revision so the pipeline still exercises the row-write
   path end-to-end in tests.
@@ -712,7 +712,7 @@ def run(
             exp_conn.commit()
 
         # Resolve the LLM adapter once. ``_get_adapter`` accepts None for
-        # offline mode via the AMIS_SYNTHESIS_LIVE env check, but its
+        # offline mode via the AMIS_SYNTHESIS_OFFLINE env check, but its
         # signature requires a SynthesisConfig — synthesize one if the
         # caller did not provide it.
         if config is None:

--- a/synthesis/summarize.py
+++ b/synthesis/summarize.py
@@ -13,7 +13,7 @@ regenerate all of them.
 Architecture decisions
 ----------------------
 * **Offline/live client selection** mirrors :func:`synthesis.llm_adapter._get_adapter`:
-  ``AMIS_SYNTHESIS_LIVE=1`` enables the live SDK; anything else uses
+  default is the live SDK; ``AMIS_SYNTHESIS_OFFLINE=1`` opts into
   :class:`FakeAnthropicClient`.
 * **Prompt caching**: the static system prompt is sent with
   ``cache_control: ephemeral`` in live mode so repeated runs pay a

--- a/synthesis/weekly.py
+++ b/synthesis/weekly.py
@@ -4,7 +4,7 @@ Assembles the weekly retrospective prompt from the synthesis tables
 (``units`` with cross-unit flags, ``graph_nodes`` / ``graph_edges`` for
 component resolution, ``sessions.raw_content_json`` for transcripts),
 calls the Anthropic API (or the offline :class:`FakeAnthropicClient`
-stand-in when ``AMIS_SYNTHESIS_LIVE`` is unset), and hands the
+stand-in when ``AMIS_SYNTHESIS_OFFLINE=1`` is set), and hands the
 rendered Markdown to :func:`synthesis.output_writer.write_retrospective`.
 
 Architecture decisions anchored here
@@ -28,7 +28,7 @@ What lives where
 * Adapter selection is handled by :func:`synthesis.llm_adapter._get_adapter`,
   which picks between the live SDK and
   :class:`synthesis.fake_client.FakeAnthropicClient` based on
-  ``AMIS_SYNTHESIS_LIVE``.
+  ``AMIS_SYNTHESIS_OFFLINE`` (default live; ``=1`` opts into the fake).
 
 Prompt caching
 --------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,3 +19,17 @@ Manual cleanup (equivalent SQL, for reference):
     DELETE FROM graph_edges WHERE week_start = 'all';
     DELETE FROM units       WHERE week_start = 'all';
 """
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _force_offline_llm(monkeypatch: pytest.MonkeyPatch):
+    """Force the offline ``_FakeAdapter`` for every test.
+
+    Production defaults to live; tests must opt out so they never hit
+    the network or burn API credit. A test that needs live behaviour
+    can ``monkeypatch.delenv("AMIS_SYNTHESIS_OFFLINE", raising=False)``
+    inside its own body.
+    """
+    monkeypatch.setenv("AMIS_SYNTHESIS_OFFLINE", "1")

--- a/tests/test_correction.py
+++ b/tests/test_correction.py
@@ -130,7 +130,7 @@ def _seed_gap(
 
 @pytest.fixture(autouse=True)
 def _scrub_live_env(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.delenv("AMIS_SYNTHESIS_LIVE", raising=False)
+    monkeypatch.setenv("AMIS_SYNTHESIS_OFFLINE", "1")
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     yield
 

--- a/tests/test_expectations.py
+++ b/tests/test_expectations.py
@@ -164,7 +164,7 @@ def _expectation_rows(exp_db: Path, week_start: str = WEEK_START) -> list[dict]:
 
 @pytest.fixture(autouse=True)
 def _scrub_live_env(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.delenv("AMIS_SYNTHESIS_LIVE", raising=False)
+    monkeypatch.setenv("AMIS_SYNTHESIS_OFFLINE", "1")
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     yield
 

--- a/tests/test_gap_analysis.py
+++ b/tests/test_gap_analysis.py
@@ -171,7 +171,7 @@ def _seed_ideal_skill_workflow(
 
 @pytest.fixture(autouse=True)
 def _scrub_live_env(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.delenv("AMIS_SYNTHESIS_LIVE", raising=False)
+    monkeypatch.setenv("AMIS_SYNTHESIS_OFFLINE", "1")
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     yield
 

--- a/tests/test_integration_real_data.py
+++ b/tests/test_integration_real_data.py
@@ -44,8 +44,10 @@ pytestmark = pytest.mark.skipif(
 def _no_live_llm(monkeypatch):
     """Force FakeAnthropicClient unless AMIS_FORCE_LIVE=1 is set."""
     if os.environ.get("AMIS_FORCE_LIVE") != "1":
-        monkeypatch.delenv("AMIS_SYNTHESIS_LIVE", raising=False)
+        monkeypatch.setenv("AMIS_SYNTHESIS_OFFLINE", "1")
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    else:
+        monkeypatch.delenv("AMIS_SYNTHESIS_OFFLINE", raising=False)
 
 
 @pytest.fixture()

--- a/tests/test_limit_unit_id_flags.py
+++ b/tests/test_limit_unit_id_flags.py
@@ -216,7 +216,7 @@ def _revision_rows(exp_db: Path, week_start: str = WEEK_START) -> list[str]:
 
 @pytest.fixture(autouse=True)
 def _scrub_live_env(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.delenv("AMIS_SYNTHESIS_LIVE", raising=False)
+    monkeypatch.setenv("AMIS_SYNTHESIS_OFFLINE", "1")
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     yield
 

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -55,8 +55,13 @@ def _make_completed_process(stdout: str, returncode: int = 0) -> subprocess.Comp
 
 @pytest.fixture(autouse=True)
 def _scrub_live_env(monkeypatch: pytest.MonkeyPatch):
-    """Unset live-mode and provider env vars before each test."""
-    monkeypatch.delenv("AMIS_SYNTHESIS_LIVE", raising=False)
+    """Reset env so each test in this file controls its own routing.
+
+    The repo-wide ``conftest.py`` autouse fixture sets
+    ``AMIS_SYNTHESIS_OFFLINE=1`` for every test. Routing tests below
+    selectively delete it to exercise live-mode branches.
+    """
+    monkeypatch.setenv("AMIS_SYNTHESIS_OFFLINE", "1")
     monkeypatch.delenv("LLM_PROVIDER", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     yield
@@ -153,8 +158,8 @@ def test_claude_cli_adapter_raises_on_is_error():
 
 
 def test_get_adapter_offline_returns_fake(monkeypatch: pytest.MonkeyPatch):
-    """With AMIS_SYNTHESIS_LIVE unset, _get_adapter returns a _FakeAdapter."""
-    # autouse fixture already unsets AMIS_SYNTHESIS_LIVE
+    """With AMIS_SYNTHESIS_OFFLINE=1, _get_adapter returns a _FakeAdapter."""
+    # autouse fixture already sets AMIS_SYNTHESIS_OFFLINE=1
     adapter = _get_adapter(_make_cfg())
     assert isinstance(adapter, _FakeAdapter), (
         f"expected _FakeAdapter in offline mode, got {type(adapter)}"
@@ -162,10 +167,10 @@ def test_get_adapter_offline_returns_fake(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_get_adapter_live_default_is_claude_cli(monkeypatch: pytest.MonkeyPatch):
-    """With AMIS_SYNTHESIS_LIVE=1 and LLM_PROVIDER unset, returns ClaudeCliAdapter."""
+    """With AMIS_SYNTHESIS_OFFLINE unset and LLM_PROVIDER unset, returns ClaudeCliAdapter."""
     from synthesis.llm_adapter import ClaudeCliAdapter as _CCA
 
-    monkeypatch.setenv("AMIS_SYNTHESIS_LIVE", "1")
+    monkeypatch.delenv("AMIS_SYNTHESIS_OFFLINE", raising=False)
     # LLM_PROVIDER unset → default is claude-cli
 
     adapter = _get_adapter(_make_cfg())
@@ -175,10 +180,10 @@ def test_get_adapter_live_default_is_claude_cli(monkeypatch: pytest.MonkeyPatch)
 
 
 def test_get_adapter_live_anthropic_with_key(monkeypatch: pytest.MonkeyPatch):
-    """With AMIS_SYNTHESIS_LIVE=1, LLM_PROVIDER=anthropic, and the key set, returns AnthropicAdapter."""
+    """With AMIS_SYNTHESIS_OFFLINE unset, LLM_PROVIDER=anthropic, and the key set, returns AnthropicAdapter."""
     from synthesis.llm_adapter import AnthropicAdapter
 
-    monkeypatch.setenv("AMIS_SYNTHESIS_LIVE", "1")
+    monkeypatch.delenv("AMIS_SYNTHESIS_OFFLINE", raising=False)
     monkeypatch.setenv("LLM_PROVIDER", "anthropic")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-live-key")
 
@@ -189,8 +194,8 @@ def test_get_adapter_live_anthropic_with_key(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_get_adapter_live_anthropic_missing_key_raises(monkeypatch: pytest.MonkeyPatch):
-    """With AMIS_SYNTHESIS_LIVE=1, LLM_PROVIDER=anthropic, but no API key: raises RuntimeError."""
-    monkeypatch.setenv("AMIS_SYNTHESIS_LIVE", "1")
+    """With AMIS_SYNTHESIS_OFFLINE unset, LLM_PROVIDER=anthropic, but no API key: raises RuntimeError."""
+    monkeypatch.delenv("AMIS_SYNTHESIS_OFFLINE", raising=False)
     monkeypatch.setenv("LLM_PROVIDER", "anthropic")
     # ANTHROPIC_API_KEY unset (autouse fixture already strips it)
 
@@ -200,8 +205,8 @@ def test_get_adapter_live_anthropic_missing_key_raises(monkeypatch: pytest.Monke
 
 
 def test_get_adapter_unknown_provider_raises(monkeypatch: pytest.MonkeyPatch):
-    """With AMIS_SYNTHESIS_LIVE=1 and an unknown LLM_PROVIDER: raises ValueError."""
-    monkeypatch.setenv("AMIS_SYNTHESIS_LIVE", "1")
+    """With AMIS_SYNTHESIS_OFFLINE unset and an unknown LLM_PROVIDER: raises ValueError."""
+    monkeypatch.delenv("AMIS_SYNTHESIS_OFFLINE", raising=False)
     monkeypatch.setenv("LLM_PROVIDER", "unknown-provider")
 
     with pytest.raises(ValueError, match="unknown-provider"):

--- a/tests/test_revision_detection.py
+++ b/tests/test_revision_detection.py
@@ -68,7 +68,7 @@ def _make_config(**overrides) -> SynthesisConfig:
 
 @pytest.fixture(autouse=True)
 def _scrub_live_env(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.delenv("AMIS_SYNTHESIS_LIVE", raising=False)
+    monkeypatch.setenv("AMIS_SYNTHESIS_OFFLINE", "1")
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     yield
 

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -171,7 +171,7 @@ def _run(
 @pytest.fixture(autouse=True)
 def _scrub_live_env(monkeypatch: pytest.MonkeyPatch):
     """Guarantee offline mode (FakeAnthropicClient) for all tests here."""
-    monkeypatch.delenv("AMIS_SYNTHESIS_LIVE", raising=False)
+    monkeypatch.setenv("AMIS_SYNTHESIS_OFFLINE", "1")
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     yield
 

--- a/tests/test_weekly.py
+++ b/tests/test_weekly.py
@@ -160,10 +160,12 @@ def _insert_unit_summaries(
 def _scrub_live_env(monkeypatch: pytest.MonkeyPatch):
     """Guarantee offline mode across every test in this module.
 
-    Some environments may have AMIS_SYNTHESIS_LIVE or ANTHROPIC_API_KEY
-    exported. Scrub both so no test accidentally tries a real API call.
+    Some environments may export ANTHROPIC_API_KEY. The repo-wide
+    conftest fixture sets AMIS_SYNTHESIS_OFFLINE=1; this fixture
+    re-asserts it and also strips the API key so no test accidentally
+    tries a real API call.
     """
-    monkeypatch.delenv("AMIS_SYNTHESIS_LIVE", raising=False)
+    monkeypatch.setenv("AMIS_SYNTHESIS_OFFLINE", "1")
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     yield
 


### PR DESCRIPTION
Closes #95.

## Summary

- Rename `AMIS_SYNTHESIS_LIVE` → `AMIS_SYNTHESIS_OFFLINE` and invert the sense. Production defaults to the live adapter (ClaudeCliAdapter or AnthropicAdapter via `LLM_PROVIDER`).
- Add a `tests/conftest.py` autouse fixture that sets `AMIS_SYNTHESIS_OFFLINE=1` for every test so the suite never hits the network.
- Update docstrings across `synthesis/*.py`, the README env-var table, and the `run_collectors.sh` comment.

## Why

A bare `am-synthesize --week ...` or `am-summarize-units` used to silently route to `FakeAnthropicClient` unless the caller exported `AMIS_SYNTHESIS_LIVE=1`. That's backwards — production runs should produce real retros by default, and tests should be the ones opting into the fake.

## Test plan

- [ ] `pytest -q` passes locally (autouse fixture keeps every test offline).
- [ ] `grep -r AMIS_SYNTHESIS_LIVE` returns no hits in code, tests, docs, or scripts.
- [ ] Manual: bare `am-summarize-units --week 2026-04-14 --limit 1` with no env vars set calls the real LLM (verify `unit_summaries.model != 'fake'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)