### PR TITLE
fix(#105): coverage diagnostic — per-week orphan-ratio and issue-with-session metric

### DIFF
--- a/synthesis/cli.py
+++ b/synthesis/cli.py
@@ -266,6 +266,7 @@ def _run_coverage(args: argparse.Namespace) -> int:
     config = load_config(args.config)
     data_dir: Path = config.data_path
     sessions_db = data_dir / "sessions.db"
+    github_db = data_dir / "github.db"
     projects_path = Path(config.session.projects_path)
     return run_coverage(
         sessions_db=sessions_db,
@@ -275,6 +276,9 @@ def _run_coverage(args: argparse.Namespace) -> int:
         emit_json=bool(getattr(args, "emit_json", False)),
         do_backfill=bool(getattr(args, "backfill", False)),
         full_rebuild=bool(getattr(args, "full", False)),
+        graph_mode=bool(getattr(args, "graph_mode", False)),
+        github_db=github_db,
+        week=getattr(args, "week", None),
     )
 
 

--- a/synthesis/coverage.py
+++ b/synthesis/coverage.py
@@ -350,6 +350,229 @@ class CoverageReport:
         return json.dumps(d, sort_keys=True, indent=2, ensure_ascii=False)
 
 
+# ---------------------------------------------------------------------------
+# Graph coverage diagnostic (Epic #93 — Slice 4 / Issue #105)
+# ---------------------------------------------------------------------------
+#
+# Read-only diagnostic over ``github.db``'s ``graph_nodes`` / ``graph_edges``
+# tables. Reports two ratios per ``week_start``:
+#
+#   1. ``session_reachability_ratio`` — fraction of session nodes reachable
+#      from any issue or PR root via ``traversal='own'`` edges. The filter
+#      MUST match the BFS walker filter introduced in Slice 2 — a different
+#      filter would measure a different graph than the walkers walk and is
+#      meaningless. The early-warning purpose: a future BFS walker added
+#      without the ``traversal`` filter silently re-introduces spurious
+#      merges; this diagnostic surfaces the orphan ratio creeping back up.
+#
+#   2. ``issue_linkage_ratio`` — fraction of issue nodes with at least one
+#      outgoing ``issue_has_session`` or ``issue_refs_session`` edge
+#      (``traversal='own'``). This is the linkage coverage acceptance bar
+#      from intent Section 6: ≥90% per week.
+#
+# STRONG invariant: this lives in ``synthesis/coverage.py`` and NOT in
+# ``am_i_shipping/health_check.py``. ``health_check.py`` stays staleness-only.
+
+
+_OWN_LINKAGE_EDGE_TYPES = ("issue_has_session", "issue_refs_session")
+
+
+@dataclass
+class GraphWeekRow:
+    """Per-week graph coverage row.
+
+    ``session_reachability_ratio`` and ``issue_linkage_ratio`` are ``None``
+    when the denominator is zero — the report explicitly distinguishes
+    "no data" from "0% reachability" (acceptance Scenario 6).
+    """
+
+    week_start: str
+    total_session_nodes: int = 0
+    reachable_session_nodes: int = 0
+    session_reachability_ratio: Optional[float] = None
+    total_issue_nodes: int = 0
+    issues_with_linked_session: int = 0
+    issue_linkage_ratio: Optional[float] = None
+
+
+@dataclass
+class GraphCoverageReport:
+    weeks: List[GraphWeekRow] = field(default_factory=list)
+
+    def to_json(self) -> str:
+        """Deterministic JSON serialization (weeks sorted by week_start)."""
+        d = {"weeks": [asdict(w) for w in sorted(self.weeks, key=lambda r: r.week_start)]}
+        return json.dumps(d, sort_keys=True, indent=2, ensure_ascii=False)
+
+
+def _ratio(num: int, den: int) -> Optional[float]:
+    if den <= 0:
+        return None
+    return num / den
+
+
+def collect_graph_coverage(
+    github_db: Path,
+    *,
+    week_start: Optional[str] = None,
+) -> GraphCoverageReport:
+    """Read ``github.db`` and return per-week graph coverage ratios.
+
+    Pure / read-only. No writes to any table. When ``week_start`` is set,
+    only that week is reported. When ``None``, every week appearing in
+    ``graph_nodes`` is reported (sorted ascending by ``week_start``).
+
+    Reachability is computed by a recursive CTE over ``graph_edges`` filtered
+    by ``traversal='own'``. The seed set is every issue or PR node for the
+    week. Reachable session nodes are counted by intersecting the closure
+    with ``graph_nodes`` rows of type ``session``.
+    """
+    report = GraphCoverageReport()
+    if not github_db.exists():
+        return report
+
+    conn = sqlite3.connect(str(github_db))
+    try:
+        # ---- Week list ----
+        if week_start is not None:
+            weeks = [week_start]
+        else:
+            try:
+                weeks = [
+                    row[0] for row in conn.execute(
+                        "SELECT DISTINCT week_start FROM graph_nodes "
+                        "ORDER BY week_start ASC"
+                    ).fetchall()
+                ]
+            except sqlite3.OperationalError:
+                # graph_nodes table missing — empty report.
+                return report
+
+        for wk in weeks:
+            row = _collect_week(conn, wk)
+            report.weeks.append(row)
+    finally:
+        conn.close()
+    return report
+
+
+def _collect_week(conn: sqlite3.Connection, wk: str) -> GraphWeekRow:
+    """Compute one ``GraphWeekRow`` from an open connection."""
+    # ---- Total session nodes ----
+    try:
+        total_session_nodes = conn.execute(
+            "SELECT COUNT(*) FROM graph_nodes "
+            "WHERE week_start = ? AND node_type = 'session'",
+            (wk,),
+        ).fetchone()[0]
+        total_issue_nodes = conn.execute(
+            "SELECT COUNT(*) FROM graph_nodes "
+            "WHERE week_start = ? AND node_type = 'issue'",
+            (wk,),
+        ).fetchone()[0]
+    except sqlite3.OperationalError:
+        return GraphWeekRow(week_start=wk)
+
+    # ---- Reachable session nodes ----
+    # Recursive CTE: seed = all issue/PR nodes for the week; expand along
+    # ``traversal='own'`` edges. Filter ``graph_nodes`` to the same week so
+    # multi-week DBs don't cross-pollinate. SQLite supports recursive CTEs.
+    try:
+        reachable_session_nodes = conn.execute(
+            """
+            WITH RECURSIVE
+              seed(node_id) AS (
+                SELECT node_id FROM graph_nodes
+                 WHERE week_start = ?
+                   AND node_type IN ('issue', 'pr')
+              ),
+              reach(node_id) AS (
+                SELECT node_id FROM seed
+                UNION
+                SELECT e.dst_node_id
+                  FROM graph_edges e
+                  JOIN reach r ON e.src_node_id = r.node_id
+                 WHERE e.week_start = ?
+                   AND e.traversal = 'own'
+              )
+            SELECT COUNT(*) FROM reach r
+              JOIN graph_nodes n
+                ON n.week_start = ? AND n.node_id = r.node_id
+             WHERE n.node_type = 'session'
+            """,
+            (wk, wk, wk),
+        ).fetchone()[0]
+    except sqlite3.OperationalError:
+        reachable_session_nodes = 0
+
+    # ---- Issues with at least one linked session ----
+    placeholders = ",".join("?" for _ in _OWN_LINKAGE_EDGE_TYPES)
+    try:
+        issues_with_linked_session = conn.execute(
+            f"""
+            SELECT COUNT(*) FROM (
+                SELECT DISTINCT e.src_node_id
+                  FROM graph_edges e
+                  JOIN graph_nodes n
+                    ON n.week_start = e.week_start AND n.node_id = e.src_node_id
+                 WHERE e.week_start = ?
+                   AND e.traversal = 'own'
+                   AND e.edge_type IN ({placeholders})
+                   AND n.node_type = 'issue'
+            )
+            """,
+            (wk, *_OWN_LINKAGE_EDGE_TYPES),
+        ).fetchone()[0]
+    except sqlite3.OperationalError:
+        issues_with_linked_session = 0
+
+    return GraphWeekRow(
+        week_start=wk,
+        total_session_nodes=total_session_nodes,
+        reachable_session_nodes=reachable_session_nodes,
+        session_reachability_ratio=_ratio(reachable_session_nodes, total_session_nodes),
+        total_issue_nodes=total_issue_nodes,
+        issues_with_linked_session=issues_with_linked_session,
+        issue_linkage_ratio=_ratio(issues_with_linked_session, total_issue_nodes),
+    )
+
+
+def format_graph_text(report: GraphCoverageReport) -> str:
+    """Human-readable per-week graph coverage table."""
+    lines: List[str] = []
+    title = "Graph coverage diagnostic — graph_nodes × graph_edges (traversal='own')"
+    lines.append(title)
+    lines.append("=" * len(title))
+    if not report.weeks:
+        lines.append("  (no data)")
+        return "\n".join(lines) + "\n"
+
+    header = (
+        "Per week (ratios use traversal='own' filter — matches BFS walkers)"
+    )
+    lines.append(header)
+    lines.append("-" * len(header))
+    for row in sorted(report.weeks, key=lambda r: r.week_start):
+        sr = (
+            f"{row.session_reachability_ratio:.2f}"
+            if row.session_reachability_ratio is not None
+            else "n/a"
+        )
+        il = (
+            f"{row.issue_linkage_ratio:.2f}"
+            if row.issue_linkage_ratio is not None
+            else "n/a"
+        )
+        lines.append(
+            f"  {row.week_start}: "
+            f"session_reachability={sr} "
+            f"({row.reachable_session_nodes}/{row.total_session_nodes})   "
+            f"issue_linkage={il} "
+            f"({row.issues_with_linked_session}/{row.total_issue_nodes})"
+        )
+    return "\n".join(lines) + "\n"
+
+
 def _bump(bucket: Dict[str, Dict[str, int]], key: str, fill: str) -> None:
     row = bucket.setdefault(
         key,
@@ -701,6 +924,30 @@ def backfill_full(
 # ---------------------------------------------------------------------------
 
 
+def run_graph_coverage(
+    *,
+    github_db: Path,
+    week: Optional[str] = None,
+    emit_json: bool = False,
+    stdout=None,
+    stderr=None,
+) -> int:
+    """Dispatch ``am-synthesize coverage --graph``. Read-only.
+
+    When ``week`` is ``None`` every week in ``graph_nodes`` is reported.
+    """
+    if stdout is None:
+        stdout = sys.stdout
+    if stderr is None:
+        stderr = sys.stderr
+    report = collect_graph_coverage(github_db, week_start=week)
+    if emit_json:
+        stdout.write(report.to_json() + "\n")
+    else:
+        stdout.write(format_graph_text(report))
+    return 0
+
+
 def run_coverage(
     *,
     sessions_db: Path,
@@ -710,6 +957,9 @@ def run_coverage(
     emit_json: bool = False,
     do_backfill: bool = False,
     full_rebuild: bool = False,
+    graph_mode: bool = False,
+    github_db: Optional[Path] = None,
+    week: Optional[str] = None,
     stdout=None,
     stderr=None,
 ) -> int:
@@ -729,6 +979,21 @@ def run_coverage(
         stdout = sys.stdout
     if stderr is None:
         stderr = sys.stderr
+    if graph_mode:
+        if do_backfill or full_rebuild:
+            print("--graph cannot be combined with --backfill/--full", file=stderr)
+            return 2
+        if github_db is None:
+            print("--graph requires github_db path", file=stderr)
+            return 2
+        return run_graph_coverage(
+            github_db=github_db,
+            week=week,
+            emit_json=emit_json,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
     if full_rebuild and not do_backfill:
         print("--full requires --backfill", file=stderr)
         return 2
@@ -792,6 +1057,23 @@ def add_coverage_subparser(subparsers: argparse._SubParsersAction) -> None:
             "With --backfill: re-parse every JSONL on disk and overwrite "
             "the matching DB row's columns in place (atomic per session, "
             "via ON CONFLICT DO UPDATE). Orphan rows are preserved."
+        ),
+    )
+    p.add_argument(
+        "--graph", dest="graph_mode", action="store_true",
+        help=(
+            "Graph coverage mode (Epic #93 / Issue #105). Read-only "
+            "diagnostic over github.db's graph_nodes/graph_edges tables. "
+            "Reports per-week session-reachability and issue-linkage ratios "
+            "computed under the traversal='own' filter that matches the BFS "
+            "walkers. Mutually exclusive with --backfill/--full."
+        ),
+    )
+    p.add_argument(
+        "--week", default=None,
+        help=(
+            "With --graph: restrict the report to a single week_start "
+            "(YYYY-MM-DD). Default: every week in graph_nodes."
         ),
     )
     p.add_argument(

--- a/tests/test_graph_coverage.py
+++ b/tests/test_graph_coverage.py
@@ -1,0 +1,410 @@
+"""Tests for the graph coverage diagnostic (Epic #93 — Issue #105).
+
+One test class per acceptance scenario in the child-4 spec
+(``docs/child-4-coverage-diagnostic.md``). Fixtures use direct
+``graph_nodes`` / ``graph_edges`` inserts so they don't depend on the
+graph_builder pipeline — the diagnostic must read whatever graph rows
+exist, not whatever the builder happens to produce today.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from am_i_shipping.db import init_github_db
+from synthesis.coverage import (
+    GraphCoverageReport,
+    GraphWeekRow,
+    collect_graph_coverage,
+    format_graph_text,
+    run_coverage,
+    run_graph_coverage,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _insert_node(conn: sqlite3.Connection, week: str, nid: str, ntype: str) -> None:
+    conn.execute(
+        "INSERT INTO graph_nodes (week_start, node_id, node_type, node_ref) "
+        "VALUES (?, ?, ?, ?)",
+        (week, nid, ntype, nid),
+    )
+
+
+def _insert_edge(
+    conn: sqlite3.Connection,
+    week: str,
+    src: str,
+    dst: str,
+    edge_type: str,
+    traversal: str = "own",
+) -> None:
+    conn.execute(
+        "INSERT INTO graph_edges "
+        "(week_start, src_node_id, dst_node_id, edge_type, traversal) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (week, src, dst, edge_type, traversal),
+    )
+
+
+@pytest.fixture
+def github_db(tmp_path) -> Path:
+    db = tmp_path / "github.db"
+    init_github_db(db)
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — Per-week session-reachability ratio
+# ---------------------------------------------------------------------------
+
+
+class TestSessionReachabilityRatio:
+    def test_eight_of_ten_reachable(self, github_db):
+        wk = "2026-04-14"
+        conn = sqlite3.connect(str(github_db))
+        try:
+            # 1 issue node, 10 session nodes; 8 sessions linked via
+            # issue_has_session edges.
+            _insert_node(conn, wk, "issue:owner/repo#1", "issue")
+            for i in range(10):
+                _insert_node(conn, wk, f"sess:{i}", "session")
+            for i in range(8):
+                _insert_edge(
+                    conn, wk, "issue:owner/repo#1", f"sess:{i}",
+                    "issue_has_session", "own",
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+        report = collect_graph_coverage(github_db, week_start=wk)
+        assert len(report.weeks) == 1
+        row = report.weeks[0]
+        assert row.total_session_nodes == 10
+        assert row.reachable_session_nodes == 8
+        assert row.session_reachability_ratio == pytest.approx(0.8)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — Per-week issue-with-session ratio
+# ---------------------------------------------------------------------------
+
+
+class TestIssueLinkageRatio:
+    def test_nine_of_ten_issues_linked(self, github_db):
+        wk = "2026-04-14"
+        conn = sqlite3.connect(str(github_db))
+        try:
+            for i in range(10):
+                _insert_node(conn, wk, f"issue:i{i}", "issue")
+            _insert_node(conn, wk, "sess:s0", "session")
+            # 9 of 10 issues have an outgoing issue_has_session edge.
+            for i in range(9):
+                _insert_edge(
+                    conn, wk, f"issue:i{i}", "sess:s0",
+                    "issue_has_session", "own",
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+        report = collect_graph_coverage(github_db, week_start=wk)
+        row = report.weeks[0]
+        assert row.total_issue_nodes == 10
+        assert row.issues_with_linked_session == 9
+        assert row.issue_linkage_ratio == pytest.approx(0.9)
+
+    def test_issue_refs_session_also_counts(self, github_db):
+        """Both edge types — issue_has_session AND issue_refs_session —
+        count toward issue linkage. The spec lists both explicitly."""
+        wk = "2026-04-14"
+        conn = sqlite3.connect(str(github_db))
+        try:
+            _insert_node(conn, wk, "issue:a", "issue")
+            _insert_node(conn, wk, "issue:b", "issue")
+            _insert_node(conn, wk, "sess:s0", "session")
+            _insert_edge(
+                conn, wk, "issue:a", "sess:s0",
+                "issue_has_session", "own",
+            )
+            _insert_edge(
+                conn, wk, "issue:b", "sess:s0",
+                "issue_refs_session", "own",
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        row = collect_graph_coverage(github_db, week_start=wk).weeks[0]
+        assert row.issues_with_linked_session == 2
+        assert row.issue_linkage_ratio == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — All weeks reported in one invocation
+# ---------------------------------------------------------------------------
+
+
+class TestMultiWeek:
+    def test_all_weeks_reported(self, github_db):
+        weeks = ["2026-03-31", "2026-04-07", "2026-04-14", "2026-04-21"]
+        conn = sqlite3.connect(str(github_db))
+        try:
+            for wk in weeks:
+                _insert_node(conn, wk, f"issue:{wk}", "issue")
+                _insert_node(conn, wk, f"sess:{wk}", "session")
+                _insert_edge(
+                    conn, wk, f"issue:{wk}", f"sess:{wk}",
+                    "issue_has_session", "own",
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+        report = collect_graph_coverage(github_db)  # no week filter
+        reported = [r.week_start for r in report.weeks]
+        assert reported == weeks  # ascending order
+        for r in report.weeks:
+            assert r.session_reachability_ratio == pytest.approx(1.0)
+            assert r.issue_linkage_ratio == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4 — Filter consistency with BFS walkers (traversal='own' only)
+# ---------------------------------------------------------------------------
+
+
+class TestTraversalFilter:
+    def test_ref_edge_does_not_count_as_reachable(self, github_db):
+        """A session reachable only via a 'ref' edge must NOT be counted
+        as reachable — the diagnostic must agree with the BFS walkers."""
+        wk = "2026-04-14"
+        conn = sqlite3.connect(str(github_db))
+        try:
+            _insert_node(conn, wk, "issue:i1", "issue")
+            _insert_node(conn, wk, "commit:c1", "commit")
+            _insert_node(conn, wk, "sess:s_own", "session")
+            _insert_node(conn, wk, "sess:s_ref", "session")
+            # Reachable: issue -> sess_own via 'own'.
+            _insert_edge(
+                conn, wk, "issue:i1", "sess:s_own",
+                "issue_has_session", "own",
+            )
+            # NOT reachable for our purposes: commit -> issue via 'ref'
+            # edge; even if we seeded from commit it shouldn't matter
+            # because we seed from issue/PR only and 'ref' is filtered out.
+            _insert_edge(
+                conn, wk, "commit:c1", "issue:i1",
+                "commit_refs_issue", "ref",
+            )
+            # And: a session connected via a ref edge from an issue.
+            _insert_edge(
+                conn, wk, "issue:i1", "sess:s_ref",
+                "issue_refs_session", "ref",
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        row = collect_graph_coverage(github_db, week_start=wk).weeks[0]
+        assert row.total_session_nodes == 2
+        assert row.reachable_session_nodes == 1  # only s_own
+        assert row.session_reachability_ratio == pytest.approx(0.5)
+
+    def test_ref_edge_does_not_count_for_issue_linkage(self, github_db):
+        """An issue whose only outgoing edge is traversal='ref' must NOT
+        be counted as having a linked session."""
+        wk = "2026-04-14"
+        conn = sqlite3.connect(str(github_db))
+        try:
+            _insert_node(conn, wk, "issue:i1", "issue")
+            _insert_node(conn, wk, "sess:s0", "session")
+            _insert_edge(
+                conn, wk, "issue:i1", "sess:s0",
+                "issue_refs_session", "ref",
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        row = collect_graph_coverage(github_db, week_start=wk).weeks[0]
+        assert row.total_issue_nodes == 1
+        assert row.issues_with_linked_session == 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario 5 — CLI integration
+# ---------------------------------------------------------------------------
+
+
+class TestCliIntegration:
+    def test_text_output_contains_ratios_and_labels(self, github_db, capsys):
+        wk = "2026-04-14"
+        conn = sqlite3.connect(str(github_db))
+        try:
+            _insert_node(conn, wk, "issue:i1", "issue")
+            _insert_node(conn, wk, "sess:s1", "session")
+            _insert_edge(
+                conn, wk, "issue:i1", "sess:s1",
+                "issue_has_session", "own",
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        rc = run_graph_coverage(github_db=github_db, week=wk)
+        assert rc == 0
+        out = capsys.readouterr().out
+        # 2-decimal ratio and clear labels.
+        assert "session_reachability=1.00" in out
+        assert "issue_linkage=1.00" in out
+        assert wk in out
+
+    def test_json_mode_structure(self, github_db, capsys):
+        wk = "2026-04-14"
+        conn = sqlite3.connect(str(github_db))
+        try:
+            _insert_node(conn, wk, "issue:i1", "issue")
+            _insert_node(conn, wk, "sess:s1", "session")
+            _insert_edge(
+                conn, wk, "issue:i1", "sess:s1",
+                "issue_has_session", "own",
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        rc = run_graph_coverage(github_db=github_db, week=wk, emit_json=True)
+        assert rc == 0
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert "weeks" in parsed
+        assert len(parsed["weeks"]) == 1
+        row = parsed["weeks"][0]
+        assert row["week_start"] == wk
+        assert row["total_session_nodes"] == 1
+        assert row["reachable_session_nodes"] == 1
+        assert row["session_reachability_ratio"] == pytest.approx(1.0)
+        assert row["total_issue_nodes"] == 1
+        assert row["issues_with_linked_session"] == 1
+        assert row["issue_linkage_ratio"] == pytest.approx(1.0)
+
+    def test_run_coverage_dispatches_graph_mode(self, github_db, tmp_path, capsys):
+        """run_coverage(graph_mode=True, ...) routes to run_graph_coverage."""
+        wk = "2026-04-14"
+        conn = sqlite3.connect(str(github_db))
+        try:
+            _insert_node(conn, wk, "issue:i1", "issue")
+            conn.commit()
+        finally:
+            conn.close()
+
+        rc = run_coverage(
+            sessions_db=tmp_path / "sessions.db",
+            projects_path=tmp_path / "projects",
+            week_start="monday",
+            data_dir=tmp_path,
+            graph_mode=True,
+            github_db=github_db,
+            week=wk,
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Graph coverage diagnostic" in out
+
+    def test_graph_with_backfill_is_rejected(self, github_db, tmp_path, capsys):
+        rc = run_coverage(
+            sessions_db=tmp_path / "sessions.db",
+            projects_path=tmp_path / "projects",
+            week_start="monday",
+            data_dir=tmp_path,
+            graph_mode=True,
+            do_backfill=True,
+            github_db=github_db,
+        )
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "--graph" in err
+
+
+# ---------------------------------------------------------------------------
+# Scenario 6 — Behaves correctly on empty input
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyInput:
+    def test_empty_db_no_exception(self, github_db):
+        # Fresh init_github_db: tables exist, no rows.
+        report = collect_graph_coverage(github_db)
+        assert report.weeks == []
+
+    def test_missing_db_no_exception(self, tmp_path):
+        report = collect_graph_coverage(tmp_path / "does-not-exist.db")
+        assert report.weeks == []
+
+    def test_zero_denominator_ratio_is_none(self, github_db):
+        """A week with no session and no issue nodes must report ratios as
+        ``None`` (not 0.0). The output must distinguish 'no data' from
+        '0% reachability'."""
+        wk = "2026-04-14"
+        conn = sqlite3.connect(str(github_db))
+        try:
+            # Insert a single PR node so the week appears, but no sessions
+            # and no issues.
+            _insert_node(conn, wk, "pr:p1", "pr")
+            conn.commit()
+        finally:
+            conn.close()
+
+        row = collect_graph_coverage(github_db, week_start=wk).weeks[0]
+        assert row.total_session_nodes == 0
+        assert row.session_reachability_ratio is None
+        assert row.total_issue_nodes == 0
+        assert row.issue_linkage_ratio is None
+
+    def test_format_text_no_data(self):
+        text = format_graph_text(GraphCoverageReport(weeks=[]))
+        assert "(no data)" in text
+
+    def test_format_text_renders_na_for_none(self):
+        report = GraphCoverageReport(weeks=[
+            GraphWeekRow(week_start="2026-04-14"),
+        ])
+        text = format_graph_text(report)
+        assert "n/a" in text
+
+
+# ---------------------------------------------------------------------------
+# Reachability through PR nodes (multi-hop)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiHopReachability:
+    def test_pr_to_session_reachable(self, github_db):
+        """PR nodes are also valid roots — pr_has_session edges (own)
+        contribute to the reachable set."""
+        wk = "2026-04-14"
+        conn = sqlite3.connect(str(github_db))
+        try:
+            _insert_node(conn, wk, "pr:p1", "pr")
+            _insert_node(conn, wk, "sess:s1", "session")
+            _insert_edge(
+                conn, wk, "pr:p1", "sess:s1",
+                "pr_has_session", "own",
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        row = collect_graph_coverage(github_db, week_start=wk).weeks[0]
+        assert row.reachable_session_nodes == 1
+        assert row.session_reachability_ratio == pytest.approx(1.0)


### PR DESCRIPTION
Part of epic #93 — graph construction directionality overhaul.

Closes #105

## Changes
- Add `synthesis/coverage.py` graph coverage functions: `GraphWeekRow`, `GraphCoverageReport`, `collect_graph_coverage()`, `format_graph_text()`, `run_graph_coverage()`
- Add `am-synthesize coverage --graph` flag (extends existing subcommand; no new top-level entry)
- Read-only diagnostic: no writes to any table
- `health_check.py` untouched (staleness-only invariant preserved)
- 16 new tests in `tests/test_graph_coverage.py` covering all 6 acceptance scenarios

## Metrics reported per week
1. **session_reachability_ratio** — % of session nodes reachable from any issue/PR root via `traversal='own'` edges (matches BFS walker filter from Slice 2)
2. **issue_linkage_ratio** — % of issue nodes with at least one outgoing `issue_has_session` or `issue_refs_session` edge (`traversal='own'`)

## Acceptance criteria
- ≥90% on both ratios for rebuilt week `2026-04-14` (verifiable after Slice 3 rebuild)
- `traversal='ref'` edges are excluded — filter matches BFS walkers exactly
- Zero-denominator weeks report `null` (not 0.0) — distinguishes "no data" from "0% reachability"