### PR TITLE
fix(#104): historical rebuild — drop and rebuild unit_id-keyed tables across all past weeks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ am-github-poller = "collector.github_poller.run:main"
 am-appswitch-export = "collector.appswitch.export:main"
 am-synthesize = "synthesis.cli:main"
 am-prepare-week = "synthesis.prepare:main"
+am-rebuild-history = "synthesis.rebuild:main"
 am-summarize-units = "synthesis.summarize:main"
 am-extract-expectations = "synthesis.expectations:main"
 

--- a/synthesis/rebuild.py
+++ b/synthesis/rebuild.py
@@ -1,0 +1,403 @@
+"""``am-rebuild-history`` CLI entry point — Epic #93, Slice 3 (Issue #104).
+
+Historical rebuild: drop every unit_id-keyed and cross-week graph table,
+take a SQLite backup before doing so, then iterate every distinct
+``week_start`` and rebuild the synthesis pipeline (build_graph →
+identify_units → compute_flags) under the new directional-edge model.
+
+This complements ``am-prepare-week``, which is single-week only. Use
+this command after Slice 2 lands new edge writers — re-running the
+rebuild against existing DBs regenerates the graph (and unit_id hashes)
+under the new vocabulary.
+
+Decisions inherited from the epic intent:
+
+* Decision 3 (EXPENSIVE-TO-REVERSE) — drop and rebuild every downstream
+  table keyed by old ``unit_id``. ``expectation_corrections`` is
+  user-authored and destroyed; we surface the destroyed row count
+  loudly to honour the "not silent" requirement from the slice spec.
+* Section 7 rollback posture — atomic across weeks. If the rebuild
+  fails partway, restore both DBs from the backup taken before the
+  rebuild begins and re-raise.
+
+What this module does NOT do:
+
+* Re-run ``am-summarize-units``, ``am-extract-expectations``, or
+  ``am-synthesize correct``. Those are invoked separately; they read
+  from the rebuilt ``units`` table on demand.
+* Preserve old ``unit_id`` values via a mapping table (Anti-choice 5).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import shutil
+import sqlite3
+import sys
+from contextlib import closing
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional, Sequence
+
+from am_i_shipping.config_loader import load_config
+from am_i_shipping.db import init_expectations_db, init_github_db
+from synthesis.cross_unit import compute_flags
+from synthesis.graph_builder import build_graph
+from synthesis.unit_identifier import identify_units
+
+
+logger = logging.getLogger(__name__)
+
+
+# Tables whose every row is keyed by ``unit_id`` (or whose every row is
+# keyed by ``week_start`` and is regenerated as a side effect of the
+# rebuild). Order is the safe drop order — none of these have explicit
+# foreign keys today, but ``unit_summaries`` declares a soft FK against
+# ``units`` which we honour by dropping the dependent first.
+GITHUB_DROP_TABLES: tuple[str, ...] = (
+    "unit_summaries",
+    "units",
+    "session_issue_attribution",
+    "graph_edges",
+    "graph_nodes",
+)
+
+EXPECTATIONS_DROP_TABLES: tuple[str, ...] = (
+    # ``expectation_corrections`` first because it is the user-authored
+    # data we need to count before destruction.
+    "expectation_corrections",
+    "expectation_revisions",
+    "expectation_gaps",
+    "expectations",
+    # ``expectation_calibration_trends`` is computed from corrections;
+    # drop it too so it does not retain stale work-type rows after
+    # corrections vanish (Slice 3 spec, Open Question Q1 default = yes).
+    "expectation_calibration_trends",
+)
+
+
+# ---------------------------------------------------------------------------
+# Backup / restore
+# ---------------------------------------------------------------------------
+
+
+def _backup_db(src: Path, dst: Path) -> None:
+    """Take a consistent SQLite backup of *src* to *dst*.
+
+    Uses the SQLite online-backup API (``Connection.backup``) rather
+    than a file copy so concurrent writers (none expected during
+    rebuild, but cheap insurance) cannot leave a torn file.
+    """
+    if not src.exists():
+        # Nothing to back up — the rebuild may legitimately run against
+        # a DB that does not yet exist (init_*_db will create it).
+        return
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    src_conn = sqlite3.connect(str(src))
+    try:
+        dst_conn = sqlite3.connect(str(dst))
+        try:
+            src_conn.backup(dst_conn)
+        finally:
+            dst_conn.close()
+    finally:
+        src_conn.close()
+
+
+def _restore_db(backup: Path, target: Path) -> None:
+    """Restore *target* from *backup* by file copy.
+
+    ``Connection.backup`` would also work in reverse, but a plain copy
+    is simpler and we are guaranteed no live connections remain at
+    restore time (the rebuild has already raised).
+    """
+    if not backup.exists():
+        # No backup taken (source DB did not exist at backup time);
+        # nothing to restore. Mirror that state by removing target.
+        if target.exists():
+            target.unlink()
+        return
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(backup, target)
+
+
+# ---------------------------------------------------------------------------
+# Per-DB drop helpers
+# ---------------------------------------------------------------------------
+
+
+def _count_corrections(expectations_db: Path) -> int:
+    """Return the number of ``expectation_corrections`` rows about to die.
+
+    Returns 0 if the file does not exist or the table is missing —
+    those are valid pre-rebuild states and are not a reason to fail.
+    """
+    if not expectations_db.exists():
+        return 0
+    with closing(sqlite3.connect(str(expectations_db))) as conn:
+        try:
+            return conn.execute(
+                "SELECT COUNT(*) FROM expectation_corrections"
+            ).fetchone()[0]
+        except sqlite3.OperationalError:
+            return 0
+
+
+def _drop_tables(db_path: Path, tables: Iterable[str]) -> None:
+    """``DROP TABLE IF EXISTS`` every table in *tables*, in order."""
+    if not db_path.exists():
+        return
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        for table in tables:
+            if not table.isidentifier():
+                # Defence-in-depth — these come from a module constant
+                # today, but we never want a non-identifier reaching
+                # the f-string below.
+                raise ValueError(f"Refusing to DROP non-identifier {table!r}")
+            conn.execute(f"DROP TABLE IF EXISTS {table}")
+        conn.commit()
+
+
+def _distinct_weeks(github_db: Path) -> list[str]:
+    """Return the sorted list of distinct ``week_start`` values.
+
+    Reads from the *backup* of ``graph_nodes`` (the source of truth
+    for which weeks have ever been ingested) before the live DB has
+    its tables dropped. Caller passes the backup path.
+    """
+    if not github_db.exists():
+        return []
+    with closing(sqlite3.connect(str(github_db))) as conn:
+        try:
+            rows = conn.execute(
+                "SELECT DISTINCT week_start FROM graph_nodes "
+                "WHERE week_start IS NOT NULL "
+                "ORDER BY week_start"
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return []
+    return [r[0] for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def rebuild_history(
+    github_db: Path,
+    sessions_db: Path,
+    expectations_db: Path,
+    *,
+    abandonment_days: int,
+    outlier_sigma: float,
+    backup_dir: Optional[Path] = None,
+    weeks: Optional[Sequence[str]] = None,
+) -> dict:
+    """Drop and rebuild every unit_id-keyed table across all weeks.
+
+    Parameters
+    ----------
+    github_db, sessions_db, expectations_db:
+        Filesystem paths to the three DBs.
+    abandonment_days, outlier_sigma:
+        Forwarded to ``compute_flags`` (matches ``am-prepare-week``
+        behaviour exactly so consumers see no semantic drift in
+        ``units.outlier_flags`` / ``abandonment_flag`` between the
+        two CLIs).
+    backup_dir:
+        Where to write the pre-rebuild ``.bak`` copies. Defaults to
+        ``<github_db.parent>/_rebuild_backup_<timestamp>/``.
+    weeks:
+        Optional override — if provided, iterate exactly these weeks
+        instead of ``SELECT DISTINCT week_start FROM graph_nodes``.
+        Useful for tests and for partial rebuilds.
+
+    Returns
+    -------
+    dict
+        Summary dict with keys ``backup_dir``, ``weeks``,
+        ``corrections_destroyed``.
+
+    Raises
+    ------
+    Any exception from the rebuild stages — the caller (``main``)
+    catches and turns into a non-zero exit code.
+    """
+    if backup_dir is None:
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        backup_dir = github_db.parent / f"_rebuild_backup_{ts}"
+
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    gh_backup = backup_dir / "github.db.bak"
+    sess_backup = backup_dir / "sessions.db.bak"
+    exp_backup = backup_dir / "expectations.db.bak"
+
+    logger.info("Pre-rebuild backup -> %s", backup_dir)
+    _backup_db(github_db, gh_backup)
+    _backup_db(sessions_db, sess_backup)
+    _backup_db(expectations_db, exp_backup)
+
+    # LOUD per Decision 3: count user-authored corrections before drop.
+    corrections_destroyed = _count_corrections(expectations_db)
+    if corrections_destroyed > 0:
+        logger.warning(
+            "Dropping `expectation_corrections` (%d rows of user-authored "
+            "corrections; these are not recoverable). Decision 3 / Issue #104.",
+            corrections_destroyed,
+        )
+    else:
+        logger.info(
+            "No expectation_corrections rows to destroy (Decision 3)."
+        )
+
+    # Resolve weeks BEFORE drop — once graph_nodes is gone we cannot
+    # recover the historical week list from the live DB.
+    if weeks is None:
+        resolved_weeks = _distinct_weeks(github_db)
+    else:
+        resolved_weeks = list(weeks)
+
+    logger.info(
+        "Rebuild plan: %d week(s): %s",
+        len(resolved_weeks),
+        ", ".join(resolved_weeks) if resolved_weeks else "(none)",
+    )
+
+    try:
+        # Atomic per-DB drop. If init_*_db fails after this we restore
+        # everything from backup; the live state is otherwise empty
+        # of the dropped tables.
+        _drop_tables(github_db, GITHUB_DROP_TABLES)
+        _drop_tables(expectations_db, EXPECTATIONS_DROP_TABLES)
+
+        # Recreate the schemas (idempotent — also picks up Slice 1's
+        # ``traversal`` column migration on legacy DBs).
+        init_github_db(github_db)
+        init_expectations_db(expectations_db)
+
+        for idx, week in enumerate(resolved_weeks, start=1):
+            logger.info(
+                "[%d/%d] Rebuilding week_start=%s",
+                idx,
+                len(resolved_weeks),
+                week,
+            )
+            build_graph(sessions_db, github_db, week_start=week)
+            identify_units(
+                github_db,
+                sessions_db,
+                week,
+                abandonment_days=abandonment_days,
+            )
+            compute_flags(
+                github_db,
+                week,
+                outlier_sigma=outlier_sigma,
+                abandonment_days=abandonment_days,
+            )
+    except Exception:
+        logger.exception(
+            "Rebuild failed — restoring DBs from backup at %s", backup_dir
+        )
+        try:
+            _restore_db(gh_backup, github_db)
+            _restore_db(sess_backup, sessions_db)
+            _restore_db(exp_backup, expectations_db)
+        except Exception:  # pragma: no cover — restore failure is rare
+            logger.exception("Restore from backup ALSO failed — manual recovery required")
+        raise
+
+    return {
+        "backup_dir": backup_dir,
+        "weeks": resolved_weeks,
+        "corrections_destroyed": corrections_destroyed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="am-rebuild-history",
+        description=(
+            "Drop and rebuild every unit_id-keyed and cross-week graph "
+            "table across every distinct week_start in github.db, then "
+            "re-run the synthesis pipeline (build_graph -> identify_units "
+            "-> compute_flags) per week. Takes a SQLite backup before "
+            "beginning; restores from backup on any failure. "
+            "WARNING: destroys user-authored `expectation_corrections` rows "
+            "(Decision 3 of epic #93 — acceptable in dev)."
+        ),
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to config.yaml (default: config.yaml in repo root).",
+    )
+    parser.add_argument(
+        "--backup-dir",
+        default=None,
+        help=(
+            "Directory to write pre-rebuild .bak files into. "
+            "Default: <data_dir>/_rebuild_backup_<UTC-timestamp>/."
+        ),
+    )
+    parser.add_argument(
+        "--week",
+        action="append",
+        default=None,
+        help=(
+            "Restrict rebuild to a single week_start (repeatable). "
+            "Default: every distinct week_start in graph_nodes."
+        ),
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Entry point. Returns a shell-suitable exit code (0 / 2)."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    config = load_config(args.config)
+    data_dir: Path = config.data_path
+    github_db = data_dir / "github.db"
+    sessions_db = data_dir / "sessions.db"
+    expectations_db = data_dir / "expectations.db"
+    synthesis_cfg = config.synthesis
+    backup_dir = Path(args.backup_dir) if args.backup_dir else None
+
+    try:
+        summary = rebuild_history(
+            github_db,
+            sessions_db,
+            expectations_db,
+            abandonment_days=synthesis_cfg.abandonment_days,
+            outlier_sigma=synthesis_cfg.outlier_sigma,
+            backup_dir=backup_dir,
+            weeks=args.week,
+        )
+    except Exception:  # noqa: BLE001 — CLI is the top of the stack
+        logging.exception("am-rebuild-history failed")
+        return 2
+
+    logger.info(
+        "Rebuild complete. weeks=%d corrections_destroyed=%d backup_dir=%s",
+        len(summary["weeks"]),
+        summary["corrections_destroyed"],
+        summary["backup_dir"],
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — CLI plumbing
+    sys.exit(main())

--- a/tests/test_rebuild.py
+++ b/tests/test_rebuild.py
@@ -1,0 +1,344 @@
+"""Tests for ``synthesis/rebuild.py`` — the ``am-rebuild-history`` CLI (Issue #104).
+
+Covers Scenarios 1–4 and 6 from the slice spec:
+
+* Scenario 1 — single command iterates every distinct ``week_start``.
+* Scenario 2 — partial-failure restore from SQLite backup.
+* Scenario 3 — destroyed ``expectation_corrections`` row count is
+  surfaced loudly before the drop.
+* Scenario 4 — idempotency: re-running produces identical state.
+* Scenario 6 — schema migration is applied (legacy DBs without the
+  ``traversal`` column come out with it).
+
+The fixture mirrors ``tests/test_prepare.py`` — it reuses
+``tests/fixtures/synthesis/golden.sqlite`` for the github + sessions
+DBs and writes a synthetic ``expectations.db`` so we can verify the
+expectations-side tables are dropped and recreated.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import shutil
+import sqlite3
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from am_i_shipping.db import init_expectations_db
+from synthesis import rebuild
+
+
+FIXTURE_SRC = Path(__file__).parent / "fixtures" / "synthesis" / "golden.sqlite"
+WEEK_START = "2025-01-06"
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_config(tmp_path: Path, data_dir: Path) -> Path:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        dedent(
+            f"""
+            session:
+              projects_path: "{tmp_path}/projects"
+            github:
+              repos:
+                - "hyang0129/fixture-repo"
+            data:
+              data_dir: "{data_dir}"
+            synthesis:
+              anthropic_api_key_env: "ANTHROPIC_API_KEY"
+              model: "claude-sonnet-4-6"
+              output_dir: "{tmp_path}/retrospectives"
+              week_start: "monday"
+              abandonment_days: 14
+              outlier_sigma: 2.0
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return cfg
+
+
+def _seed_correction(expectations_db: Path, week: str = WEEK_START) -> None:
+    """Insert one expectation_corrections row so we can observe destruction."""
+    init_expectations_db(expectations_db)
+    conn = sqlite3.connect(str(expectations_db))
+    try:
+        conn.execute(
+            "INSERT INTO expectation_corrections "
+            "(week_start, unit_id, facet, original_value, corrected_value, "
+            "correction_note, corrected_by) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (week, "abc123def456", "scope", "old", "new", "note", "user"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def env(tmp_path: Path) -> dict:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    gh_db = data_dir / "github.db"
+    sess_db = data_dir / "sessions.db"
+    exp_db = data_dir / "expectations.db"
+    shutil.copy(FIXTURE_SRC, gh_db)
+    shutil.copy(FIXTURE_SRC, sess_db)
+    cfg_path = _write_config(tmp_path, data_dir)
+    return {
+        "cfg": cfg_path,
+        "data_dir": data_dir,
+        "github_db": gh_db,
+        "sessions_db": sess_db,
+        "expectations_db": exp_db,
+    }
+
+
+def _hash_table(db_path: Path, table: str) -> str:
+    """Stable hash of a table's contents for idempotency assertions."""
+    with sqlite3.connect(str(db_path)) as conn:
+        rows = conn.execute(f"SELECT * FROM {table} ORDER BY 1, 2, 3").fetchall()
+    h = hashlib.sha256()
+    for row in rows:
+        h.update(repr(row).encode("utf-8"))
+    return h.hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — single-command rebuild iterates every past week_start
+# ---------------------------------------------------------------------------
+
+
+class TestScenario1IteratesAllWeeks:
+    def test_main_rebuilds_known_week(self, env: dict) -> None:
+        rc = rebuild.main(["--config", str(env["cfg"])])
+        assert rc == 0
+        # Post-rebuild: graph_nodes and units exist for the fixture's week
+        with sqlite3.connect(str(env["github_db"])) as conn:
+            n_nodes = conn.execute(
+                "SELECT COUNT(*) FROM graph_nodes WHERE week_start = ?",
+                (WEEK_START,),
+            ).fetchone()[0]
+            n_units = conn.execute(
+                "SELECT COUNT(*) FROM units WHERE week_start = ?",
+                (WEEK_START,),
+            ).fetchone()[0]
+        assert n_nodes > 0
+        assert n_units > 0
+
+    def test_iterates_every_distinct_week(self, env: dict) -> None:
+        # Inject a second synthetic week_start into graph_nodes so the
+        # rebuild has more than one to iterate over.
+        extra_week = "2025-01-13"
+        with sqlite3.connect(str(env["github_db"])) as conn:
+            conn.execute(
+                "INSERT OR IGNORE INTO graph_nodes "
+                "(week_start, node_id, node_type, node_ref, created_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (extra_week, "synthetic-extra", "issue", "fake/repo#1", "2025-01-13T00:00:00Z"),
+            )
+            conn.commit()
+
+        summary = rebuild.rebuild_history(
+            env["github_db"],
+            env["sessions_db"],
+            env["expectations_db"],
+            abandonment_days=14,
+            outlier_sigma=2.0,
+        )
+        assert WEEK_START in summary["weeks"]
+        assert extra_week in summary["weeks"]
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — partial-failure restore
+# ---------------------------------------------------------------------------
+
+
+class TestScenario2RestoreOnFailure:
+    def test_restore_from_backup_on_pipeline_failure(
+        self, env: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Capture pre-rebuild content of every dropped table
+        pre_state = {
+            t: _hash_table(env["github_db"], t)
+            for t in ("graph_nodes", "graph_edges", "units", "unit_summaries")
+        }
+        # Pre-rebuild graph_nodes must be non-empty so a successful
+        # restore is observable (a wiped table also "matches" an empty
+        # pre-state by accident).
+        with sqlite3.connect(str(env["github_db"])) as conn:
+            assert conn.execute(
+                "SELECT COUNT(*) FROM graph_nodes"
+            ).fetchone()[0] > 0
+
+        # Force build_graph to blow up after the drop has already run
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("simulated pipeline failure")
+
+        monkeypatch.setattr(rebuild, "build_graph", boom)
+
+        with pytest.raises(RuntimeError, match="simulated pipeline failure"):
+            rebuild.rebuild_history(
+                env["github_db"],
+                env["sessions_db"],
+                env["expectations_db"],
+                abandonment_days=14,
+                outlier_sigma=2.0,
+            )
+
+        # All four dropped tables exist and contain their pre-rebuild
+        # content. SQLite's backup API is page-by-page so raw byte
+        # comparison can drift even on identical content; compare by
+        # row contents instead.
+        post_state = {
+            t: _hash_table(env["github_db"], t)
+            for t in ("graph_nodes", "graph_edges", "units", "unit_summaries")
+        }
+        assert post_state == pre_state, (
+            "github.db tables were not restored from backup after failure"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — destroyed corrections count is surfaced loudly
+# ---------------------------------------------------------------------------
+
+
+class TestScenario3DestroyedCorrectionsLoud:
+    def test_warning_logged_with_count(
+        self, env: dict, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _seed_correction(env["expectations_db"])
+        caplog.set_level(logging.WARNING, logger="synthesis.rebuild")
+
+        rc = rebuild.main(["--config", str(env["cfg"])])
+        assert rc == 0
+
+        # The warning must mention the row count and the table name and
+        # appear BEFORE the drop (we cannot enforce order via caplog
+        # easily, but its presence is the load-bearing assertion).
+        warned = [
+            r for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any(
+            "expectation_corrections" in r.getMessage()
+            and "1" in r.getMessage()
+            for r in warned
+        ), (
+            "Expected a WARNING naming `expectation_corrections` and the "
+            f"row count (1). Got: {[r.getMessage() for r in warned]}"
+        )
+
+    def test_no_corrections_logs_info_not_warning(
+        self, env: dict, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # No expectation_corrections rows -> only INFO, no WARNING.
+        caplog.set_level(logging.INFO, logger="synthesis.rebuild")
+        rc = rebuild.main(["--config", str(env["cfg"])])
+        assert rc == 0
+        warned = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "expectation_corrections" in r.getMessage()
+        ]
+        assert warned == []
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4 — idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestScenario4Idempotent:
+    def test_second_run_produces_identical_units_table(self, env: dict) -> None:
+        rc1 = rebuild.main(["--config", str(env["cfg"])])
+        assert rc1 == 0
+        h1_units = _hash_table(env["github_db"], "units")
+        h1_nodes = _hash_table(env["github_db"], "graph_nodes")
+
+        rc2 = rebuild.main(["--config", str(env["cfg"])])
+        assert rc2 == 0
+        h2_units = _hash_table(env["github_db"], "units")
+        h2_nodes = _hash_table(env["github_db"], "graph_nodes")
+
+        assert h1_units == h2_units, "units table contents diverged on re-run"
+        assert h1_nodes == h2_nodes, "graph_nodes contents diverged on re-run"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 6 — schema migration applies
+# ---------------------------------------------------------------------------
+
+
+class TestScenario6SchemaMigration:
+    def test_traversal_column_exists_after_rebuild(self, env: dict) -> None:
+        rc = rebuild.main(["--config", str(env["cfg"])])
+        assert rc == 0
+        with sqlite3.connect(str(env["github_db"])) as conn:
+            cols = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(graph_edges)").fetchall()
+            }
+        assert "traversal" in cols, (
+            "Slice 1 traversal column missing on graph_edges after rebuild"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing sanity
+# ---------------------------------------------------------------------------
+
+
+class TestCli:
+    def test_parser_accepts_optional_week(self) -> None:
+        parser = rebuild._build_parser()
+        args = parser.parse_args(["--week", "2025-01-06", "--week", "2025-01-13"])
+        assert args.week == ["2025-01-06", "2025-01-13"]
+
+    def test_parser_accepts_no_args(self) -> None:
+        parser = rebuild._build_parser()
+        args = parser.parse_args([])
+        assert args.week is None
+        assert args.config is None
+
+    def test_explicit_week_filter_only_rebuilds_listed(self, env: dict) -> None:
+        # Inject an extra week, then ask the CLI to rebuild only the
+        # original week — the extra week's nodes should disappear (the
+        # drop happened) but no rebuild ran for it.
+        extra_week = "2025-01-13"
+        with sqlite3.connect(str(env["github_db"])) as conn:
+            conn.execute(
+                "INSERT OR IGNORE INTO graph_nodes "
+                "(week_start, node_id, node_type, node_ref, created_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (extra_week, "synthetic-extra", "issue", "fake/repo#1", "2025-01-13T00:00:00Z"),
+            )
+            conn.commit()
+
+        rc = rebuild.main(
+            ["--config", str(env["cfg"]), "--week", WEEK_START]
+        )
+        assert rc == 0
+
+        with sqlite3.connect(str(env["github_db"])) as conn:
+            n_extra = conn.execute(
+                "SELECT COUNT(*) FROM graph_nodes WHERE week_start = ?",
+                (extra_week,),
+            ).fetchone()[0]
+            n_main = conn.execute(
+                "SELECT COUNT(*) FROM graph_nodes WHERE week_start = ?",
+                (WEEK_START,),
+            ).fetchone()[0]
+        assert n_extra == 0, "extra week was rebuilt despite --week filter"
+        assert n_main > 0, "filtered week was not rebuilt"


### PR DESCRIPTION
Part of epic #93 — graph construction directionality overhaul.

Closes #104

## Changes
- New `am-rebuild-history` CLI (`synthesis/rebuild.py`) registered in `pyproject.toml`
- Takes SQLite backup of `github.db`, `sessions.db`, `expectations.db` before any drop
- Drops every unit_id-keyed table (`units`, `unit_summaries`, `expectations`, `expectation_gaps`, `expectation_revisions`, `expectation_corrections`, `expectation_calibration_trends`) plus the cross-week graph tables (`graph_nodes`, `graph_edges`, `session_issue_attribution`)
- Iterates every distinct `week_start` from `graph_nodes` (resolved before drop) and re-runs `build_graph -> identify_units -> compute_flags` per week, matching `am-prepare-week` semantics
- Loudly surfaces destroyed `expectation_corrections` row count as a WARNING (Decision 3 of intent — user-authored data is not recoverable)
- On any pipeline exception, restores all three DBs from backup and re-raises

## Tests
New `tests/test_rebuild.py` covers Scenarios 1–4 and 6 from the slice spec:
- Multi-week iteration via `_distinct_weeks`
- Partial-failure restore from backup (forced exception in `build_graph`)
- WARNING-level log message naming `expectation_corrections` and the row count
- Idempotent re-run (table content hashes match across two runs)
- `traversal` column present on `graph_edges` after rebuild against a legacy DB

## Test plan
- [x] `python -m pytest tests/test_rebuild.py` — 10 passed
- [x] `python -m pytest tests/` — 740 passed, 26 skipped
- [ ] Manual verification on real `github.db` for week `2026-04-14` (Scenario 5 — recorded once Slice 2 has landed in this epic branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)