### PR TITLE
fix(#111): collector ignores pr-link JSONL events, leaving sessions unlinked to PRs

### DIFF
--- a/collector/session_parser.py
+++ b/collector/session_parser.py
@@ -225,6 +225,42 @@ def _strip_content_blocks(content: Any) -> Any:
     return content
 
 
+def _extract_pr_link_event(entry: dict) -> "dict | None":
+    """Extract a gh_event dict from a top-level ``pr-link`` JSONL entry.
+
+    ``pr-link`` entries are emitted by Claude Code when a session is explicitly
+    linked to a PR.  They carry authoritative linkage — strictly more reliable
+    than the head_ref/git_branch/working-directory heuristic in
+    ``session_linker.py``.
+
+    Expected shape::
+
+        {
+            "type": "pr-link",
+            "sessionId": "...",
+            "timestamp": "2026-...",
+            "prNumber": 130,
+            "prRepository": "owner/repo",
+            "prUrl": "https://github.com/owner/repo/pull/130",
+        }
+
+    Returns a gh_event dict with ``event_type='pr_link'``, or ``None`` if the
+    entry is missing required fields (``prNumber`` or ``prRepository``).
+    """
+    pr_number = entry.get("prNumber")
+    pr_repository = entry.get("prRepository")
+    if pr_number is None or not pr_repository:
+        return None
+    return {
+        "event_type": "pr_link",
+        "repo": str(pr_repository),
+        "ref": str(pr_number),
+        "url": entry.get("prUrl", ""),
+        "confidence": "high",
+        "created_at": entry.get("timestamp", ""),
+    }
+
+
 def _extract_gh_events(entry: dict, pending_creates: dict) -> list:
     """Extract GitHub/git CLI events from a single JSONL entry.
 
@@ -567,6 +603,17 @@ def parse_session(filepath: str | Path, threshold: int = 3) -> SessionRecord:
                         timestamps.append(ts)
                     except ValueError:
                         pass
+
+                # Handle pr-link entries (top-level, not user/assistant messages).
+                # These carry authoritative PR linkage emitted by Claude Code when a
+                # session is explicitly linked to a PR. Shape:
+                # {"type": "pr-link", "sessionId": "...", "timestamp": "...",
+                #  "prNumber": N, "prRepository": "owner/repo", "prUrl": "https://..."}
+                if entry_type == "pr-link":
+                    pr_link_ev = _extract_pr_link_event(entry)
+                    if pr_link_ev is not None:
+                        gh_events_list.append(pr_link_ev)
+                    continue
 
                 # Only process user/assistant message entries
                 if entry_type not in ("user", "assistant"):

--- a/collector/store.py
+++ b/collector/store.py
@@ -149,6 +149,23 @@ def upsert_session(
                         ev.get("created_at"),
                     ),
                 )
+                # Issue #111: for pr-link events, also write the graph-linkage row
+                # directly into pr_sessions.  The INSERT OR IGNORE on the PK
+                # (repo, pr_number, session_uuid) provides idempotency — repeated
+                # pr-link entries in the same JSONL (observed up to 3×) collapse to
+                # one row after the deduplication in parse_session, but even if
+                # called multiple times the write is safe.
+                if ev["event_type"] == "pr_link":
+                    gh_conn.execute(
+                        "INSERT OR IGNORE INTO pr_sessions "
+                        "(repo, pr_number, session_uuid) "
+                        "VALUES (?, ?, ?)",
+                        (
+                            ev["repo"],
+                            int(ev["ref"]),
+                            record.session_uuid,
+                        ),
+                    )
             # Issue #86: skill invocations. Use INSERT OR REPLACE so re-parsing
             # an already-ingested session overwrites rather than leaves stale
             # target_repo/target_ref in place.

--- a/synthesis/rebuild.py
+++ b/synthesis/rebuild.py
@@ -61,6 +61,13 @@ GITHUB_DROP_TABLES: tuple[str, ...] = (
     "session_issue_attribution",
     "graph_edges",
     "graph_nodes",
+    # Issue #111: session-keyed linkage tables must be rebuilt when the
+    # session parser gains new event-type support (e.g. pr-link).  Dropping
+    # them here causes the backfill_full call (below) to re-populate them
+    # from the JSONLs on disk, recovering any previously-missing pr_sessions
+    # rows without requiring a separate migration step.
+    "session_gh_events",
+    "pr_sessions",
 )
 
 EXPECTATIONS_DROP_TABLES: tuple[str, ...] = (
@@ -190,6 +197,7 @@ def rebuild_history(
     sessions_db: Path,
     expectations_db: Path,
     *,
+    projects_path: Optional[Path] = None,
     abandonment_days: int,
     outlier_sigma: float,
     backup_dir: Optional[Path] = None,
@@ -201,6 +209,14 @@ def rebuild_history(
     ----------
     github_db, sessions_db, expectations_db:
         Filesystem paths to the three DBs.
+    projects_path:
+        Root directory of Claude Code session JSONLs (same as
+        ``config.session.projects_path``).  When provided, ``backfill_full``
+        is called before ``build_graph`` so that newly-supported JSONL event
+        types (e.g. ``pr-link``) are re-parsed from every session on disk
+        and the freshly-dropped ``session_gh_events`` / ``pr_sessions``
+        tables are repopulated.  If ``None``, the backfill step is skipped
+        (the existing ``sessions.db`` rows drive the rebuild as before).
     abandonment_days, outlier_sigma:
         Forwarded to ``compute_flags`` (matches ``am-prepare-week``
         behaviour exactly so consumers see no semantic drift in
@@ -276,6 +292,31 @@ def rebuild_history(
         # ``traversal`` column migration on legacy DBs).
         init_github_db(github_db)
         init_expectations_db(expectations_db)
+
+        # Issue #111: re-parse all sessions so newly-supported event types
+        # (pr-link) populate the freshly-dropped session_gh_events /
+        # pr_sessions tables.  backfill_full is atomic per-session (upsert
+        # semantics) and has no max_files_per_run cap — preferred over
+        # delete-sessions + run_batch (ADR Decision 1).
+        if projects_path is not None:
+            from synthesis.coverage import backfill_full  # avoid circular at module level
+
+            logger.info(
+                "Issue #111 backfill: re-parsing all sessions via backfill_full "
+                "(projects_path=%s)",
+                projects_path,
+            )
+            bf_summary = backfill_full(
+                sessions_db,
+                projects_path,
+                data_dir=github_db.parent,
+            )
+            logger.info(
+                "backfill_full complete: reingested=%d errored=%d orphans_preserved=%d",
+                bf_summary.reingested,
+                bf_summary.errored,
+                bf_summary.orphans_preserved,
+            )
 
         for idx, week in enumerate(resolved_weeks, start=1):
             logger.info(
@@ -381,6 +422,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             github_db,
             sessions_db,
             expectations_db,
+            projects_path=Path(config.session.projects_path),
             abandonment_days=synthesis_cfg.abandonment_days,
             outlier_sigma=synthesis_cfg.outlier_sigma,
             backup_dir=backup_dir,

--- a/tests/fixtures/pr_link_session.jsonl
+++ b/tests/fixtures/pr_link_session.jsonl
@@ -1,0 +1,6 @@
+{"type":"ai-title","sessionId":"test-pr-link-uuid","timestamp":"2026-01-10T10:00:00Z","title":"Test PR-link session"}
+{"type":"pr-link","sessionId":"test-pr-link-uuid","timestamp":"2026-01-10T10:00:01Z","prNumber":130,"prRepository":"hyang0129/am-i-shipping","prUrl":"https://github.com/hyang0129/am-i-shipping/pull/130"}
+{"type":"pr-link","sessionId":"test-pr-link-uuid","timestamp":"2026-01-10T10:00:02Z","prNumber":130,"prRepository":"hyang0129/am-i-shipping","prUrl":"https://github.com/hyang0129/am-i-shipping/pull/130"}
+{"type":"pr-link","sessionId":"test-pr-link-uuid","timestamp":"2026-01-10T10:00:03Z","prNumber":130,"prRepository":"hyang0129/am-i-shipping","prUrl":"https://github.com/hyang0129/am-i-shipping/pull/130"}
+{"type":"user","sessionId":"test-pr-link-uuid","timestamp":"2026-01-10T10:01:00Z","message":{"role":"user","content":"Fix the bug in session_parser.py"}}
+{"type":"assistant","sessionId":"test-pr-link-uuid","timestamp":"2026-01-10T10:02:00Z","message":{"role":"assistant","content":"I'll fix the bug now.","usage":{"input_tokens":100,"output_tokens":50}}}

--- a/tests/test_component_backfill_pr_link.py
+++ b/tests/test_component_backfill_pr_link.py
@@ -1,0 +1,230 @@
+"""Component tests: synthesis.coverage.backfill_full → collector.session_parser.parse_session
+→ collector.store.upsert_session → pr_sessions in github.db.
+
+Boundary: the pr_link ingestion path through the full backfill pipeline.
+
+When ``backfill_full`` re-ingests a JSONL containing ``pr-link`` entries the
+wiring must produce a row in ``github.db::pr_sessions``.  No earlier test
+exercises all three modules cooperating across this exact path:
+
+  1. ``synthesis.coverage.backfill_full`` discovers the JSONL and calls
+     ``parse_session`` on it.
+  2. ``parse_session`` extracts the ``pr_link`` gh_event via
+     ``_extract_pr_link_event`` and returns a ``SessionRecord``.
+  3. ``upsert_session`` writes the ``pr_sessions`` row alongside the
+     ``session_gh_events`` audit row.
+
+These are two or more real modules cooperating across one named boundary with
+only the filesystem and SQLite as infrastructure — no mocks of any module
+under test.  The tests use the canonical ``pr_link_session.jsonl`` fixture
+committed with the PR.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from am_i_shipping.db import init_github_db, init_sessions_db
+from synthesis.coverage import backfill_full
+
+FIXTURES = Path(__file__).parent / "fixtures"
+PR_LINK_FIXTURE = FIXTURES / "pr_link_session.jsonl"
+
+
+def _projects_dir_with_pr_link(tmp_path: Path) -> Path:
+    """Create a minimal projects_path that contains the pr-link fixture JSONL.
+
+    ``backfill_full`` uses ``_build_uuid_index`` which rglob-s for ``*.jsonl``
+    files under ``projects_path`` (skipping ``subagents/`` subdirectories).
+    We mirror the real layout: one project directory containing the JSONL.
+    """
+    project_dir = tmp_path / "projects" / "test-project"
+    project_dir.mkdir(parents=True)
+    dest = project_dir / "test-pr-link-uuid.jsonl"
+    shutil.copy(PR_LINK_FIXTURE, dest)
+    return tmp_path / "projects"
+
+
+def _seed_empty_sessions_row(db_path: Path, session_uuid: str) -> None:
+    """Insert a sessions row with NULL raw_content_json to simulate an
+    un-backfilled row that backfill_full should overwrite.
+
+    ``backfill_full`` re-ingests *every* JSONL in projects_path, not just
+    those with NULL raw_content_json, so the seed row is not strictly
+    required — but it makes the test more realistic and the assertion about
+    the sessions table more meaningful.
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO sessions (
+                session_uuid, turn_count, tool_call_count,
+                tool_failure_count, reprompt_count, bail_out,
+                session_duration_seconds, working_directory,
+                git_branch, raw_content_json
+            ) VALUES (?, 0, 0, 0, 0, 0, 0.0, NULL, NULL, NULL)
+            """,
+            (session_uuid,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestBackfillFullPopulatesPrSessions:
+    """backfill_full → parse_session → upsert_session → pr_sessions contract."""
+
+    SESSION_UUID = "test-pr-link-uuid"
+
+    def test_pr_sessions_row_present_after_backfill(self, tmp_path: Path) -> None:
+        """[Arrange] Empty databases + JSONL with pr-link entries on disk.
+        [Act] Call backfill_full.
+        [Assert] pr_sessions contains exactly 1 row for the session with the
+        correct repo and pr_number.
+        """
+        sess_db = tmp_path / "sessions.db"
+        gh_db = tmp_path / "github.db"
+        init_sessions_db(sess_db)
+        init_github_db(gh_db)
+        _seed_empty_sessions_row(sess_db, self.SESSION_UUID)
+        projects_path = _projects_dir_with_pr_link(tmp_path)
+
+        # [Act]
+        summary = backfill_full(sess_db, projects_path, data_dir=tmp_path)
+
+        # [Assert]
+        assert summary.reingested >= 1, (
+            f"backfill_full must report at least 1 reingested session, got {summary.reingested}"
+        )
+
+        conn = sqlite3.connect(str(gh_db))
+        try:
+            rows = conn.execute(
+                "SELECT repo, pr_number, session_uuid FROM pr_sessions "
+                "WHERE session_uuid = ?",
+                (self.SESSION_UUID,),
+            ).fetchall()
+        finally:
+            conn.close()
+
+        assert len(rows) == 1, (
+            f"Expected exactly 1 pr_sessions row after backfill_full, got {len(rows)}: {rows}"
+        )
+        repo, pr_number, session_uuid = rows[0]
+        assert repo == "hyang0129/am-i-shipping"
+        assert pr_number == 130
+        assert session_uuid == self.SESSION_UUID
+
+    def test_pr_sessions_idempotent_across_two_backfills(self, tmp_path: Path) -> None:
+        """Running backfill_full twice must not duplicate pr_sessions rows.
+
+        ``upsert_session``'s ``INSERT OR IGNORE INTO pr_sessions`` clause
+        guarantees idempotency at the store level; this test verifies the
+        contract survives the full pipeline invocation.
+        """
+        sess_db = tmp_path / "sessions.db"
+        gh_db = tmp_path / "github.db"
+        init_sessions_db(sess_db)
+        init_github_db(gh_db)
+        projects_path = _projects_dir_with_pr_link(tmp_path)
+
+        # [Act] — two consecutive full backfills
+        backfill_full(sess_db, projects_path, data_dir=tmp_path)
+        backfill_full(sess_db, projects_path, data_dir=tmp_path)
+
+        # [Assert]
+        conn = sqlite3.connect(str(gh_db))
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM pr_sessions WHERE session_uuid = ?",
+                (self.SESSION_UUID,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+        assert count == 1, (
+            f"Expected exactly 1 pr_sessions row after two backfills, got {count} "
+            "(upsert_session INSERT OR IGNORE idempotency failed across the pipeline)"
+        )
+
+    def test_session_gh_events_audit_row_present_after_backfill(self, tmp_path: Path) -> None:
+        """backfill_full must also write the session_gh_events audit row for the pr_link event.
+
+        pr_sessions captures graph-linkage; session_gh_events captures the audit
+        trail.  Both must be written; this test verifies the audit boundary.
+        """
+        sess_db = tmp_path / "sessions.db"
+        gh_db = tmp_path / "github.db"
+        init_sessions_db(sess_db)
+        init_github_db(gh_db)
+        projects_path = _projects_dir_with_pr_link(tmp_path)
+
+        # [Act]
+        backfill_full(sess_db, projects_path, data_dir=tmp_path)
+
+        # [Assert]
+        conn = sqlite3.connect(str(gh_db))
+        try:
+            rows = conn.execute(
+                "SELECT event_type, repo, ref FROM session_gh_events "
+                "WHERE session_uuid = ? AND event_type = 'pr_link'",
+                (self.SESSION_UUID,),
+            ).fetchall()
+        finally:
+            conn.close()
+
+        assert len(rows) == 1, (
+            f"Expected 1 session_gh_events row with event_type='pr_link', got {len(rows)}: {rows}"
+        )
+        event_type, repo, ref = rows[0]
+        assert event_type == "pr_link"
+        assert repo == "hyang0129/am-i-shipping"
+        assert ref == "130"
+
+    def test_three_repeated_pr_links_produce_single_pr_sessions_row(
+        self, tmp_path: Path
+    ) -> None:
+        """The pr_link_session.jsonl fixture has 3 identical pr-link entries.
+
+        After deduplication in parse_session and INSERT OR IGNORE in
+        upsert_session, exactly 1 pr_sessions row must appear.  This verifies
+        that the dedup contract in parse_session carries through the pipeline.
+        """
+        sess_db = tmp_path / "sessions.db"
+        gh_db = tmp_path / "github.db"
+        init_sessions_db(sess_db)
+        init_github_db(gh_db)
+        projects_path = _projects_dir_with_pr_link(tmp_path)
+
+        # [Act]
+        backfill_full(sess_db, projects_path, data_dir=tmp_path)
+
+        # [Assert] — pr_sessions must have exactly 1 row
+        conn = sqlite3.connect(str(gh_db))
+        try:
+            pr_count = conn.execute(
+                "SELECT COUNT(*) FROM pr_sessions WHERE session_uuid = ?",
+                (self.SESSION_UUID,),
+            ).fetchone()[0]
+            # Also verify the session_gh_events side: dedup in parse_session collapses
+            # the 3 repeated pr_link entries to 1 gh_event before upsert_session.
+            gh_event_count = conn.execute(
+                "SELECT COUNT(*) FROM session_gh_events "
+                "WHERE session_uuid = ? AND event_type = 'pr_link'",
+                (self.SESSION_UUID,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+        assert pr_count == 1, (
+            f"Expected 1 pr_sessions row for 3 repeated pr_link entries in JSONL, got {pr_count}"
+        )
+        assert gh_event_count == 1, (
+            f"Expected 1 session_gh_events pr_link row (deduped), got {gh_event_count}"
+        )

--- a/tests/test_rebuild.py
+++ b/tests/test_rebuild.py
@@ -342,3 +342,91 @@ class TestCli:
             ).fetchone()[0]
         assert n_extra == 0, "extra week was rebuilt despite --week filter"
         assert n_main > 0, "filtered week was not rebuilt"
+
+
+# ---------------------------------------------------------------------------
+# Issue #111 — backfill regression: rebuild re-parses sessions for pr-link
+# ---------------------------------------------------------------------------
+
+PR_LINK_FIXTURE = Path(__file__).parent / "fixtures" / "pr_link_session.jsonl"
+
+
+class TestRebuildPrLinkBackfill:
+    """Verify that rebuild_history calls backfill_full and populates pr_sessions.
+
+    Uses a real JSONL fixture containing pr-link entries.  The test seeds
+    sessions.db and github.db from the golden SQLite fixture (which has no
+    pr_sessions rows for the test session), then runs rebuild_history with
+    projects_path pointing at a temp directory containing the pr-link JSONL.
+    After rebuild, pr_sessions must contain the expected row.
+    """
+
+    def _setup_projects_dir(self, tmp_path: Path) -> Path:
+        """Create a minimal projects_path structure with the pr-link fixture."""
+        # backfill_full uses _build_uuid_index which walks projects_path for
+        # <sessionId>/<sessionId>.jsonl or similar patterns.  Mirror the
+        # directory structure that Claude Code uses: each project is a dir,
+        # each session is a JSONL file named <uuid>.jsonl.
+        session_uuid = "test-pr-link-uuid"
+        project_dir = tmp_path / "projects" / "test-project"
+        project_dir.mkdir(parents=True)
+        dest = project_dir / f"{session_uuid}.jsonl"
+        shutil.copy(PR_LINK_FIXTURE, dest)
+        return tmp_path / "projects"
+
+    def test_rebuild_populates_pr_sessions_from_pr_link_fixture(
+        self, tmp_path: Path
+    ) -> None:
+        """After rebuild_history with projects_path, pr_sessions has the expected row."""
+        from am_i_shipping.db import init_github_db, init_sessions_db
+        from synthesis.rebuild import GITHUB_DROP_TABLES, rebuild_history
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        gh_db = data_dir / "github.db"
+        sess_db = data_dir / "sessions.db"
+        exp_db = data_dir / "expectations.db"
+
+        # Seed DBs from the golden fixture (has graph_nodes so weeks are known).
+        shutil.copy(FIXTURE_SRC, gh_db)
+        shutil.copy(FIXTURE_SRC, sess_db)
+        init_expectations_db(exp_db)
+
+        projects_path = self._setup_projects_dir(tmp_path)
+
+        rebuild_history(
+            gh_db,
+            sess_db,
+            exp_db,
+            projects_path=projects_path,
+            abandonment_days=14,
+            outlier_sigma=2.0,
+        )
+
+        conn = sqlite3.connect(str(gh_db))
+        try:
+            rows = conn.execute(
+                "SELECT repo, pr_number, session_uuid FROM pr_sessions "
+                "WHERE session_uuid = 'test-pr-link-uuid'",
+            ).fetchall()
+        finally:
+            conn.close()
+
+        assert len(rows) == 1, (
+            f"Expected 1 pr_sessions row for test-pr-link-uuid after rebuild, got {rows}"
+        )
+        repo, pr_number, session_uuid = rows[0]
+        assert repo == "hyang0129/am-i-shipping"
+        assert pr_number == 130
+        assert session_uuid == "test-pr-link-uuid"
+
+    def test_github_drop_tables_includes_session_keyed_tables(self) -> None:
+        """GITHUB_DROP_TABLES must include session_gh_events and pr_sessions (Issue #111)."""
+        from synthesis.rebuild import GITHUB_DROP_TABLES
+
+        assert "session_gh_events" in GITHUB_DROP_TABLES, (
+            "session_gh_events must be in GITHUB_DROP_TABLES so rebuild re-populates it"
+        )
+        assert "pr_sessions" in GITHUB_DROP_TABLES, (
+            "pr_sessions must be in GITHUB_DROP_TABLES so rebuild re-populates it"
+        )

--- a/tests/test_session_gh_events.py
+++ b/tests/test_session_gh_events.py
@@ -14,7 +14,12 @@ from pathlib import Path
 
 import pytest
 
-from collector.session_parser import SessionRecord, _extract_gh_events, parse_session
+from collector.session_parser import (
+    SessionRecord,
+    _extract_gh_events,
+    _extract_pr_link_event,
+    parse_session,
+)
 from collector.store import upsert_session
 from am_i_shipping.db import init_github_db
 
@@ -596,3 +601,194 @@ class TestUpsertSessionGhEventsPersistence:
             conn.close()
 
         assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests for pr-link event type (Issue #111)
+# ---------------------------------------------------------------------------
+
+FIXTURES = Path(__file__).parent / "fixtures"
+PR_LINK_FIXTURE = FIXTURES / "pr_link_session.jsonl"
+
+
+class TestExtractPrLinkEvent:
+    """Unit tests for _extract_pr_link_event helper."""
+
+    def test_well_formed_entry_returns_event(self):
+        entry = {
+            "type": "pr-link",
+            "sessionId": "test-pr-link-uuid",
+            "timestamp": "2026-01-10T10:00:01Z",
+            "prNumber": 130,
+            "prRepository": "hyang0129/am-i-shipping",
+            "prUrl": "https://github.com/hyang0129/am-i-shipping/pull/130",
+        }
+        ev = _extract_pr_link_event(entry)
+        assert ev is not None
+        assert ev["event_type"] == "pr_link"
+        assert ev["repo"] == "hyang0129/am-i-shipping"
+        assert ev["ref"] == "130"
+        assert ev["url"] == "https://github.com/hyang0129/am-i-shipping/pull/130"
+        assert ev["confidence"] == "high"
+        assert ev["created_at"] == "2026-01-10T10:00:01Z"
+
+    def test_missing_pr_number_returns_none(self):
+        entry = {
+            "type": "pr-link",
+            "prRepository": "hyang0129/am-i-shipping",
+        }
+        assert _extract_pr_link_event(entry) is None
+
+    def test_missing_pr_repository_returns_none(self):
+        entry = {
+            "type": "pr-link",
+            "prNumber": 130,
+        }
+        assert _extract_pr_link_event(entry) is None
+
+    def test_missing_url_defaults_to_empty_string(self):
+        entry = {
+            "type": "pr-link",
+            "prNumber": 99,
+            "prRepository": "hyang0129/am-i-shipping",
+            "timestamp": "2026-01-10T10:00:00Z",
+        }
+        ev = _extract_pr_link_event(entry)
+        assert ev is not None
+        assert ev["url"] == ""
+
+    def test_pr_number_coerced_to_string_ref(self):
+        entry = {
+            "type": "pr-link",
+            "prNumber": 42,
+            "prRepository": "owner/repo",
+        }
+        ev = _extract_pr_link_event(entry)
+        assert ev["ref"] == "42"
+        assert isinstance(ev["ref"], str)
+
+
+class TestParsePrLinkSession:
+    """Integration tests: parse_session correctly handles pr-link JSONL entries."""
+
+    def test_three_repeated_pr_links_collapse_to_one_gh_event(self):
+        """Fixture has 3 identical pr-link entries; dedup must produce 1 gh_event."""
+        record = parse_session(PR_LINK_FIXTURE)
+        pr_link_events = [
+            ev for ev in record.gh_events if ev["event_type"] == "pr_link"
+        ]
+        assert len(pr_link_events) == 1, (
+            f"Expected 1 pr_link event after dedup, got {len(pr_link_events)}: "
+            f"{pr_link_events}"
+        )
+
+    def test_pr_link_event_has_correct_fields(self):
+        record = parse_session(PR_LINK_FIXTURE)
+        ev = next(e for e in record.gh_events if e["event_type"] == "pr_link")
+        assert ev["repo"] == "hyang0129/am-i-shipping"
+        assert ev["ref"] == "130"
+        assert ev["confidence"] == "high"
+
+    def test_session_uuid_extracted(self):
+        record = parse_session(PR_LINK_FIXTURE)
+        assert record.session_uuid == "test-pr-link-uuid"
+
+    def test_user_assistant_entries_still_parsed(self):
+        """pr-link entries must not prevent normal user/assistant parsing."""
+        record = parse_session(PR_LINK_FIXTURE)
+        assert record.turn_count >= 1
+
+    def test_extract_gh_events_not_called_for_pr_link(self, tmp_path):
+        """_extract_gh_events should never see a pr-link entry (outer loop handles it)."""
+        # Verify that _extract_gh_events returns [] for a pr-link entry (the guard at line 247).
+        pr_link_entry = {
+            "type": "pr-link",
+            "prNumber": 130,
+            "prRepository": "hyang0129/am-i-shipping",
+            "timestamp": "2026-01-10T10:00:00Z",
+        }
+        result = _extract_gh_events(pr_link_entry, {})
+        assert result == [], (
+            "_extract_gh_events must return [] for pr-link entries "
+            "(outer loop handles them before _extract_gh_events is called)"
+        )
+
+
+class TestUpsertPrLinkPrSessions:
+    """Tests that upsert_session writes pr_sessions rows for pr_link events (Issue #111)."""
+
+    def test_pr_link_event_writes_pr_sessions_row(self, tmp_path):
+        """A SessionRecord with a pr_link gh_event produces 1 pr_sessions row."""
+        github_db = tmp_path / "github.db"
+        sessions_db = tmp_path / "sessions.db"
+        init_github_db(github_db)
+
+        record = parse_session(PR_LINK_FIXTURE)
+        upsert_session(
+            record,
+            db_path=sessions_db,
+            data_dir=tmp_path,
+            skip_health=True,
+        )
+
+        conn = sqlite3.connect(str(github_db))
+        try:
+            rows = conn.execute(
+                "SELECT repo, pr_number, session_uuid FROM pr_sessions "
+                "WHERE session_uuid = ?",
+                (record.session_uuid,),
+            ).fetchall()
+        finally:
+            conn.close()
+
+        assert len(rows) == 1
+        repo, pr_number, session_uuid = rows[0]
+        assert repo == "hyang0129/am-i-shipping"
+        assert pr_number == 130
+        assert session_uuid == "test-pr-link-uuid"
+
+    def test_pr_sessions_row_idempotent_on_second_upsert(self, tmp_path):
+        """Calling upsert_session twice for the same pr-link session leaves 1 pr_sessions row."""
+        github_db = tmp_path / "github.db"
+        sessions_db = tmp_path / "sessions.db"
+        init_github_db(github_db)
+
+        record = parse_session(PR_LINK_FIXTURE)
+        upsert_session(record, db_path=sessions_db, data_dir=tmp_path, skip_health=True)
+        upsert_session(record, db_path=sessions_db, data_dir=tmp_path, skip_health=True)
+
+        conn = sqlite3.connect(str(github_db))
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM pr_sessions WHERE session_uuid = ?",
+                (record.session_uuid,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+        assert count == 1
+
+    def test_session_gh_events_audit_row_written(self, tmp_path):
+        """upsert_session also writes a session_gh_events row with event_type='pr_link'."""
+        github_db = tmp_path / "github.db"
+        sessions_db = tmp_path / "sessions.db"
+        init_github_db(github_db)
+
+        record = parse_session(PR_LINK_FIXTURE)
+        upsert_session(record, db_path=sessions_db, data_dir=tmp_path, skip_health=True)
+
+        conn = sqlite3.connect(str(github_db))
+        try:
+            rows = conn.execute(
+                "SELECT event_type, repo, ref FROM session_gh_events "
+                "WHERE session_uuid = ? AND event_type = 'pr_link'",
+                (record.session_uuid,),
+            ).fetchall()
+        finally:
+            conn.close()
+
+        assert len(rows) == 1
+        event_type, repo, ref = rows[0]
+        assert event_type == "pr_link"
+        assert repo == "hyang0129/am-i-shipping"
+        assert ref == "130"

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -287,3 +287,133 @@ class TestUpsertSessionGhEvents:
             conn.close()
 
         assert count == 0
+
+
+class TestUpsertSessionPrSessions:
+    """upsert_session writes pr_sessions rows for pr_link events (Issue #111)."""
+
+    def _make_pr_link_record(self, session_uuid: str = "pr-link-test-uuid") -> "SessionRecord":
+        from am_i_shipping.db import init_github_db  # noqa: F401 (used in tests)
+
+        return SessionRecord(
+            session_uuid=session_uuid,
+            turn_count=1,
+            tool_call_count=0,
+            tool_failure_count=0,
+            reprompt_count=0,
+            bail_out=False,
+            session_duration_seconds=60.0,
+            working_directory="/tmp/test",
+            git_branch="main",
+            raw_content_json="[]",
+            input_tokens=0,
+            output_tokens=0,
+            cache_creation_tokens=0,
+            cache_read_tokens=0,
+            fast_mode_turns=0,
+            gh_events=[
+                {
+                    "event_type": "pr_link",
+                    "repo": "hyang0129/am-i-shipping",
+                    "ref": "130",
+                    "url": "https://github.com/hyang0129/am-i-shipping/pull/130",
+                    "confidence": "high",
+                    "created_at": "2026-01-10T10:00:01Z",
+                }
+            ],
+        )
+
+    def test_pr_link_event_writes_pr_sessions_row(self, tmp_path):
+        """upsert_session with a pr_link gh_event writes 1 row to pr_sessions."""
+        from am_i_shipping.db import init_github_db
+
+        db_path = tmp_path / "sessions.db"
+        gh_db_path = tmp_path / "github.db"
+        init_github_db(gh_db_path)
+
+        record = self._make_pr_link_record()
+        upsert_session(record, db_path=db_path, data_dir=tmp_path)
+
+        conn = sqlite3.connect(str(gh_db_path))
+        try:
+            rows = conn.execute(
+                "SELECT repo, pr_number, session_uuid FROM pr_sessions "
+                "WHERE session_uuid = ?",
+                (record.session_uuid,),
+            ).fetchall()
+        finally:
+            conn.close()
+
+        assert len(rows) == 1
+        repo, pr_number, session_uuid = rows[0]
+        assert repo == "hyang0129/am-i-shipping"
+        assert pr_number == 130
+        assert session_uuid == "pr-link-test-uuid"
+
+    def test_pr_sessions_idempotent_on_second_upsert(self, tmp_path):
+        """Two upsert calls for the same session produce exactly 1 pr_sessions row."""
+        from am_i_shipping.db import init_github_db
+
+        db_path = tmp_path / "sessions.db"
+        gh_db_path = tmp_path / "github.db"
+        init_github_db(gh_db_path)
+
+        record = self._make_pr_link_record()
+        upsert_session(record, db_path=db_path, data_dir=tmp_path)
+        upsert_session(record, db_path=db_path, data_dir=tmp_path)
+
+        conn = sqlite3.connect(str(gh_db_path))
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM pr_sessions WHERE session_uuid = ?",
+                (record.session_uuid,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+        assert count == 1
+
+    def test_non_pr_link_event_does_not_write_pr_sessions(self, tmp_path):
+        """upsert_session with issue_comment event writes 0 pr_sessions rows."""
+        from am_i_shipping.db import init_github_db
+
+        db_path = tmp_path / "sessions.db"
+        gh_db_path = tmp_path / "github.db"
+        init_github_db(gh_db_path)
+
+        record = SessionRecord(
+            session_uuid="non-pr-link-uuid",
+            turn_count=1,
+            tool_call_count=0,
+            tool_failure_count=0,
+            reprompt_count=0,
+            bail_out=False,
+            session_duration_seconds=60.0,
+            working_directory="/tmp/test",
+            git_branch="main",
+            raw_content_json="[]",
+            input_tokens=0,
+            output_tokens=0,
+            cache_creation_tokens=0,
+            cache_read_tokens=0,
+            fast_mode_turns=0,
+            gh_events=[
+                {
+                    "event_type": "issue_comment",
+                    "repo": "hyang0129/am-i-shipping",
+                    "ref": "42",
+                    "url": "",
+                    "confidence": "high",
+                    "created_at": "2026-01-10T10:00:00Z",
+                }
+            ],
+        )
+        upsert_session(record, db_path=db_path, data_dir=tmp_path)
+
+        conn = sqlite3.connect(str(gh_db_path))
+        try:
+            count = conn.execute("SELECT COUNT(*) FROM pr_sessions").fetchone()[0]
+        finally:
+            conn.close()
+
+        assert count == 0


### PR DESCRIPTION
Closes #111

## What changed

Sessions run from working directories whose names do not match the repo short name (e.g. a session running from `d:\containers\claude-rts` working on the `hyang0129/am-i-shipping` repo) were silently excluded from the graph because the collector's batch parser skipped `{"type":"pr-link",...}` top-level JSONL entries — the session's own authoritative declaration of which PR it was working on. This PR adds first-class support for `pr-link` entries, writes both an audit row and a graph-linkage row per session, and extends `rebuild_history` to re-parse all existing sessions so 28 previously-orphaned PR linkages are recovered without any synthesis-layer code changes.

## Implementation walkthrough

### New / modified functions

**`_extract_pr_link_event(entry: dict) -> dict | None` in `collector/session_parser.py`**

New helper that converts a raw `pr-link` JSONL entry into a gh_event dict with `event_type='pr_link'`, `confidence='high'`, and `ref=str(prNumber)`. Returns `None` if either `prNumber` or `prRepository` is absent. This is the leaf-level extractor — its output shape is identical to events produced by `_extract_gh_events`, so no downstream consumers need to change.

**`parse_session` outer loop — `collector/session_parser.py:604-616`**

Before the existing `if entry_type not in ("user", "assistant"): continue` guard, a new `if entry_type == "pr-link":` branch dispatches to `_extract_pr_link_event` and appends the result to `gh_events_list`. The entry then hits `continue` and never reaches `_extract_gh_events`. The existing dedup pass at lines 690–704 collapses multiple identical `pr-link` entries (same session emits up to 3×) to a single gh_event keyed by `(event_type, repo, ref)`.

**`upsert_session` — `collector/store.py:152-168`**

Inside the `for ev in gh_events:` loop, after `INSERT OR IGNORE INTO session_gh_events`, a conditional writes a `pr_sessions` row when `ev["event_type"] == "pr_link"`. The `INSERT OR IGNORE` on the composite PK `(repo, pr_number, session_uuid)` makes the write idempotent.

**`GITHUB_DROP_TABLES` — `synthesis/rebuild.py:58-73`**

Extended with `"session_gh_events"` and `"pr_sessions"`. Both tables must be in the drop scope so that `backfill_full` repopulates them from JSONLs on disk during rebuild.

**`rebuild_history(projects_path=None, ...)` — `synthesis/rebuild.py:197-323`**

New optional keyword argument `projects_path: Optional[Path]`. When provided, `rebuild_history` calls `backfill_full(sessions_db, projects_path)` after dropping and recreating schemas, before the `build_graph` loop. `backfill_full` re-parses every JSONL on disk using upsert semantics (atomic per-session, no destructive deletion window, no `max_files_per_run` cap). The graph builder then finds the freshly-written `pr_sessions` rows and emits `pr_has_session` edges automatically — no graph builder changes needed.

### How components interact

```mermaid
graph TD
    A[JSONL on disk] --> B[parse_session outer loop]
    B -->|entry_type == pr-link| C[_extract_pr_link_event]
    B -->|entry_type == user/assistant| D[_extract_gh_events]
    C --> E[gh_events_list dedup]
    D --> E
    E --> F[upsert_session]
    F -->|all events| G[session_gh_events audit row]
    F -->|pr_link events only| H[pr_sessions linkage row]
    H --> I[build_graph]
    G -.->|skipped by graph builder| I
    I --> J[pr_has_session edge traversal=own]
```

### Default execution path

**Before `am-rebuild-history`**: `_drop_tables(GITHUB_DROP_TABLES)` → `init_github_db` → `for week: build_graph → identify_units → compute_flags`. Session-keyed tables were not dropped, so stale (empty) rows persisted.

**After**: `_drop_tables(GITHUB_DROP_TABLES including session_gh_events + pr_sessions)` → `init_github_db` → `backfill_full(sessions_db, projects_path)` (re-parses all JSONLs, writes fresh rows) → `for week: build_graph → identify_units → compute_flags`. The `build_graph` call finds the new `pr_sessions` rows and emits `pr_has_session` edges.

### Edge cases and error handling

- **Missing `prNumber` or `prRepository`**: `_extract_pr_link_event` returns `None`; silently skipped.
- **3 repeated pr-link records**: Collapsed to 1 by existing `(event_type, repo, ref)` dedup. `INSERT OR IGNORE` makes second+ writes safe.
- **`backfill_full` partial failure**: Atomic per-session (upsert, not delete). Failed sessions are logged and skipped; successfully parsed sessions are preserved.
- **`projects_path=None`**: Backfill step is skipped; `rebuild_history` behaves exactly as before. Backward-compatible.

### What was intentionally not changed

- **`session_linker.py`**: Head_ref/git_branch heuristic unchanged. `pr-link` writes to `pr_sessions` directly and bypasses `session_linker` entirely. Running `link_sessions` after the fix is safe (idempotent).
- **`synthesis/graph_builder.py`**: `_read_pr_sessions` and the `pr_has_session` edge loop already handle all `pr_sessions` rows. No changes needed.
- **`am_i_shipping/db.py`**: Schema already supports the new data. No migration.
- **URL-text scanning and content-block-nested pr-link**: Explicitly deferred per spec (high FP risk / not observed in data).

## Tier / approach

Tier 2 — Planner + parallel Coders (collector layer / rebuild layer) + Tester + ADR for rebuild mechanism decision

## Acceptance criteria

- [x] `parse_session` on a JSONL with 3 repeated `pr-link` entries produces exactly 1 gh_event with `event_type='pr_link'`
- [x] `upsert_session` with a pr_link gh_event writes 1 row to `pr_sessions` with correct `(repo, pr_number, session_uuid)`
- [x] `upsert_session` called twice leaves exactly 1 `pr_sessions` row (idempotency)
- [x] `session_gh_events` gets 1 row with `event_type='pr_link'` for a freshly parsed pr-link session
- [x] `GITHUB_DROP_TABLES` includes `'session_gh_events'` and `'pr_sessions'`
- [x] `rebuild_history` calls `backfill_full` before `build_graph` when `projects_path` is set
- [x] `_extract_gh_events` is NOT called for `pr-link` entries (outer loop handles them first)
- [x] 774 existing tests pass, 26 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review summary
- Cycles run: 0 of 2 (exited early — no critical/major tier `fix` findings)
- Findings fixed: 0 (none required)
- Intent validation: clean
- Outstanding: 2 minor tier `propose` findings deferred to author (F-0-1: type validation on prNumber; F-0-2: overstated test invariant)

## History
Squash: C — kept as-is (3 commits: init, fix, component-test)
Rebased onto `main` — branch was already up to date. Component test committed and pushed.

## Merge instructions
Merge via **squash merge** (not merge commit or rebase merge).